### PR TITLE
Removed concept of class and subclasses and added more classes

### DIFF
--- a/docusaurus/docs/reference/context/landuse.mdx
+++ b/docusaurus/docs/reference/context/landuse.mdx
@@ -1,0 +1,25 @@
+---
+title: landuse
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import JSONSchemaViewer from "@theme/JSONSchemaViewer";
+import generateResolverOptions from "@site/src/components/shared-libs/generateResolverOptions"
+import yamlLoad from "@site/src/components/yamlLoad"
+import LanduseSchema from "!!raw-loader!@site/docs/_schema/context/landuse.yaml";
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Landuse
+
+## Schema
+
+<Tabs>
+  <TabItem value="browsable" label="Browsable" default>
+    <JSONSchemaViewer schema={ yamlLoad(LanduseSchema) } resolverOptions={ generateResolverOptions({remote: true, yamlBasePath: '/context'})}/>
+  </TabItem>
+  <TabItem value="yaml" label="YAML" default>
+    <CodeBlock language="jsx">{LanduseSchema}</CodeBlock>
+  </TabItem>
+</Tabs>

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -152,6 +152,7 @@ const sidebars = {
           items: [
               'reference/context/water',
               'reference/context/land',
+              'reference/context/landuse',
           ]
         },
       ]

--- a/schema/context/land.yaml
+++ b/schema/context/land.yaml
@@ -1,13 +1,14 @@
 ---
 "$schema": https://json-schema.org/draft/2020-12/schema
-title: Land(cover) Schema
-description: Landcover
+title: Land Schema
+description: Land
 type: object
 properties:
   geometry:
-    description: Landcover TODO
+    description: Land TODO
     unevaluatedProperties: false
     oneOf:
+      - "$ref": https://geojson.org/schema/Point.json
       - "$ref": https://geojson.org/schema/LineString.json
       - "$ref": https://geojson.org/schema/MultiLineString.json
       - "$ref": https://geojson.org/schema/Polygon.json
@@ -21,22 +22,29 @@ properties:
     properties:
       names: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/names" }
       class:
-        description: The type of water body such as an ocean or lake.
+        description: The type of land such as an mountain, valley, island, cave or reef.
         default: [land]
         type: string
         enum:
+          - beach
+          - dune
           - forest
           - glacier
+          - grass
+          - grassland
+          - hill
           - land
-          - physical
+          - meadow
+          - peak
           - reef
           - sand
           - scrub
           - tree
+          - tree_row
+          - valley
+          - volcano
           - wetland
-      subclass:
-        description: "Subclass"
-        type: string
+          - wood
       landuse:
         description: Value of the landuse tag if present
         type: string
@@ -46,6 +54,4 @@ properties:
       surface:
         description: Value of the surface tag if present
         type: string
-      wikidata:
-        description: Value of the surface tag if present
-        type: string
+      wikidata: {"$ref" : "./defs.yaml#/$defs/propertyDefinitions/wikidata" }

