### PR TITLE
Add footway to road class enum

### DIFF
--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -132,6 +132,7 @@ properties:
             - parkingAisle # service road intended for parking
             - driveway # service road intended for deliveries
             - pedestrian
+            - footway
             - sidewalk
             - crosswalk
             - steps


### PR DESCRIPTION
Re-adding footway as a road class to handle features without a differentiating footway tag. Previously removed in #78.