### PR TITLE
Fix 113: [Defect] Inconsistent country and region code property names across addresses and admins themes

### DIFF
--- a/counterexamples/places/bad-address-invalid-property.yaml
+++ b/counterexamples/places/bad-address-invalid-property.yaml
@@ -12,8 +12,8 @@ properties:
       locality: "New York"
     - freeform: "770 Brodway, #802"
       locality: "New York"
-      region2: "NY"
-      country: "US"
+      isoSubCountryCode2: "NY"
+      isoCountryCodeAlpha2: "US"
   # Overture properties
   theme: places
   type: place

--- a/counterexamples/places/bad-address-missing-required-property.yaml
+++ b/counterexamples/places/bad-address-missing-required-property.yaml
@@ -11,8 +11,8 @@ properties:
     - freeform: "770 Broadway, Floor 8"
       locality: "New York"
     - locality: "New York"
-      region: "NY"
-      country: "US"
+      isoSubCountryCode: "NY"
+      isoCountryCodeAlpha2: "US"
   # Overture properties
   theme: places
   type: place

--- a/examples/places/place-alternate-categories.yaml
+++ b/examples/places/place-alternate-categories.yaml
@@ -29,8 +29,8 @@ properties:
       locality: "New York"
     - freeform: "770 Brodway, #802"
       locality: "New York"
-      region: "NY"
-      country: "US"
+      isoSubCountryCode: "NY"
+      isoCountryCodeAlpha2: "US"
   # Overture properties
   theme: places
   type: place

--- a/examples/places/place.yaml
+++ b/examples/places/place.yaml
@@ -27,8 +27,8 @@ properties:
       locality: "New York"
     - freeform: "770 Brodway, #802"
       locality: "New York"
-      region: "NY"
-      country: "US"
+      isoSubCountryCode: "NY"
+      isoCountryCodeAlpha2: "US"
   # Overture properties
   theme: places
   type: place

--- a/examples/places/place2.yaml
+++ b/examples/places/place2.yaml
@@ -8,10 +8,10 @@ properties:
   addresses:
   - freeform: 770 Broadway, Floor 8
     locality: New York
-  - country: US
+  - isoCountryCodeAlpha2: US
     freeform: '770 Broadway #802'
     locality: New York
-    region: NY
+    isoSubCountryCode: "NY"
   brand:
     name: Example
     wikidata: Q1000

--- a/schema/admins/defs.yaml
+++ b/schema/admins/defs.yaml
@@ -70,12 +70,6 @@ description: Common schema definitions for admins theme
       type: integer
       minimum: 1
       maximum: 11
-    isoCountryCodeAlpha2:
-      description: ISO 3166-1 alpha-2 country code.
-      type: string
-    isoSubCountryCode:
-      description: ISO-3166-2 Country subdivision code.
-      type: string
     defaultLanguage:
       description: Most common language used within the area.
       "$ref": "../defs.yaml#/$defs/propertyDefinitions/language"
@@ -91,7 +85,7 @@ description: Common schema definitions for admins theme
       required: [adminLevel]
       properties:
         adminLevel: { "$ref": "#/$defs/propertyDefinitions/adminLevel" }
-        isoCountryCodeAlpha2: { "$ref": "#/$defs/propertyDefinitions/isoCountryCodeAlpha2" }
-        isoSubCountryCode: { "$ref": "#/$defs/propertyDefinitions/isoSubCountryCode" }
+        isoCountryCodeAlpha2: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/isoCountryCodeAlpha2" }
+        isoSubCountryCode: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/isoSubCountryCode" }
         defaultLanguage: { "$ref": "#/$defs/propertyDefinitions/defaultLanguage" }
         drivingSide: { "$ref": "#/$defs/propertyDefinitions/drivingSide" }

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -238,16 +238,18 @@ description: Common schema definitions shared by all themes
         postCode:
           description: Post code where the address is located
           type: string
-        region:
-          description: ISO-3166-2 subdivision/province code
-          type: string
-        country:
-          description: ISO 3166 alpha2 country code
-          type: string
+        isoSubCountryCode: { "$ref": "#/$defs/propertyDefinitions/isoSubCountryCode" }
+        isoCountryCodeAlpha2: { "$ref": "#/$defs/propertyDefinitions/isoCountryCodeAlpha2" }
     wikidata:
       description: A wikidata ID if available, as found on https://www.wikidata.org/.
       type: string
       pattern: ^Q\d+
+    isoCountryCodeAlpha2:
+      description: ISO 3166-1 alpha-2 country code.
+      type: string
+    isoSubCountryCode:
+      description: ISO-3166-2 Country subdivision code.
+      type: string
   propertyContainers:
     overtureFeaturePropertiesContainer:
       title: Overture Properties


### PR DESCRIPTION
Simply moved definition of properties to root defs.yaml and updated places.yaml to reference it + updated examples