### PR TITLE
Users/ibantea/transportation refactor

### DIFF
--- a/examples/transportation/docusaurus/access-restriction-01-blanket.yaml
+++ b/examples/transportation/docusaurus/access-restriction-01-blanket.yaml
@@ -14,4 +14,5 @@ properties:
   subType: road
   road:
     restrictions:
-      access: [denied]
+      access: 
+      - accessType: denied

--- a/examples/transportation/docusaurus/access-restriction-02-private-with-deliveries.yaml
+++ b/examples/transportation/docusaurus/access-restriction-02-private-with-deliveries.yaml
@@ -15,8 +15,9 @@ properties:
   road:
     restrictions:
       access:
-        - denied
-        - allowed: { when: { recognized: [asPrivate] } }
-        - allowed:
-            when: { using: [toDeliver] }
-            during: Mo-Fr 08:30-16:30
+        - accessType: denied
+        - accessType: allowed
+          when: { recognized: [asPrivate] }
+        - accessType: allowed
+          when: { using: [toDeliver] }
+          during: Mo-Fr 08:30-16:30

--- a/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
+++ b/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
@@ -15,5 +15,7 @@ properties:
   road:
     restrictions:
       access:
-        - denied: { when: { mode: [motorVehicle] } }
-        - allowed: { when: { using: [atDestination] } }
+        - accessType: denied
+          when: { mode: [motorVehicle] } }
+        - accessType: allowed
+          when: { using: [atDestination] } }

--- a/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
+++ b/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
@@ -16,6 +16,6 @@ properties:
     restrictions:
       access:
         - accessType: denied
-          when: { mode: [motorVehicle] } }
+          when: { mode: [motorVehicle] }
         - accessType: allowed
-          when: { using: [atDestination] } }
+          when: { using: [atDestination] }

--- a/examples/transportation/docusaurus/access-restriction-04-axle-limit.yaml
+++ b/examples/transportation/docusaurus/access-restriction-04-axle-limit.yaml
@@ -15,7 +15,7 @@ properties:
   road:
     restrictions:
       access:
-        - denied:
-            when:
-              mode: [hgv]
-              vehicle: { axleCount: { isAtLeast: 5 } }
+        - accessType: denied
+          when:
+            mode: [hgv]
+            vehicle: { axleCount: { isAtLeast: 5 } }

--- a/examples/transportation/docusaurus/access-restriction.yaml
+++ b/examples/transportation/docusaurus/access-restriction.yaml
@@ -23,7 +23,8 @@ properties:
     roadNames:
       - common: [ { language: local, value: "SR 520" } ]
     class: motorway
-    surface: paved
+    surface: 
+    - value: paved
     restrictions:
       access:
         - accessType: denied

--- a/examples/transportation/docusaurus/access-restriction.yaml
+++ b/examples/transportation/docusaurus/access-restriction.yaml
@@ -21,10 +21,10 @@ properties:
     - overture:transportation:example:simple-road-connector-2
   road:
     roadNames:
-      common: [ { language: local, value: "SR 520" } ]
+      - common: [ { language: local, value: "SR 520" } ]
     class: motorway
     surface: paved
     restrictions:
       access:
-        - denied:
-            when: {mode: [foot]}
+        - accessType: denied
+          when: {mode: [foot]}

--- a/examples/transportation/docusaurus/lanes-hov.yaml
+++ b/examples/transportation/docusaurus/lanes-hov.yaml
@@ -36,10 +36,10 @@ properties:
       - direction: forward # lane 0 -> hov only
         restrictions:
           access:
-            - allowed:
-                when:
-                  mode:
-                    - hov
+            - accessType: allowed
+              when:
+                mode:
+                  - hov
           minOccupancy:
             isAtLeast: 3
       - direction: forward # lane 1

--- a/examples/transportation/docusaurus/lanes-hov.yaml
+++ b/examples/transportation/docusaurus/lanes-hov.yaml
@@ -41,6 +41,6 @@ properties:
                 mode:
                   - hov
           minOccupancy:
-            isAtLeast: 3
+            - isAtLeast: 3
       - direction: forward # lane 1
       - direction: forward # lane 2

