### PR TITLE
Updated admin_level min max values

### DIFF
--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -38,7 +38,7 @@ description: Common schema definitions shared by all themes
         release where the geometry or attributes of this feature
         changed.
       type: integer
-      minValue: 0
+      minimum: 0
       "$comment": >-
         It might be reasonable to combine "updateTime" and "version"
         in a single "updateVersion" field which gives the last Overture
@@ -87,8 +87,8 @@ description: Common schema definitions shared by all themes
         the distance along a path such as a road segment or a river
         center-line segment.
       type: number
-      minValue: 0
-      maxValue: 1
+      minimum: 0
+      maxiumum: 1
       "$comment": >-
         One possible advantage to using percentages over absolute
         distances is being able to trivially validate that the position

--- a/schema/places/place.yaml
+++ b/schema/places/place.yaml
@@ -37,8 +37,8 @@ properties:
       confidence:
         description: The confidence of the existence of the place. It's a number between 0 and 1. 0 means that we're sure that the place doesn't exist (anymore). 1 means that we're sure that the place exists. If there's no value for the confidence, it means that we don't have any confidence information.
         type: number
-        minValue: 0
-        maxValue: 1
+        minimum: 0
+        maximum: 1
       websites:
         description: The websites of the place.
         type: array

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -311,7 +311,7 @@ properties:
       prefixItems:
         - description: Number of speed units
           type: integer
-          minValue: 20
+          minimum: 20
         - description: One speed unit
           type: string
           enum: [ "km/h", "mph" ]


### PR DESCRIPTION
Definitions have property minValue and maxValue (see property "version" or "linearlyReferencedPosition") while admin_level has properties "minimum" and "maximum". Changing to align with general overture defs.yaml