### PR TITLE
feat: remove the use of mix-type fields for transportation access restrictions

### DIFF
--- a/counterexamples/transportation/segment/road/restrictions/bad-access-mode-not.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/bad-access-mode-not.yaml
@@ -22,5 +22,5 @@ properties:
     flags: [is_link, is_tunnel, isPrivate]
     restrictions:
       access:
-        - allowed:
-            when: {mode_not: [foo]}
+        - access_type: allowed
+          when: {mode_not: [foo]}

--- a/counterexamples/transportation/segment/road/restrictions/bad-access-mode.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/bad-access-mode.yaml
@@ -24,5 +24,5 @@ properties:
     flags: [is_link, is_tunnel]
     restrictions:
       access:
-        - allowed:
-            when: {mode: [foo]}
+        - access_type: allowed
+          when: {mode: [foo]}

--- a/counterexamples/transportation/segment/road/restrictions/bad-access-restrictions-vehicle.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/bad-access-restrictions-vehicle.yaml
@@ -22,5 +22,5 @@ properties:
     flags: [is_link, is_tunnel, isPrivate]
     restrictions:
       access:
-        - allowed:
-            when: {vehicle: {axle_count: {isFoo: 5}}}
+        - access_type: allowed
+          when: {vehicle: {axle_count: {is_foo: 5}}}

--- a/counterexamples/transportation/segment/road/restrictions/turns/bad-access-restrictions-modes.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/turns/bad-access-restrictions-modes.yaml
@@ -22,5 +22,5 @@ properties:
     flags: [is_link, is_tunnel, isPrivate]
     restrictions:
       access:
-        - allowed:
-            when: {mode: [foo]}
+        - access_type: allowed
+          when: {mode: [foo]}

--- a/counterexamples/transportation/segment/road/restrictions/turns/bad-access-restrictions-not-modes.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/turns/bad-access-restrictions-not-modes.yaml
@@ -22,5 +22,5 @@ properties:
     flags: [is_link, is_tunnel, isPrivate]
     restrictions:
       access:
-        - allowed:
-            when: {mode_not: [foo]}
+        - access_type: allowed
+          when: {mode_not: [foo]}

--- a/counterexamples/transportation/segment/road/restrictions/turns/bad-access-restrictions-recognized.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/turns/bad-access-restrictions-recognized.yaml
@@ -22,5 +22,5 @@ properties:
     flags: [is_link, is_tunnel, isPrivate]
     restrictions:
       access:
-        - allowed:
-            when: {recognized: [foo]}
+        - access_type: allowed
+          when: {recognized: [foo]}

--- a/counterexamples/transportation/segment/road/restrictions/turns/bad-access-restrictions-using.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/turns/bad-access-restrictions-using.yaml
@@ -22,5 +22,5 @@ properties:
     flags: [is_link, is_tunnel, isPrivate]
     restrictions:
       access:
-        - allowed:
-            when: {using: [foo]}
+        - access_type: allowed
+          when: {using: [foo]}

--- a/counterexamples/transportation/segment/road/restrictions/turns/bad-access-restrictions-vehicle.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/turns/bad-access-restrictions-vehicle.yaml
@@ -22,5 +22,5 @@ properties:
     flags: [is_link, is_tunnel, isPrivate]
     restrictions:
       access:
-        - allowed:
-            when: {vehicle: {axle_count: {isFoo: 5}}}
+        - access_type: allowed
+          when: {vehicle: {axle_count: {is_foo: 5}}}

--- a/examples/transportation/docusaurus/access-restriction-01-blanket.yaml
+++ b/examples/transportation/docusaurus/access-restriction-01-blanket.yaml
@@ -14,4 +14,5 @@ properties:
   subtype: road
   road:
     restrictions:
-      access: [denied]
+      access:
+        - access_type: denied

--- a/examples/transportation/docusaurus/access-restriction-02-private-with-deliveries.yaml
+++ b/examples/transportation/docusaurus/access-restriction-02-private-with-deliveries.yaml
@@ -15,8 +15,9 @@ properties:
   road:
     restrictions:
       access:
-        - denied
-        - allowed: { when: { recognized: [as_private] } }
-        - allowed:
-            when: { using: [to_deliver] }
-            during: Mo-Fr 08:30-16:30
+        - access_type: denied
+        - access_type: allowed
+          when: { recognized: [as_private] }
+        - access_type: allowed
+          when: { using: [to_deliver] }
+          during: Mo-Fr 08:30-16:30

--- a/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
+++ b/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
@@ -15,5 +15,7 @@ properties:
   road:
     restrictions:
       access:
-        - denied: { when: { mode: [motor_vehicle] } }
-        - allowed: { when: { using: [at_destination] } }
+        - access_type: denied
+          when: { mode: [motor_vehicle] }
+        - access_type: allowed
+          when: { using: [at_destination] }

--- a/examples/transportation/docusaurus/access-restriction-04-axle-limit.yaml
+++ b/examples/transportation/docusaurus/access-restriction-04-axle-limit.yaml
@@ -15,7 +15,7 @@ properties:
   road:
     restrictions:
       access:
