### PR TITLE
Update turn restriction schema as per the discussion in (https://gith…

### DIFF
--- a/examples/transportation/docusaurus/turn-restriction-01-source.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-01-source.yaml
@@ -23,4 +23,4 @@ properties:
            - segmentId: overture:transportation:example:simple-turn-restriction-target
              connectorId: overture:transportation:example:simple-turn-restriction-connector2
            finalHeading: forward
-           when: {heading : forward} 
+           when: {heading: forward} 

--- a/examples/transportation/docusaurus/turn-restriction-01-source.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-01-source.yaml
@@ -18,8 +18,9 @@ properties:
     - overture:transportation:example:simple-turn-restriction-connector2
   road:
     restrictions:
-      turns:
-        - segmentId: overture:transportation:example:simple-turn-restriction-target
-          connectorId: overture:transportation:example:simple-turn-restriction-connector2
-          direction: forward
-          toDirection: forward
+      prohibitedTransitions:
+         - sequence:  
+           - segmentId: overture:transportation:example:simple-turn-restriction-target
+             connectorId: overture:transportation:example:simple-turn-restriction-connector2
+           finalHeading: forward
+           when: {heading : forward} 

--- a/examples/transportation/docusaurus/turn-restriction-02-source.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-source.yaml
@@ -27,14 +27,13 @@ properties:
     class: primary
     surface: paved
     restrictions:
-      turns:
-        - segmentId: overture:transportation:example:via-turn-restriction-target
-          connectorId: overture:transportation:example:via-turn-restriction-connector2
-          toDirection: forward
-          reason: legal
-          direction: forward
-          during: Mo-Fr 06:00-09:00, 15:00-19:00
-          via:
+      prohibitedTransitions:
+        - sequence:
+            - segmentId: overture:transportation:example:via-turn-restriction-target
+              connectorId: overture:transportation:example:via-turn-restriction-connector2
             - segmentId: overture:transportation:example:via-turn-restriction-via
               connectorId: overture:transportation:example:via-turn-restriction-connector1
-              toDirection: forward
+          finalHeading: forward
+          reason: legal
+          when: {heading: forward}
+          during: Mo-Fr 06:00-09:00, 15:00-19:00

--- a/examples/transportation/segment/road/road-flow-reversible.yaml
+++ b/examples/transportation/segment/road/road-flow-reversible.yaml
@@ -21,8 +21,8 @@ properties:
         restrictions:
           access:
             - allowed:
-                direction: forward
+                heading: forward
                 during: Mo-Su 00:00-12:00
             - allowed:
-                direction: backward
+                heading: backward
                 during: Mo-Su 12:00-24:00

--- a/examples/transportation/segment/road/road-oneway-no-lanes.yaml
+++ b/examples/transportation/segment/road/road-oneway-no-lanes.yaml
@@ -17,4 +17,4 @@ properties:
     restrictions:
       access:
         - denied:
-            direction: forward
+            heading: forward

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -36,21 +36,18 @@ properties:
         - maxSpeed: [30, "km/h"]
           at: [0.25, 0.50]
           during: Mo-Sa 09:00-12:00, We 15:00-18:00
-      turns:
-        - segmentId: overture:transportation:segment:234
-          connectorId: overture:transportation:connector:123
-          toDirection: forward
+      prohibitedTransitions:
+        - sequence:
+          - segmentId: overture:transportation:segment:234
+            connectorId: overture:transportation:connector:123
+          finalHeading: forward
           reason: legal
-          direction: forward
-        - segmentId: overture:transportation:segment:345
-          connectorId: overture:transportation:connector:234
-          toDirection: backward
-          reason: divider
-          direction: backward
-          via:
+          when: {heading: forward}
+        - sequence:
             - segmentId: overture:transportation:segment:456
               connectorId: overture:transportation:connector:345
-              toDirection: forward
             - segmentId: overture:transportation:segment:567
               connectorId: overture:transportation:connector:456
-              toDirection: forward
+          finalHeading: backward
+          reason: divider
+          when: {heading: backward}

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -226,12 +226,12 @@ properties:
           "$comment": >-
             Restrictions define two kinds of rerstriction on this segemnt
             Travel Restrictions defines how certain modes of transportation
-            may be limited on this segement, for example trucks are not
+            may be limited on this segment, for example trucks are not
             permitted from 7AM to 7PM
 
             Turn restrictions defines restrcited tunrs that orignates from
-            this segement, for example against driving side turn from this
-            segement to another connected segement is blocked.
+            this segment, for example against driving side turn from this
+            segment to another connected segment is blocked.
           type: object
           unevaluatedProperties: false
           properties:
@@ -258,15 +258,15 @@ properties:
                      default:
                        enum: [legal]
                    sequence:
-                     description: Sequence of ordered segements that needs to be traversed in order for the relation to be effective
+                     description: Ordered sequence of segments that needs to be traversed in order for the relation to be effective
                      type: array
                      items:
-                       description: GERS ID of the connected segments and the relevent connector
+                       description: Pair of segment and connector IDs along the sequence 
                        "$ref": "#/$defs/propertyDefinitions/relationTarget"
                      minItems: 1
                      uniqueItems: true
                    finalHeading:
-                     description: direction of travel on the target that pertains to the relation
+                     description: Direction of travel that is prohibited on the destination segment of the sequence.
                      "$ref": "#/$defs/propertyDefinitions/direction"
 
     roadFlag:

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -237,15 +237,14 @@ properties:
           properties:
             speedLimits: { "$ref": "#/$defs/propertyContainers/speedLimitsContainer" }
             access: { "$ref": "#/$defs/propertyContainers/accessContainer" }
-            turns:
+            prohibitedTransitions:
               description: Turn restriction from this segment to other segments.
               type: array
               items:
-                 allOf:
-                   - "$ref": "#/$defs/propertyContainers/modesContainer"
-                   - "$ref": "#/$defs/propertyContainers/duringContainer"
-                   - "$ref": "#/$defs/propertyDefinitions/relationTarget"
                  unevaluatedProperties: false
+                 allOf:
+                   - "$ref": "#/$defs/propertyContainers/ruleContainer"
+                   - "$ref": "#/$defs/propertyContainers/duringContainer"
                  type: object
                  properties:
                    reason:
@@ -258,17 +257,18 @@ properties:
                        - gatedKey
                      default:
                        enum: [legal]
-                   direction:
-                     description: direction of travel on the source that pertains to the relation
-                     "$ref": "#/$defs/propertyDefinitions/direction"
-                   via:
+                   sequence:
                      description: Sequence of ordered segements that needs to be traversed in order for the relation to be effective
                      type: array
                      items:
-                       description: GERS ID of the connected segments
+                       description: GERS ID of the connected segments and the relevent connector
                        "$ref": "#/$defs/propertyDefinitions/relationTarget"
                      minItems: 1
                      uniqueItems: true
+                   finalHeading:
+                     description: direction of travel on the target that pertains to the relation
+                     "$ref": "#/$defs/propertyDefinitions/direction"
+
     roadFlag:
       description: Simple flags that can be on or off for a road segment
       type: string
@@ -388,10 +388,7 @@ properties:
             necessarily be conncted to the source of the relation (for example  signposts)
             (TODO replace with GERS ID)
           type: string
-        toDirection:
-          description: direction of travel on the target that pertains to the relation
-          "$ref": "#/$defs/propertyDefinitions/direction"
-      required: [segmentId]
+      required: [segmentId, connectorId]
   propertyContainers:
     atRangeContainer:
       description: >-
@@ -438,10 +435,10 @@ properties:
       "$comment": >-
         If neither mode nor modeNot is specified, the rule has the
         default travel modes for the segment subType.
-    directionContainer:
+    headingContainer:
       description: properties defining direction for which a rule is active
       properties:
-        direction:
+        heading:
           "$ref": "#/$defs/propertyDefinitions/direction"
     speedLimitsContainer:
       description: Rules governing speed on this road segment or lane
@@ -450,7 +447,7 @@ properties:
         description: An individual speed limit rule
         "$comment": >-
           TODO: Speed limits probably have directionality, so
-          should factor out a directionContainer for this
+          should factor out a headingContainer for this
           purpose and use it to introduce an optional
           direction property in each rule.
         type: object
@@ -486,7 +483,7 @@ properties:
                       - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
                       - { "$ref": "#/$defs/propertyContainers/duringContainer" }
                       - { "$ref": "#/$defs/propertyContainers/ruleContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/directionContainer" }
+                      - { "$ref": "#/$defs/propertyContainers/headingContainer" }
               - required: [ designated ]
                 properties:
                   designated:
@@ -496,7 +493,7 @@ properties:
                       - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
                       - { "$ref": "#/$defs/propertyContainers/duringContainer" }
                       - { "$ref": "#/$defs/propertyContainers/ruleContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/directionContainer" }
+                      - { "$ref": "#/$defs/propertyContainers/headingContainer" }
               - required: [ denied ]
                 properties:
                   denied:
@@ -506,7 +503,7 @@ properties:
                       - { "$ref": "#/$defs/propertyContainers/atRangeContainer" }
                       - { "$ref": "#/$defs/propertyContainers/duringContainer" }
                       - { "$ref": "#/$defs/propertyContainers/ruleContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/directionContainer" }
+                      - { "$ref": "#/$defs/propertyContainers/headingContainer" }
             minLength: 1
     ruleContainer:
       description: >-
@@ -518,7 +515,7 @@ properties:
           type: object
           allOf:
             - "$ref": "#/$defs/propertyContainers/modesContainer"
-            - "$ref": "#/$defs/propertyContainers/duringContainer"
+            - "$ref": "#/$defs/propertyContainers/headingContainer"
           unevaluatedProperties: false
           properties:
             using:


### PR DESCRIPTION
…ub.com/OvertureMaps/schema-wg/issues/131)

Other impact:
Renamed direction container to heading container. As a result access restriction need to be heading: instead of direction: However, I guess this should be changed to rules container instead so that it becomes when {heading: forward} instead of just heading:forward.

Removed during container from rules container. There is no reason for during container to be part of rule container.

Next Step: Fix combobulator to take of these changes

---

**UPDATE** (from Vic): This is the staging docs website for this pull request: https://dfhx9f55j8eg5.cloudfront.net/pr/56.