### PR TITLE
[WIP] add sourceTags attribute?

### DIFF
--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -244,6 +244,10 @@ description: Common schema definitions shared by all themes
         country:
           description: ISO 3166 alpha2 country code
           type: string
+    sourceTags:
+      description: Attributes that pass directly through from the source data
+      type: object
+
     wikidata:
       description: A wikidata ID if available, as found on https://www.wikidata.org/.
       type: string


### PR DESCRIPTION
## Context

The `base` theme currently has a `sourceTags` attribute to capture tags that come directly from the source, primarily passing through OSM tags. 

This works for `base` because there is only one source (OSM). Is there value in extending this attribute to other themes?

If so, how is it captured? When data could be coming from multiple sources, how would sourceTags be organized?

```yaml
sourceTags: 
  osm: 
    building: garage
  esri:
    "addr:number": 129
```

Or the order of `sources` is `[osm,esri]` and `sourceTags` looks like: 

```yaml
sourceTags: 
  - building:gararge
  - "addr:number": 129
```



Scenarios:
1. **Buildings**: buildings from either OSM or Esri might have addresses or other tags associated that users may want. If, for example, our current list of classes are insufficient, a user might be interested in knowing what the original `building` tag was.