-        - denied:
-            when:
-              mode: [hgv]
-              vehicle: { axle_count: { is_at_least: 5 } }
+        - access_type: denied
+          when:
+            mode: [hgv]
+            vehicle: { axle_count: { is_at_least: 5 } }

--- a/examples/transportation/docusaurus/access-restriction.yaml
+++ b/examples/transportation/docusaurus/access-restriction.yaml
@@ -26,5 +26,5 @@ properties:
     surface: paved
     restrictions:
       access:
-        - denied:
-            when: {mode: [foot]}
+        - access_type: denied
+          when: {mode: [foot]}

--- a/examples/transportation/docusaurus/lanes-hov.yaml
+++ b/examples/transportation/docusaurus/lanes-hov.yaml
@@ -36,10 +36,10 @@ properties:
       - direction: forward # lane 0 -> hov only
         restrictions:
           access:
-            - allowed:
-                when:
-                  mode:
-                    - hov
+            - access_type: allowed
+              when:
+                mode:
+                  - hov
           min_occupancy:
             is_at_least: 3
       - direction: forward # lane 1

--- a/examples/transportation/docusaurus/subjective-heading-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-heading-scoping.yaml
@@ -20,9 +20,9 @@ properties:
     class: primary
     restrictions:
       access:
-        - denied:
-            when: { heading: backward }
-        - allowed:
-            when:
-              heading: backward
-              mode: [bus]
+        - access_type: denied
+          when: { heading: backward }
+        - access_type: allowed
+          when:
+            heading: backward
+            mode: [bus]

--- a/examples/transportation/docusaurus/subjective-status-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-status-scoping.yaml
@@ -16,6 +16,6 @@ properties:
   road:
     restrictions:
       access:
-        - denied
-        - allowed:
-            when: { recognized: [as_private] }
+        - access_type: denied
+        - access_type: allowed
+          when: { recognized: [as_private] }

--- a/examples/transportation/docusaurus/subjective-usage-purpose-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-usage-purpose-scoping.yaml
@@ -15,6 +15,6 @@ properties:
   road:
     restrictions:
       access:
-        - denied
-        - allowed:
-            when: { using: [as_customer, at_destination] }
+        - access_type: denied
+        - access_type: allowed
+          when: { using: [as_customer, at_destination] }

--- a/examples/transportation/docusaurus/temporal-scoping.yaml
+++ b/examples/transportation/docusaurus/temporal-scoping.yaml
@@ -16,5 +16,6 @@ properties:
   road:
     restrictions:
       access:
-        - denied: { during: "Mo-Fr 15:00-18:00" }
-          when: { not_mode: [bus] }
+        - access_type: denied
+          during: "Mo-Fr 15:00-18:00"
+          when: { mode_not: [bus] }

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-access-for-travel-modes.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-access-for-travel-modes.yaml
@@ -26,23 +26,23 @@ properties:
       - direction: backward # lane 0 not allowed for trucks (heavy good vehicles)
         restrictions:
           access:
-            - denied:
-                when:
-                  mode:
-                    - hgv
+            - access_type: denied
+              when:
+                mode:
+                  - hgv
       - direction: forward # lane 1
       - direction: forward # lane 2 not allowed for buses and trucks
         restrictions:
           access:
-            - denied:
-                when:
-                  mode:
-                    - hgv
-                    - bus
+            - access_type: denied
+              when:
+                mode:
+                  - hgv
+                  - bus
       - direction: forward # lane 3 - allowed only for bicycles
         restrictions:
           access:
-            - allowed:
-                when:
-                  mode:
-                    - bicycle
+            - access_type: allowed
+              when:
+                mode:
+                  - bicycle

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-access-with-lr.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-access-with-lr.yaml
@@ -28,10 +28,10 @@ properties:
       - direction: forward # lane 2 from its 60% of length (till the end) it is allowed only for buses (before 60% mark it is available for all vehicles)
         restrictions:
           access:
-            - allowed:
-                when:
-                  mode:
-                    - bus
+            - access_type: allowed
+              when:
+                mode:
+                  - bus
               at:
                 - 0.6
                 - 1.0

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-hov-occupancy-scoped.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-hov-occupancy-scoped.yaml
@@ -32,11 +32,11 @@ properties:
       - direction: forward # lane 0 -> hov only that allows also bicycles
         restrictions:
           access:
-            - allowed:
-                when:
-                  mode:
-                    - hov
-                    - bicycle
+            - access_type: allowed
+              when:
+                mode:
+                  - hov
+                  - bicycle
           min_occupancy:
             - is_at_least: 3
               when:

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-hov.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-hov.yaml
@@ -32,10 +32,10 @@ properties:
       - direction: forward # lane 0 -> hov only
         restrictions:
           access:
-            - allowed:
-                when:
-                  mode:
-                    - hov
+            - access_type: allowed
+              when:
+                mode:
+                  - hov
           min_occupancy:
             is_at_least: 3
       - direction: forward # lane 1

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-speed-limits.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-speed-limits.yaml
@@ -32,21 +32,21 @@ properties:
       - direction: forward # lane 1  -> hgv vehicles cannot use that lane
         restrictions:
           access:
-            - denied:
-                when:
-                  mode:
-                    - hgv
+            - access_type: denied
+              when:
+                mode:
+                  - hgv
       - direction: forward # lane 2 - available for all vehicles except hgv vehicles if their weight is more than 3 tons, and they must limit their speed to 80 km/h
         # for all other vehicles segment speed limit (100 km/h) applies
         restrictions:
           access:
-            - denied:
-                when:
-                  mode:
-                    - hgv
-                  vehicle:
-                    weight:
-                      is_at_most: 3
+            - access_type: denied
+              when:
+                mode:
+                  - hgv
+                vehicle:
+                  weight:
+                    is_at_most: 3
           speed_limits:
             - max_speed:
                 - 80

--- a/examples/transportation/segment/road/road-acesss-restriction.yaml
+++ b/examples/transportation/segment/road/road-acesss-restriction.yaml
@@ -20,15 +20,15 @@ properties:
   road:
     restrictions:
       access:
-        - denied
-        - designated:
-            when: {mode: [truck]}
-            at: [0.1, 0.25]
-        - allowed:
-            when:
-              using: [as_customer, to_farm]
-              recognized: [as_permitted, as_employee]
-            at: [0.25, 0.50]
-        - allowed:
-            when: {vehicle: {axle_count: {is_more_than: 5}}}
-            at: [0.50, 0.70]
+        - access_type: denied
+        - access_type: designated
+          when: {mode: [truck]}
+          at: [0.1, 0.25]
+        - access_type: allowed
+          when:
+            using: [as_customer, to_farm]
+            recognized: [as_permitted, as_employee]
+          at: [0.25, 0.50]
+        - access_type: allowed
+          when: {vehicle: {axle_count: {is_more_than: 5}}}
+          at: [0.50, 0.70]

--- a/examples/transportation/segment/road/road-flow-reversible.yaml
+++ b/examples/transportation/segment/road/road-flow-reversible.yaml
@@ -20,9 +20,9 @@ properties:
       - direction: reversible
         restrictions:
           access:
-            - allowed:
-                heading: forward
-                during: Mo-Su 00:00-12:00
-            - allowed:
-                heading: backward
-                during: Mo-Su 12:00-24:00
+            - access_type: allowed
+              heading: forward
+              during: Mo-Su 00:00-12:00
+            - access_type: allowed
+              heading: backward
+              during: Mo-Su 12:00-24:00

--- a/examples/transportation/segment/road/road-oneway-no-lanes.yaml
+++ b/examples/transportation/segment/road/road-oneway-no-lanes.yaml
@@ -16,5 +16,5 @@ properties:
     # one way road in backward direction (forward access is denied)
     restrictions:
       access:
-        - denied:
-            heading: forward
+        - access_type: denied
+          heading: forward

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -460,41 +460,19 @@ properties:
       description: Rules governing access to this road segment or lane
       type: array
       items:
-        oneOf:
-          - "$ref": "#/$defs/propertyDefinitions/accessOption"
-          - type: object
-            oneOf:
-              - required: [ allowed ]
-                properties:
-                  allowed:
-                    type: object
-                    unevaluatedProperties: false
-                    allOf:
-                      - { "$ref": "../defs.yaml#/$defs/propertyContainers/atRangeContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/duringContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/ruleContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/headingContainer" }
-              - required: [ designated ]
-                properties:
-                  designated:
-                    type: object
-                    unevaluatedProperties: false
-                    allOf:
-                      - { "$ref": "../defs.yaml#/$defs/propertyContainers/atRangeContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/duringContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/ruleContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/headingContainer" }
-              - required: [ denied ]
-                properties:
-                  denied:
-                    type: object
-                    unevaluatedProperties: false
-                    allOf:
-                      - { "$ref": "../defs.yaml#/$defs/propertyContainers/atRangeContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/duringContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/ruleContainer" }
-                      - { "$ref": "#/$defs/propertyContainers/headingContainer" }
-            minLength: 1
+        type: object
+        unevaluatedProperties: false
+        allOf:
+          - { "$ref": "../defs.yaml#/$defs/propertyContainers/atRangeContainer" }
+          - { "$ref": "#/$defs/propertyContainers/duringContainer" }
+          - { "$ref": "#/$defs/propertyContainers/ruleContainer" }
+          - { "$ref": "#/$defs/propertyContainers/headingContainer" }
+        required: [access_type]
+        properties:
+          access_type:
+            type: string
+            enum: [allowed, denied, designated]
+        minLength: 1
     ruleContainer:
       description: >-
         Properties that allow defining rules from environmental and subjective scoping properties .


### PR DESCRIPTION
Based on:
- the slack conversation: https://overturemaps.slack.com/archives/C04NBKDE1DZ/p1700058876659019
- this draft PR from @ibnt1 

this PR tackles the use of mix-type fields for transportation access restrictions