### PR TITLE
Change adminLevel from 2,4,6... to 1,2,3...

### DIFF
--- a/counterexamples/admins/admin-lower-adminLevel-no-context.json
+++ b/counterexamples/admins/admin-lower-adminLevel-no-context.json
@@ -7,7 +7,7 @@
     "updateTime": "2023-02-22T23:55:01-08:00",
     "subType": "administrativeLocality",
     "localityType": "country",
-    "adminLevel": 3,
+    "adminLevel": 1,
     "isoCountryCodeAlpha2": "US",
     "defaultLanguage": "en",
     "drivingSide": "right",

--- a/counterexamples/admins/locality/bad-language.json
+++ b/counterexamples/admins/locality/bad-language.json
@@ -7,7 +7,7 @@
     "updateTime": "2023-02-22T23:55:01-08:00",
     "subType": "administrativeLocality",
     "localityType": "country",
-    "adminLevel": 2,
+    "adminLevel": 0,
     "isoCountryCodeAlpha2": "US",
     "defaultLanguage": "english",
     "drivingSide": "right",

--- a/counterexamples/admins/locality/bad-language.json
+++ b/counterexamples/admins/locality/bad-language.json
@@ -7,7 +7,7 @@
     "updateTime": "2023-02-22T23:55:01-08:00",
     "subType": "administrativeLocality",
     "localityType": "country",
-    "adminLevel": 0,
+    "adminLevel": 1,
     "isoCountryCodeAlpha2": "US",
     "defaultLanguage": "english",
     "drivingSide": "right",

--- a/counterexamples/admins/locality/missing-locality-type.json
+++ b/counterexamples/admins/locality/missing-locality-type.json
@@ -7,7 +7,7 @@
     "updateTime": "2023-02-22T23:55:01-08:00",
     "subType": "administrativeLocality",
     "contextId": "northAmericaId",