--- a/examples/transportation/docusaurus/simple-road.yaml
+++ b/examples/transportation/docusaurus/simple-road.yaml
@@ -20,7 +20,8 @@ properties:
     roadNames:
       - common: [ { language: local, value: "Nicola Street" } ]
     class: residential
-    surface: paved
+    surface: 
+    - value: paved
     lanes:
       - direction: backward
       - direction: forward

--- a/examples/transportation/docusaurus/simple-road.yaml
+++ b/examples/transportation/docusaurus/simple-road.yaml
@@ -18,7 +18,7 @@ properties:
     - overture:transportation:example:simple-road-connector-2
   road:
     roadNames:
-      common: [ { language: local, value: "Nicola Street" } ]
+      - common: [ { language: local, value: "Nicola Street" } ]
     class: residential
     surface: paved
     lanes:

--- a/examples/transportation/docusaurus/subjective-status-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-status-scoping.yaml
@@ -16,6 +16,6 @@ properties:
   road:
     restrictions:
       access:
-        - denied
-        - allowed:
-            when: { recognized: [asPrivate] }
+        - accessType: denied
+        - accessType: allowed
+          when: { recognized: [asPrivate] }

--- a/examples/transportation/docusaurus/subjective-usage-purpose-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-usage-purpose-scoping.yaml
@@ -15,6 +15,6 @@ properties:
   road:
     restrictions:
       access:
-        - denied
-        - allowed:
-            when: { using: [asCustomer, atDestination] }
+        - accessType: denied
+        - accessType: allowed
+          when: { using: [asCustomer, atDestination] }

--- a/examples/transportation/docusaurus/temporal-scoping.yaml
+++ b/examples/transportation/docusaurus/temporal-scoping.yaml
@@ -16,5 +16,6 @@ properties:
   road:
     restrictions:
       access:
-        - denied: { during: "Mo-Fr 15:00-18:00" }
+        - accessType: denied
+          during: "Mo-Fr 15:00-18:00"
           when: { notMode: [bus] }

--- a/examples/transportation/docusaurus/turn-restriction-02-source.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-source.yaml
@@ -25,7 +25,8 @@ properties:
     roadNames:
       - common: [ { language: local, value: "Arborway" } ]
     class: primary
-    surface: paved
+    surface: 
+    - value: paved
     restrictions:
       turns:
         - segmentId: overture:transportation:example:via-turn-restriction-target

--- a/examples/transportation/docusaurus/turn-restriction-02-source.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-source.yaml
@@ -23,7 +23,7 @@ properties:
     - overture:transportation:example:via-turn-restriction-connector1
   road:
     roadNames:
-      common: [ { language: local, value: "Arborway" } ]
+      - common: [ { language: local, value: "Arborway" } ]
     class: primary
     surface: paved
     restrictions:

--- a/examples/transportation/docusaurus/turn-restriction-02-target.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-target.yaml
@@ -23,4 +23,5 @@ properties:
     roadNames:
       - common: [ { language: local, value: "Arborway" } ]
     class: primary
-    surface: paved
+    surface: 
+    - value: paved

--- a/examples/transportation/docusaurus/turn-restriction-02-target.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-target.yaml
@@ -21,6 +21,6 @@ properties:
     - overture:transportation:example:via-turn-restriction-connector2
   road:
     roadNames:
-      common: [ { language: local, value: "Arborway" } ]
+      - common: [ { language: local, value: "Arborway" } ]
     class: primary
     surface: paved

--- a/examples/transportation/docusaurus/turn-restriction-02-via.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-via.yaml
@@ -19,6 +19,6 @@ properties:
     - overture:transportation:example:via-turn-restriction-connector2
   road:
     roadNames:
-      common: [ { language: local, value: "Washington Street" } ]
+      - common: [ { language: local, value: "Washington Street" } ]
     class: secondary
     surface: paved

--- a/examples/transportation/docusaurus/turn-restriction-02-via.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-via.yaml
@@ -21,4 +21,5 @@ properties:
     roadNames:
       - common: [ { language: local, value: "Washington Street" } ]
     class: secondary
-    surface: paved
+    surface: 
+    - value: paved

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-access-for-travel-modes.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-access-for-travel-modes.yaml
@@ -26,23 +26,23 @@ properties:
       - direction: backward # lane 0 not allowed for trucks (heavy good vehicles)
         restrictions:
           access:
