### PR TITLE
Adding elevation to base

### DIFF
--- a/schema/base/defs.yaml
+++ b/schema/base/defs.yaml
@@ -7,6 +7,10 @@ description: Common schema definitions the base theme (primarily from OSM)
     sourceTags:
       description: Any attributes/tags from the original source data that should be passed through.
       type: object
+    elevation:
+      description: Elevation above sea level (in meters) of the feature.
+      type: integer
+      maximum: 9000
   propertyContainers:
     osmPropertiesContainer:
       title: "OSM Properties"

--- a/schema/base/land.yaml
+++ b/schema/base/land.yaml
@@ -72,4 +72,5 @@ properties:
           - volcano
           - wetland
           - wood
+      elevation: { "$ref": ./defs.yaml#/$defs/propertyDefinitions/elevation }
       names: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/names" }

--- a/schema/base/landUse.yaml
+++ b/schema/base/landUse.yaml
@@ -155,6 +155,7 @@ properties:
           - winterSports
           - zoo
       names: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/names" }
+      elevation: { "$ref": ./defs.yaml#/$defs/propertyDefinitions/elevation }
       surface:
         description: Surface material, mostly form the OSM tag, with some normalization.
         type: string


### PR DESCRIPTION
Adds elevation as a top-level attribute in `land`, `landUse`, and `water` types.