### PR TITLE
Update featureUpdateTime pattern regex

### DIFF
--- a/counterexamples/common/timestamp/bad-timestamp-invalid-days.yaml
+++ b/counterexamples/common/timestamp/bad-timestamp-invalid-days.yaml
@@ -1,0 +1,15 @@
+---
+id: bad-timestamp-invalid-days
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    main: someCategory
+  theme: places
+  type: place
+  version: 0
+  updateTime: "2024-02-32T15:45:22Z"
+  extExpectedErrors:
+    - "does not match pattern"

--- a/counterexamples/common/timestamp/bad-timestamp-invalid-hours.yaml
+++ b/counterexamples/common/timestamp/bad-timestamp-invalid-hours.yaml
@@ -1,0 +1,15 @@
+---
+id: bad-timestamp-invalid-hours
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    main: someCategory
+  theme: places
+  type: place
+  version: 0
+  updateTime: "2024-01-12T24:59:22-08:00"
+  extExpectedErrors:
+    - "does not match pattern"

--- a/counterexamples/common/timestamp/bad-timestamp-invalid-miliseconds.yaml
+++ b/counterexamples/common/timestamp/bad-timestamp-invalid-miliseconds.yaml
@@ -1,0 +1,15 @@
+---
+id: bad-timestamp-invalid-miliseconds
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    main: someCategory
+  theme: places
+  type: place
+  version: 0
+  updateTime: "2024-01-12T22:59:22.1234-08:00"
+  extExpectedErrors:
+    - "does not match pattern"

--- a/counterexamples/common/timestamp/bad-timestamp-invalid-minutes.yaml
+++ b/counterexamples/common/timestamp/bad-timestamp-invalid-minutes.yaml
@@ -1,0 +1,15 @@
+---
+id: bad-timestamp-invalid-minutes
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    main: someCategory
+  theme: places
+  type: place
+  version: 0
+  updateTime: "2024-01-12T14:60:22-08:00"
+  extExpectedErrors:
+    - "does not match pattern"

--- a/counterexamples/common/timestamp/bad-timestamp-invalid-months.yaml
+++ b/counterexamples/common/timestamp/bad-timestamp-invalid-months.yaml
@@ -1,0 +1,15 @@
+---
+id: bad-timestamp-invalid-months
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    main: someCategory
+  theme: places
+  type: place
+  version: 0
+  updateTime: "2024-13-22T12:59:22-08:00"
+  extExpectedErrors:
+    - "does not match pattern"

--- a/counterexamples/common/timestamp/bad-timestamp-invalid-seconds.yaml
+++ b/counterexamples/common/timestamp/bad-timestamp-invalid-seconds.yaml
@@ -1,0 +1,15 @@
+---
+id: bad-timestamp-invalid-seconds
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    main: someCategory
+  theme: places
+  type: place
+  version: 0
+  updateTime: "2024-11-22T12:44:61-08:00"
+  extExpectedErrors:
+    - "does not match pattern"

--- a/counterexamples/common/timestamp/bad-timestamp-invalid-timezone.yaml
+++ b/counterexamples/common/timestamp/bad-timestamp-invalid-timezone.yaml
@@ -1,0 +1,15 @@
+---
+id: bad-timestamp-invalid-timezone
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    main: someCategory
+  theme: places
+  type: place
+  version: 0
+  updateTime: "2024-11-22T12:44:22+25:00"
+  extExpectedErrors:
+    - "does not match pattern"

--- a/counterexamples/common/timestamp/bad-timestamp-no-timezone.yaml
+++ b/counterexamples/common/timestamp/bad-timestamp-no-timezone.yaml
@@ -1,0 +1,15 @@
+---
+id: bad-timestamp-no-timezone
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    main: someCategory
+  theme: places
+  type: place
+  version: 0
+  updateTime: "2024-11-22T12:44:22"
+  extExpectedErrors:
+    - "does not match pattern"

--- a/counterexamples/common/timestamp/bad-timestamp-yaml-no-quotes.yaml
+++ b/counterexamples/common/timestamp/bad-timestamp-yaml-no-quotes.yaml
@@ -1,5 +1,5 @@
 ---
-id: bad-yaml-timestamp
+id: bad-timestamp-yaml-no-quotes
 type: Feature
 geometry:
   type: Point

--- a/examples/common/timestamp/timestamp-leap-second.yaml
+++ b/examples/common/timestamp/timestamp-leap-second.yaml
@@ -1,0 +1,12 @@
+---
+id: timestamp-leap-second
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  theme: transportation
+  type: segment
+  subType: road
+  version: 0
+  updateTime: "1990-12-31T15:59:60-08:00"