-            - denied:
-                when:
-                  mode:
-                    - hgv
+            - accessType: denied
+              when:
+                mode:
+                  - hgv
       - direction: forward # lane 1
       - direction: forward # lane 2 not allowed for buses and trucks
         restrictions:
           access:
-            - denied:
-                when:
-                  mode:
-                    - hgv
-                    - bus
+            - accessType: denied
+              when:
+                mode:
+                  - hgv
+                  - bus
       - direction: forward # lane 3 - allowed only for bicycles
         restrictions:
           access:
-            - allowed:
-                when:
-                  mode:
-                    - bicycle
+            - accessType: allowed
+              when:
+                mode:
+                  - bicycle

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-access-with-lr.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-access-with-lr.yaml
@@ -28,10 +28,10 @@ properties:
       - direction: forward # lane 2 from its 60% of length (till the end) it is allowed only for buses (before 60% mark it is available for all vehicles)
         restrictions:
           access:
-            - allowed:
-                when:
-                  mode:
-                    - bus
+            - accessType: allowed
+              when:
+                mode:
+                  - bus
               at:
                 - 0.6
                 - 1.0

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-hov-occupancy-scoped.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-hov-occupancy-scoped.yaml
@@ -32,11 +32,11 @@ properties:
       - direction: forward # lane 0 -> hov only that allows also bicycles
         restrictions:
           access:
-            - allowed:
-                when:
-                  mode:
-                    - hov
-                    - bicycle
+            - accessType: allowed
+              when:
+                mode:
+                  - hov
+                  - bicycle
           minOccupancy:
             - isAtLeast: 3
               when:

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-hov.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-hov.yaml
@@ -32,10 +32,10 @@ properties:
       - direction: forward # lane 0 -> hov only
         restrictions:
           access:
-            - allowed:
-                when:
-                  mode:
-                    - hov
+            - accessType: allowed
+              when:
+                mode:
+                  - hov
           minOccupancy:
             isAtLeast: 3
       - direction: forward # lane 1

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-hov.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-hov.yaml
@@ -37,6 +37,6 @@ properties:
                 mode:
                   - hov
           minOccupancy:
-            isAtLeast: 3
+            - isAtLeast: 3
       - direction: forward # lane 1
       - direction: forward # lane 2

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-speed-limits.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-speed-limits.yaml
@@ -32,21 +32,21 @@ properties:
       - direction: forward # lane 1  -> hgv vehicles cannot use that lane
         restrictions:
           access:
-            - denied:
-                when:
-                  mode:
-                    - hgv
+            - accessType: denied
+              when:
+                mode:
+                  - hgv
       - direction: forward # lane 2 - available for all vehicles except hgv vehicles if their weight is more than 3 tons, and they must limit their speed to 80 km/h
         # for all other vehicles segment speed limit (100 km/h) applies
         restrictions:
           access:
-            - denied:
-                when:
-                  mode:
-                    - hgv
-                  vehicle:
-                    weight:
-                      isAtMost: 3
+            - accessType: denied
+              when:
+                mode:
+                  - hgv
+                vehicle:
+                  weight:
+                    isAtMost: 3
           speedLimits:
             - maxSpeed:
                 - 80

--- a/examples/transportation/segment/road/road-acesss-restriction.yaml
+++ b/examples/transportation/segment/road/road-acesss-restriction.yaml
@@ -20,15 +20,15 @@ properties:
   road:
     restrictions:
       access:
-        - denied
-        - designated:
-            when: {mode: [truck]}
-            at: [0.1, 0.25]
-        - allowed:
-            when:
-              using: [asCustomer, toFarm]
-              recognized: [asPermitted, asEmployee]
-            at: [0.25, 0.50]
-        - allowed:
-            when: {vehicle: {axleCount: {isMoreThan: 5}}}
-            at: [0.50, 0.70]
+        - accessType: denied
+        - accessType: designated
+          when: {mode: [truck]}
+          at: [0.1, 0.25]
+        - accessType: allowed
+          when:
+            using: [asCustomer, toFarm]
+            recognized: [asPermitted, asEmployee]
+          at: [0.25, 0.50]
+        - accessType: allowed
+          when: {vehicle: {axleCount: {isMoreThan: 5}}}
+          at: [0.50, 0.70]

