### PR TITLE
Navigate to main OMF website on docs site logo click

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -69,6 +69,7 @@ const config = {
         logo: {
           alt: 'Overture Maps Foundation Logo',
           src: 'img/omf_logo_transparent.png',
+          href: 'https://overturemaps.org'
         },
         items: [
           {


### PR DESCRIPTION
# Details

This behavior seems to make the most sense intuitively, and it ensures there's a path back to the main Overture Maps website from the docs.

# Testing

Tested locally using:

```
~/overture/schema/docusaurus $ npm run start
```