### PR TITLE
[Waiting] - Adds link in main navbar to tutorials page

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -85,7 +85,7 @@ const config = {
             label: 'Global Entity Reference System',
           },
           {
-            to: 'https://labs.overturemaps.org/how-to',
+            to: 'https://labs.overturemaps.org/how-to/',
             label: 'How-To Guides',
             target: ''
           },

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -84,6 +84,11 @@ const config = {
             // docId: 'gers/gers',
             label: 'Global Entity Reference System',
           },
+          {
+            to: 'https://labs.overturemaps.org/how-to',
+            label: 'How-To Guides',
+            target: ''
+          },
         ],
       },
       footer: {

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -86,7 +86,7 @@ const config = {
           },
           {
             to: 'https://labs.overturemaps.org/how-to/',
-            label: 'How-To Guides',
+            label: 'How-to Guides',
             target: ''
           },
         ],


### PR DESCRIPTION
This PR adds the `How-to Guides` link to the main nav bar:
![image](https://github.com/OvertureMaps/schema/assets/1637425/0305125a-4780-4db7-8b14-d274a49ad2c7)

<hr>
Wait until https://labs.overturemaps.org/how-to/ is ready to be announced (it's currently private) Repo: https://github.com/overturemaps/how-to


Preview: https://dfhx9f55j8eg5.cloudfront.net/pr/54