### PR TITLE
Fix type maxiumum->maximum on linearlyReferencedPosition

### DIFF
--- a/examples/transportation/segment/road/road-with-lr-name.yaml
+++ b/examples/transportation/segment/road/road-with-lr-name.yaml
@@ -20,7 +20,7 @@ properties:
     roadNames:
       - at:
           - 0
-          - 50
+          - 0.5
         common:
           - value: Common Road Name 1
             language: local
@@ -28,8 +28,8 @@ properties:
           - value: SRN1
             language: local
       - at:
-        - 50
-        - 100
+        - 0.5
+        - 1
         common:
           - value: Common Road Name 2
             language: local

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -106,7 +106,7 @@ description: Common schema definitions shared by all themes
         center-line segment.
       type: number
       minimum: 0
-      maxiumum: 1
+      maximum: 1
       "$comment": >-
         One possible advantage to using percentages over absolute
         distances is being able to trivially validate that the position


### PR DESCRIPTION
Looks like test on https://github.com/OvertureMaps/schema/blob/main/examples/transportation/segment/road/lanes/lanes-on-straight-road-lr.yaml is failing now, because it has values 0-100 and not 0-1, can someone from transportation figure this one out?