--- a/examples/common/timestamp/timestamp-utc.yaml
+++ b/examples/common/timestamp/timestamp-utc.yaml
@@ -1,0 +1,13 @@
+---
+id: timestamp-utc
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    main: someCategory
+  theme: places
+  type: place
+  version: 0
+  updateTime: "2024-01-22T12:00:00Z"

--- a/examples/common/timestamp/timestamp-with-tz-offset.yaml
+++ b/examples/common/timestamp/timestamp-with-tz-offset.yaml
@@ -1,0 +1,11 @@
+---
+id: timestamp-with-tz-offset
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  theme: transportation
+  type: connector
+  version: 0
+  updateTime: "2024-01-22T12:00:00-08:00"

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -30,7 +30,7 @@ description: Common schema definitions shared by all themes
       description: Timestamp when the feature was last updated
       type: string
       format: date-time
-      pattern: ^[1-9]\d{3}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?(Z|[-+]\d{2}:\d{2})?$
+      pattern: ^([1-9]\d{3})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):([0-5]\d):([0-5]\d|60)(\.\d{1,3})?(Z|[-+]([01]\d|2[0-3]):[0-5]\d)$
       "$comment": >-
         Pattern is used as a fallback because not all JSON schema
         implementations treat "format" as an assertion, for some it is

--- a/test.sh
+++ b/test.sh
@@ -135,7 +135,7 @@ function expected_errors() {
   local instance_file="$1"
   local type
   type=$(yq -r '.properties | type' "$instance_file")
-  if [ "$type" != "object" ]; then
+  if [[ "$type" != "object" && "$type" != "!!map" ]]; then
     return 1
   fi
   yq -r '(.properties.extExpectedErrors // []) | .[]' "$instance_file"
@@ -178,7 +178,7 @@ function counterexamples() {
   if command -v yq >/dev/null; then
     yq_installed=true
   else
-    >&2 printf "WARNING: yq is not installed. Install yq for higher-fidelity counterexample testing."
+    >&2 printf "WARNING: yq is not installed. Install yq for higher-fidelity counterexample testing.\n"
   fi
   find counterexamples -type f | sort | while read -r instance_file; do
     if ! match "$instance_file"; then
@@ -198,6 +198,7 @@ function counterexamples() {
       for expected_error in "${expected_errors[@]}"; do
         for actual_error in "${actual_errors[@]}"; do
           if [[ "$actual_error" == *"$expected_error"* ]]; then
+            echo OK
             continue 2
           fi
         done


### PR DESCRIPTION
Update featureUpdateTime pattern regex

### Regex breakdown
| Regex | Element | Range
| - | - | -
| `^` | Start of the string | N/A
| `([1-9]\d{3})` | Year | 1000-9999
| `-(0[1-9]\|1[0-2])` | Month | 01-12
| `-(0[1-9]\|[12]\d\|3[01])` | Day | 01-31
| `T([01]\d\|2[0-3])` | Hours | 00-23
| `:([0-5]\d)` | Minutes | 00-59
| `:([0-5]\d\|60)` | Seconds | 00-59 or 60 (to accomodate leap second)
| `(\.\d{1,3})?` | Miliseconds | none or 0 to 999 (0-3 decimal precision)
| `(Z\|[-+]([01]\d\|2[0-3]):[0-5]\d)` | Timezone | Z for UTC or -24:59 to +24:59
| `$` | End of the string | N/A

### Not covered with regex validation
This pattern does not validate correctness of timestamps for
- Month-Day combination: 2024-04-31T12:00:00Z is accepted
- Validity of date for leap year: 2023-02-29T12:00:00Z is accepted
- Validity of date for leap second: 2024-01-15T12:00:60Z is accepted
- Validity of timezone offset: 2024-01-01T12:00:00-14:00 is accepted

### Testing
- Added examples and counterexamples
- Ran overture schema unit tests
```
# (Mac) Prerequisite install Homebrew
# Install Golang
> brew install go
# Install YAML processor CLI tool (yq)
> brew install yq
# If not already, add go bin to your path
> export PATH="$PATH":$HOME/go/bin
# Install json schema CLI tool (jv)
> go install github.com/santhosh-tekuri/jsonschema/cmd/jv@latest
# Check if jv if available
> jv --version
# Run tests
> ./test.sh
```