### PR TITLE
Fix small issues in transportation docs

### DIFF
--- a/docusaurus/docs/themes/transportation/roads.mdx
+++ b/docusaurus/docs/themes/transportation/roads.mdx
@@ -171,7 +171,7 @@ road class govern.
 Turn restrictions on a road segment limit the transitions which are
 allowed from that segment into other
 [physically connected](shape-connectivity#physical-connectivity)
-segments segments.
+segments.
 
 Every road segment has an *implied* set of allowed transitions
 defined by its [access restrictions](#access-restrictions) as well as

--- a/docusaurus/docs/themes/transportation/scoping-rules.mdx
+++ b/docusaurus/docs/themes/transportation/scoping-rules.mdx
@@ -318,6 +318,14 @@ situation. Each individual rule in the list of rules is itself a scoped value,
 a scoped value, and the assessment of which rule applies to a given set of facts
 is done by the rule evaluation algorithm.
 
+<!--
+
+TODO: Feedback from Karen given 2023-08-29 that 👆 is very abstract and could
+      use an immediate example. I think an "easy" solution would be to wangle
+      a speed limits example with two rules that are just one-liner `maxSpeed`
+      entries.
+-->
+
 ### Absolute form
 
 There are cases when specifying a property value using rules makes sense, and

--- a/docusaurus/docs/themes/transportation/travel-modes.mdx
+++ b/docusaurus/docs/themes/transportation/travel-modes.mdx
@@ -58,7 +58,7 @@ precise definition to those applications that require them.
 A travel mode is recognized by the Overture Transportation schema when
 it becomes part of the [`mode`](https://github.com/OvertureMaps/schema/blob/5f82f1d6a916031cb32730e1fac7e1a353f10c60/schema/transportation/segment.yaml#L103)
 enumeration. As of our draft schema release `v0.4.0`, this enumeration
-is relatively small and contains only travel modes which we some
+is relatively small and contains only travel modes which we have some
 confidence will be generally-applicable both across jurisdictions and
 over time. We expect the list to change in future schema updates, to be
 larger once we reach a table `v1.0.0` schema, and to continue to expand
@@ -96,7 +96,7 @@ built-in list of recognized travel modes.
 
 ### Scoping to travel modes
 
-Travel modes can used to change the scope of scoped and rule-based
+Travel modes can be used to change the scope of scoped and rule-based
 properties within the schema. For example, they can affect the scope of
 access restrictions, turn restrictions, or speed limits on [road](roads)
 segments. Since travel modes are expressed via scoping properties, it

--- a/examples/transportation/docusaurus/geometric-scoping.yaml
+++ b/examples/transportation/docusaurus/geometric-scoping.yaml
@@ -3,7 +3,7 @@ id: overture:transportation:example:geometric-scoping
 type: Feature
 geometry:
   type: LineString
-  coordinates: [[0, 0], [1, 1]] #TODO get some real geometry
+  coordinates: [[0, 0], [1, 1]]
 properties:
   theme: transportation
   type: segment
@@ -13,7 +13,7 @@ properties:
   road:
     restrictions:
       speedLimits:
-        - at: [0, 0.15]               # TODO: Put real values.
+        - at: [0, 0.15]
           maxSpeed: [100, "km/h"]
         - at: [0.15, 1]
           maxSpeed: [60, "km/h"]


### PR DESCRIPTION
# Description

- Delete some TODO items in an example that are bleeding into the official docusaurus website.
- Fix a few small typos.
- Add a hidden TODO to provide an example about rule-based properties to help readers concretize the fairly abstract wording.

# Thanks!

Thanks to Karen for pointing these out.

# Testing

See staging docs version of changes here: https://dfhx9f55j8eg5.cloudfront.net/pr/48/themes/transportation/