--- a/examples/transportation/segment/road/road-flow-alternating.yaml
+++ b/examples/transportation/segment/road/road-flow-alternating.yaml
@@ -13,7 +13,8 @@ properties:
   connectors: [fooConnector, barConnector]
   road:
     class: primary
-    surface: paved
+    surface: 
+    - value: paved
       # This models a single-lane road whose direction alternates
       # on a regular rhythm (by default instructed by signals).
     lanes:

--- a/examples/transportation/segment/road/road-flow-reversible.yaml
+++ b/examples/transportation/segment/road/road-flow-reversible.yaml
@@ -20,9 +20,9 @@ properties:
       - direction: reversible
         restrictions:
           access:
-            - allowed:
-                direction: forward
-                during: Mo-Su 00:00-12:00
-            - allowed:
-                direction: backward
-                during: Mo-Su 12:00-24:00
+            - accessType: allowed
+              direction: forward
+              during: Mo-Su 00:00-12:00
+            - accessType: allowed
+              direction: backward
+              during: Mo-Su 12:00-24:00

--- a/examples/transportation/segment/road/road-flow-reversible.yaml
+++ b/examples/transportation/segment/road/road-flow-reversible.yaml
@@ -13,7 +13,8 @@ properties:
   connectors: [fooConnector, barConnector]
   road:
     class: primary
-    surface: paved
+    surface: 
+    - value: paved
       # This models a single-lane road whose direction is
       # completely reversible at arbitrary times.
     lanes:

--- a/examples/transportation/segment/road/road-oneway-no-lanes.yaml
+++ b/examples/transportation/segment/road/road-oneway-no-lanes.yaml
@@ -16,5 +16,5 @@ properties:
     # one way road in backward direction (forward access is denied)
     restrictions:
       access:
-        - denied:
-            direction: forward
+        - accessType: denied
+          direction: forward

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -23,7 +23,8 @@ properties:
       - common:
         - value: Common Road Name
           language: local
-    surface: gravel
+    surface: 
+    - value: gravel
     flags: [isLink, isTunnel, isPrivate]
     restrictions:
       speedLimits:

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -25,7 +25,8 @@ properties:
           language: local
     surface: 
     - value: gravel
-    flags: [isLink, isTunnel, isPrivate]
+    flags: 
+    - values: [isLink, isTunnel, isPrivate]
     restrictions:
       speedLimits:
         - minSpeed: [90, "km/h"]

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -20,7 +20,7 @@ properties:
     # no access nor lanes information -> means by default road is accessible in both directions with at least one lane in each direction
     class: secondary
     roadNames:
-      common:
+      - common:
         - value: Common Road Name
           language: local
     surface: gravel

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -71,15 +71,13 @@ properties:
                 If a lane is restricted for use only by HOVs, then the default minimum vehicle
                 occupancy qualifying as HOV is 2+ passengers (including the driver).  This
                 restriction can be provided to override the default definition of HOV.
-              oneOf:
-                - "$ref": "#/$defs/propertyDefinitions/relationalExpression"
-                - type: array
-                  items:
-                    type: object
-                    unevaluatedProperties: false
-                    allOf:
-                      - "$ref": "#/$defs/propertyContainers/ruleContainer"
-                      - "$ref": "#/$defs/propertyDefinitions/relationalExpression"
+              type: array
+              items:
+                type: object
+                unevaluatedProperties: false
+                allOf:
+                  - "$ref": "#/$defs/propertyContainers/ruleContainer"
+                  - "$ref": "#/$defs/propertyDefinitions/relationalExpression"
     laneDirection:
       type: string
       enum:
@@ -140,39 +138,31 @@ properties:
             enum: [ unknown ]
         roadNames:
           unevaluatedProperties: false
