### PR TITLE
Removing level property from connectors schema

### DIFF
--- a/counterexamples/transportation/connector/level-property-not-allowed.json
+++ b/counterexamples/transportation/connector/level-property-not-allowed.json
@@ -1,0 +1,18 @@
+{
+    "id": "unrecognizedLevelProperty",
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [0, 0]
+    },
+    "properties": {
+      "theme": "transportation",
+      "type": "connector",
+      "version": 0,
+      "updateTime": "2023-04-24T09:19:00-07:00",
+      "level": 3,
+      "extExpectedErrors": [
+        "[I#/properties/level] [S#/properties/properties/unevaluatedProperties] not allowed"
+      ]
+    }
+  }

--- a/examples/transportation/connector/connector.yaml
+++ b/examples/transportation/connector/connector.yaml
@@ -12,5 +12,4 @@ properties:
   type: connector
   version: 0
   updateTime: "2023-02-23T00:02:01-08:00"
-  level: 3
 #

--- a/examples/transportation/docusaurus/connector.yaml
+++ b/examples/transportation/docusaurus/connector.yaml
@@ -9,4 +9,3 @@ properties:
   type: connector
   version: 0
   updateTime: "2023-02-23T00:02:01-08:00"
-  level: 3

--- a/schema/transportation/connector.yaml
+++ b/schema/transportation/connector.yaml
@@ -19,4 +19,3 @@ properties:
     unevaluatedProperties: false
     allOf:
       - "$ref": ../defs.yaml#/$defs/propertyContainers/overtureFeaturePropertiesContainer
-      - "$ref": ../defs.yaml#/$defs/propertyContainers/levelContainer


### PR DESCRIPTION
Removing levels property from connectors schema as it does not align well with segment feature. 
Issue: https://github.com/OvertureMaps/schema-wg/issues/138

### Testing
Tested by modifying examples and counterexamples accordingly and running test script.