### PR TITLE
Add confidence to sources

### DIFF
--- a/counterexamples/buildings/bad-confidence-in-source.yaml
+++ b/counterexamples/buildings/bad-confidence-in-source.yaml
@@ -1,0 +1,23 @@
+---
+id: overture:buildings:footprint:1234
+type: Feature
+geometry:
+  type: Polygon
+  coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]
+properties:
+  # Custom user properties.
+  extFoo: I am a customer user property.
+  extBar: Me too!
+  # Overture properties
+  theme: buildings
+  type: building
+  version: 1
+  updateTime: "2023-02-22T23:55:01-08:00"
+  height: 21.34
+  sources:
+  - property: ""
+    dataset: microsoftMLBuildings,
+    confidence: 100
+  - property: /properties/height
+    dataset:  metaLidarExtractions,
+    confidence: -1

--- a/examples/buildings/building-polygon.yaml
+++ b/examples/buildings/building-polygon.yaml
@@ -25,6 +25,8 @@ properties:
   class: civic
   sources:
   - property: ""
-    dataset: microsoftMLBuildings
+    dataset: microsoftMLBuildings,
+    confidence: 1
   - property: /properties/height
-    dataset:  metaLidarExtractions
+    dataset:  metaLidarExtractions,
+    confidence: 0.95

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -80,8 +80,8 @@ description: Common schema definitions shared by all themes
         confidence:
           description: If the source data has a confidence value, especially for ml-derived data, record that here.
           type: number
-          minValue: 0
-          maxValue: 1
+          minimum: 0
+          maximum: 1
     theme:
       description: Top-level Overture theme this feature belongs to
       type: string

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -77,6 +77,11 @@ description: Common schema definitions shared by all themes
         recordId:
           type: string
           description: Refers to the specific record within the dataset that was used.
+        confidence:
+          description: If the source data has a confidence value, especially for ml-derived data, record that here.
+          type: number
+          minValue: 0
+          maxValue: 1
     theme:
       description: Top-level Overture theme this feature belongs to
       type: string


### PR DESCRIPTION
A new version of https://github.com/OvertureMaps/schema/pull/44 because `main` had not been merged back into `dev`.