-          oneOf:
-            - type: object
-              allOf:
-                - { "$ref": "../defs.yaml#/$defs/propertyDefinitions/names" }
-            - type: array
-              items:
-                type: object
-                required: [at]
-                unevaluatedProperties: false
-                allOf:
-                  - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
-                  - { "$ref": "../defs.yaml#/$defs/propertyDefinitions/names" }
-              minItems: 1
-              uniqueItems: true
+          type: array
+          items:
+            type: object
+            required: [at]
+            unevaluatedProperties: false
+            allOf:
+              - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
+              - { "$ref": "../defs.yaml#/$defs/propertyDefinitions/names" }
+          minItems: 1
+          uniqueItems: true
 
         surface:
           description: Physical surface of the road. May either be
             specified as a single global value for the segment, or as
             an array of surface rules.
-          oneOf:
-            - { "$ref": "#/$defs/propertyDefinitions/roadSurface" }
-            - type: array
-              items:
-                type: object
-                allOf:
-                  - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
-                unevaluatedProperties: false
-                properties:
-                  value: { "$ref": "#/$defs/propertyDefinitions/roadSurface" }
-              minItems: 1
-              uniqueItems: true
-          default:
-            enum: [unknown]
+          type: array
+          items:
+            type: object
+            allOf:
+              - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
+            unevaluatedProperties: false
+            properties:
+              value: { "$ref": "#/$defs/propertyDefinitions/roadSurface" }
+          minItems: 1
+          uniqueItems: true
           "$comment": >-
             We should likely restrict the available surface types to
             the subset of the common OSM surface=* tag values that are
@@ -184,18 +174,16 @@ properties:
             as an array of flag rules.
           type: array
           items:
-            oneOf:
-              - { "$ref": "#/$defs/propertyDefinitions/roadFlag" }
-              - type: object
-                allOf:
-                  - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
-                  - { "$ref": "#/$defs/propertyContainers/duringContainer" }
-                unevaluatedProperties: false
-                properties:
-                  values:
-                    type: array
-                    items: { "$ref": "#/$defs/propertyDefinitions/roadFlag" }
-                    uniqueItems: true
+            type: object
+            allOf:
+              - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
+              - { "$ref": "#/$defs/propertyContainers/duringContainer" }
+            unevaluatedProperties: false
+            properties:
+              values:
+                type: array
+                items: { "$ref": "#/$defs/propertyDefinitions/roadFlag" }
+                uniqueItems: true
           uniqueItems: true
         lanes:
           description: >-
@@ -473,41 +461,19 @@ properties:
       description: Rules governing access to this road segment or lane
       type: array
       items:
-        oneOf:
-          - "$ref": "#/$defs/propertyDefinitions/accessOption"
-          - type: object
-            oneOf:
-              - required: [ allowed ]
-                properties:
-                  allowed:
-                    type: object
-                    unevaluatedProperties: false
-                    allOf:
-                      - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/duringContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/ruleContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/directionContainer" }
-              - required: [ designated ]
-                properties:
-                  designated:
-                    type: object
-                    unevaluatedProperties: false
-                    allOf:
-                      - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/duringContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/ruleContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/directionContainer" }
-              - required: [ denied ]
-                properties:
-                  denied:
-                    type: object
-                    unevaluatedProperties: false
-                    allOf:
-                      - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/duringContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/ruleContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/directionContainer" }
-            minLength: 1
+        type: object
+        unevaluatedProperties: false
+        allOf:
+          - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
+          - { "$ref": "#/$defs/propertyContainers/duringContainer" }
+          - { "$ref": "#/$defs/propertyContainers/ruleContainer" }
+          - { "$ref": "#/$defs/propertyContainers/directionContainer" }
+        required: [accessType]
+        properties:
+          accessType:
+            type: string
+            enum: [allowed, denied, designated]
+        minLength: 1
     ruleContainer:
       description: >-
         Properties that allow defining rules from environmental and subjective scoping properties .

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -141,7 +141,6 @@ properties:
           type: array
           items:
             type: object
-            required: [at]
             unevaluatedProperties: false
             allOf:
               - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }


### PR DESCRIPTION
Draft proposal to have static data types. Intended to benefit:
- can have corresponding parquet data structures and can automatically derive a parquet data types for all properties in json schema, including complex nested properties; 
- data structures that are easier to understand and consume programmatically.

Investigating downside that a strongly type parquet schema for nested complex properties is not being converted properly by ogr2ogr.