--- a/schema/context/landuse.yaml
+++ b/schema/context/landuse.yaml
@@ -1,0 +1,141 @@
+---
+"$schema": https://json-schema.org/draft/2020-12/schema
+title: Landuse Schema
+description: Landuse
+type: object
+properties:
+  geometry:
+    description: Landuse TODO
+    unevaluatedProperties: false
+    oneOf:
+      - "$ref": https://geojson.org/schema/Point.json
+      - "$ref": https://geojson.org/schema/LineString.json
+      - "$ref": https://geojson.org/schema/MultiLineString.json
+      - "$ref": https://geojson.org/schema/Polygon.json
+      - "$ref": https://geojson.org/schema/MultiPolygon.json
+  properties:
+    unevaluatedProperties: false
+    allOf:
+      - "$ref": ./defs.yaml#/$defs/propertyContainers/osmPropertiesContainer
+      - "$ref": ../defs.yaml#/$defs/propertyContainers/overtureFeaturePropertiesContainer
+      - "$ref": ../defs.yaml#/$defs/propertyContainers/levelContainer
+    properties:
+      names: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/names" }
+      class:
+        description: The type of water body such as an ocean or lake.
+        default: [land]
+        type: string
+        enum:
+        - farmland
+        - farmyard
+        - meadow
+        - animal_keeping
+        - helipad
+        - aerodrome
+        - heliport
+        - aquaculture
+        - camp_site
+        - cemetery
+        - conservation
+        - construction
+        - greenfield
+        - industrial
+        - commercial
+        - retail
+        - brownfield
+        - institutional
+        - school
+        - college
+        - university
+        - education
+        - schoolyard
+        - water_park
+        - theme_park
+        - zoo
+        - bunker
+        - tee
+        - green
+        - fairway
+        - water_hazard
+        - golf_course
+        - rough
+        - lateral_water_hazard
+        - driving_range
+        - orchard
+        - garden
+        - vineyard
+        - allotments
+        - greenhouse_horticulture
+        - plant_nursery
+        - flowerbed
+        - landfill
+        - hospital
+        - clinic
+        - doctors
+        - military
+        - military_other
+        - range
+        - training_area
+        - barracks
+        - airfield
+        - danger_area
+        - base
+        - obstacle_course
+        - nuclear_explosion_site
+        - naval_base
+        - trench
+        - grass
+        - park
+        - village_green
+        - common
+        - dog_park
+        - national_park
+        - state_park
+        - forest
+        - nature_reserve
+        - species_management_area
+        - protected_landscape_seascape
+        - environmental
+        - natural_monument
+        - wilderness_area
+        - aboriginal_land
+        - strict_nature_reserve
+        - civic_admin
+        - public
+        - pitch
+        - playground
+        - recreation_ground
+        - track
+        - stadium
+        - marina
+        - religious
+        - churchyard
+        - residential
+        - garages
+        - static_caravan
+        - quarry
+        - logging
+        - salt_pond
+        - peat_cutting
+        - pier
+        - dam
+        - highway
+        - traffic_island
+        - depot
+        - winter_sports
+      landuse:
+        description: Value of the landuse tag if present
+        type: string
+      level:
+        description: Value of the level tag if present
+        type: string
+      layer:
+        description: Value of the layer tag if present
+        type: string
+      sport:
+        description: Value of the sport tag if present
+        type: string
+      surface:
+        description: Value of the surface tag if present
+        type: string
+      wikidata: {"$ref" : "./defs.yaml#/$defs/propertyDefinitions/wikidata" }

--- a/schema/context/water.yaml
+++ b/schema/context/water.yaml
@@ -8,6 +8,7 @@ properties:
     description: Water TODO
     unevaluatedProperties: false
     oneOf:
+      - "$ref": https://geojson.org/schema/Point.json
       - "$ref": https://geojson.org/schema/LineString.json
       - "$ref": https://geojson.org/schema/MultiLineString.json
       - "$ref": https://geojson.org/schema/Polygon.json
@@ -21,21 +22,49 @@ properties:
     properties:
       names: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/names" }
       class:
-        description: The type of water body such as an ocean or lake.
+        description: The type of water body such as an river, ocean or lake.
         default: [water]
         type: string
         enum:
-          - human_made
+          - basin
+          - bay
+          - canal
+          - cape
+          - ditch
+          - dock
+          - drain
+          - fairway
+          - fish_pass
+          - fishpond
+          - geyser
+          - hot_spring
+          - lagoon
           - lake
+          - lock
+          - moat
           - ocean
+          - oxbow
           - pond
+          - reflecting_pool
+          - reservoir
           - river
+          - salt_pool
+          - sea
+          - sewage
+          - shoal
+          - spring
+          - strait
           - stream
+          - swimming_pool
+          - tidal_channel
+          - wastewater
           - water
-      subclass:
-        description: "Subclass"
-        type: string
+          - water_storage
+          - waterfall
       salt:
         description: Is it salt water or not
+        type: boolean
+      intermittent:
+        description: Is it intermittent water or not
         type: boolean
       wikidata: {"$ref" : "./defs.yaml#/$defs/propertyDefinitions/wikidata" }


### PR DESCRIPTION
In attempt to avoid complex class->subclass rules, I'm suggesting just having class that subclass in Earth Table, hopefully this won't complicate things even more, if so we can move back to class/subclass Also added Point as allowed geometry, since some of this features like sea, peak(mountain)... have point I also added water and land features that we use that are missing in Earth Table Fixed landuse to appear in docs