-    "adminLevel": 0,
+    "adminLevel": 1,
     "names": {
       "common": [
         {

--- a/counterexamples/admins/locality/missing-locality-type.json
+++ b/counterexamples/admins/locality/missing-locality-type.json
@@ -6,8 +6,8 @@
     "version": 0,
     "updateTime": "2023-02-22T23:55:01-08:00",
     "subType": "administrativeLocality",
-    "adminLevel": 2,
     "contextId": "northAmericaId",
+    "adminLevel": 0,
     "names": {
       "common": [
         {

--- a/counterexamples/admins/locality/missing-names.json
+++ b/counterexamples/admins/locality/missing-names.json
@@ -7,7 +7,7 @@
     "updateTime": "2023-02-22T23:55:01-08:00",
     "subType": "administrativeLocality",
     "localityType": "country",
-    "adminLevel": 2,
+    "adminLevel": 0,
     "contextId": "northAmericaId"
   },
   "geometry": {

--- a/counterexamples/admins/locality/missing-names.json
+++ b/counterexamples/admins/locality/missing-names.json
@@ -7,7 +7,7 @@
     "updateTime": "2023-02-22T23:55:01-08:00",
     "subType": "administrativeLocality",
     "localityType": "country",
-    "adminLevel": 0,
+    "adminLevel": 1,
     "contextId": "northAmericaId"
   },
   "geometry": {

--- a/counterexamples/admins/locality/missing-sub-type.json
+++ b/counterexamples/admins/locality/missing-sub-type.json
@@ -6,7 +6,7 @@
     "version": 0,
     "updateTime": "2023-02-22T23:55:01-08:00",
     "localityType": "country",
-    "adminLevel": 0,
+    "adminLevel": 1,
     "contextId": "northAmericaId",
     "names": {
       "common": [

--- a/counterexamples/admins/locality/missing-sub-type.json
+++ b/counterexamples/admins/locality/missing-sub-type.json
@@ -6,7 +6,7 @@
     "version": 0,
     "updateTime": "2023-02-22T23:55:01-08:00",
     "localityType": "country",
-    "adminLevel": 2,
+    "adminLevel": 0,
     "contextId": "northAmericaId",
     "names": {
       "common": [

--- a/docusaurus/docs/themes/admins/admins.mdx
+++ b/docusaurus/docs/themes/admins/admins.mdx
@@ -11,7 +11,7 @@ The current version of the schema does not support the modeling of multiple geo-
 
 ### Clear Country Definitions
 
-There are no gaps or overlaps at the country level (<code>adminLevel=2</code>) in order to support visualization, sectioning, and other mapping use cases, even in cases of disputed boundaries.
+There are no gaps or overlaps at the country level (<code>adminLevel=0</code>) in order to support visualization, sectioning, and other mapping use cases, even in cases of disputed boundaries.
 Additionally, all countries have been assigned an ISO3166-1 ISO country code which has been kept as close as possible to the standard. For some disputed areas and remote overseas territories, custom ISO codes have been created to describe the region which can be easily identified.
 
 ### Admin Types

--- a/docusaurus/docs/themes/admins/admins.mdx
+++ b/docusaurus/docs/themes/admins/admins.mdx
@@ -11,7 +11,7 @@ The current version of the schema does not support the modeling of multiple geo-
 
 ### Clear Country Definitions
 
-There are no gaps or overlaps at the country level (<code>adminLevel=0</code>) in order to support visualization, sectioning, and other mapping use cases, even in cases of disputed boundaries.
+There are no gaps or overlaps at the country level (<code>adminLevel=1</code>) in order to support visualization, sectioning, and other mapping use cases, even in cases of disputed boundaries.
 Additionally, all countries have been assigned an ISO3166-1 ISO country code which has been kept as close as possible to the standard. For some disputed areas and remote overseas territories, custom ISO codes have been created to describe the region which can be easily identified.
 
 ### Admin Types

--- a/examples/admins/administrativeBoundary/administrativeBoundary.yaml
+++ b/examples/admins/administrativeBoundary/administrativeBoundary.yaml
@@ -16,5 +16,5 @@ properties:
   type: administrativeBoundary
   updateTime: '2023-02-22T23:55:01-08:00'
   version: 0
-  adminLevel: 0
+  adminLevel: 1
   isMaritime: true

--- a/examples/admins/administrativeBoundary/administrativeBoundary.yaml
+++ b/examples/admins/administrativeBoundary/administrativeBoundary.yaml
@@ -16,5 +16,5 @@ properties:
   type: administrativeBoundary
   updateTime: '2023-02-22T23:55:01-08:00'
   version: 0
-  adminLevel: 2
+  adminLevel: 0
   isMaritime: true

--- a/examples/admins/administrativeBoundary/disputedAdministrativeBoundary.yaml
+++ b/examples/admins/administrativeBoundary/disputedAdministrativeBoundary.yaml
@@ -16,6 +16,6 @@ properties:
   type: administrativeBoundary
   updateTime: '2023-02-22T23:55:01-08:00'
   version: 0
-  adminLevel: 0
+  adminLevel: 1
   isMaritime: true
   geopolDisplay: disputed

--- a/examples/admins/administrativeBoundary/disputedAdministrativeBoundary.yaml
+++ b/examples/admins/administrativeBoundary/disputedAdministrativeBoundary.yaml
@@ -16,6 +16,6 @@ properties:
   type: administrativeBoundary
   updateTime: '2023-02-22T23:55:01-08:00'
   version: 0
-  adminLevel: 2
+  adminLevel: 0
   isMaritime: true
   geopolDisplay: disputed

--- a/examples/admins/locality/admin-country-no-context.yaml
+++ b/examples/admins/locality/admin-country-no-context.yaml
@@ -11,7 +11,7 @@ properties:
   updateTime: '2023-02-22T23:55:01-08:00'
   version: 0
   subType: administrativeLocality
-  adminLevel: 2
+  adminLevel: 0
   defaultLanguage: en
   drivingSide: right
   isoCountryCodeAlpha2: US

--- a/examples/admins/locality/admin-country-no-context.yaml
+++ b/examples/admins/locality/admin-country-no-context.yaml
@@ -11,7 +11,7 @@ properties:
   updateTime: '2023-02-22T23:55:01-08:00'
   version: 0
   subType: administrativeLocality
-  adminLevel: 0
+  adminLevel: 1
   defaultLanguage: en
   drivingSide: right
   isoCountryCodeAlpha2: US

--- a/examples/admins/locality/geometry-point.yaml
+++ b/examples/admins/locality/geometry-point.yaml
@@ -12,7 +12,7 @@ properties:
   version: 0
   subType: administrativeLocality
   contextId: northAmericaId
-  adminLevel: 0
+  adminLevel: 1
   defaultLanguage: en
   drivingSide: right
   isoCountryCodeAlpha2: US

--- a/examples/admins/locality/geometry-point.yaml
+++ b/examples/admins/locality/geometry-point.yaml
@@ -11,8 +11,8 @@ properties:
   updateTime: '2023-02-22T23:55:01-08:00'
   version: 0
   subType: administrativeLocality
-  adminLevel: 2
   contextId: northAmericaId
+  adminLevel: 0
   defaultLanguage: en
   drivingSide: right
   isoCountryCodeAlpha2: US

--- a/examples/admins/locality/no-optional-properties.yaml
+++ b/examples/admins/locality/no-optional-properties.yaml
@@ -11,7 +11,7 @@ properties:
   updateTime: '2023-02-22T23:55:01-08:00'
   version: 0
   subType: administrativeLocality
-  adminLevel: 0
+  adminLevel: 1
   contextId: northAmericaId
   localityType: country
   names:

--- a/examples/admins/locality/no-optional-properties.yaml
+++ b/examples/admins/locality/no-optional-properties.yaml
@@ -11,7 +11,7 @@ properties:
   updateTime: '2023-02-22T23:55:01-08:00'
   version: 0
   subType: administrativeLocality
-  adminLevel: 2
+  adminLevel: 0
   contextId: northAmericaId
   localityType: country
   names:

--- a/schema/admins/defs.yaml
+++ b/schema/admins/defs.yaml
@@ -66,10 +66,10 @@ description: Common schema definitions for admins theme
                                  Vračar, Belgrade, Serbia
                                  Arecibo, Puerto Rico
     adminLevel:
-      description: Hierarchical level for administrative entity or border (matching admin_level in OSM taxonomy)
+      description: Hierarchical level for administrative entity or border. E.g. in United States, Country locality representing United States has adminLevel=0, States have adminLevel=1, Counties have adminLevel=2.
       type: integer
-      minimum: 1
-      maximum: 11
+      minimum: 0
+      maximum: 6
     isoCountryCodeAlpha2:
       description: ISO 3166-1 alpha-2 country code.
       type: string

--- a/schema/admins/defs.yaml
+++ b/schema/admins/defs.yaml
@@ -66,7 +66,7 @@ description: Common schema definitions for admins theme
                                  Vračar, Belgrade, Serbia
                                  Arecibo, Puerto Rico
     adminLevel:
-      description: Hierarchical level for administrative entity or border. E.g. in United States, Country locality representing United States has adminLevel=0, States have adminLevel=1, Counties have adminLevel=2.
+      description: Hierarchical level for administrative entity or border. E.g. in United States, Country locality representing United States has adminLevel=1, States have adminLevel=2, Counties have adminLevel=3.
       type: integer
       minimum: 0
       maximum: 6

--- a/schema/admins/locality.yaml
+++ b/schema/admins/locality.yaml
@@ -22,7 +22,7 @@ properties:
           allOf:
           - "$ref": "./defs.yaml#/$defs/propertyContainers/adminPropertiesContainer"
           - title: "Conditional Properties"
-            if: {properties: {adminLevel: { minimum: 3 }}}
+            if: {properties: {adminLevel: { minimum: 1 }}}
             then:
               required: [contextId]
       - "$ref": ../defs.yaml#/$defs/propertyContainers/overtureFeaturePropertiesContainer

--- a/schema/admins/locality.yaml
+++ b/schema/admins/locality.yaml
@@ -22,7 +22,7 @@ properties:
           allOf:
           - "$ref": "./defs.yaml#/$defs/propertyContainers/adminPropertiesContainer"
           - title: "Conditional Properties"
-            if: {properties: {adminLevel: { minimum: 1 }}}
+            if: {properties: {adminLevel: { minimum: 2 }}}
             then:
               required: [contextId]
       - "$ref": ../defs.yaml#/$defs/propertyContainers/overtureFeaturePropertiesContainer


### PR DESCRIPTION
Originally idea was just follow OSM admin_level taxonomy, which defeats pourpose of Overture which is to normalize data, for example Isle of Man has local goverments admin_level=8 in OSM, but those are first level subdivision inside country, so we need to remap it to something representing that, until now we mapped that into adminLevel=4 which meant 1st subdivision of country. To make things simplier, we decided to go with 1=country and then 1st subdivision of country has adminLevel=2, 2nd subdivision of country has adminLevel=3 and so on...