### PR TITLE
Update segment surface default value to scalar value unknown

### DIFF
--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -159,7 +159,7 @@ properties:
               minItems: 1
               uniqueItems: true
           default:
-            enum: [unknown]
+            enum: unknown
           "$comment": >-
             We should likely restrict the available surface types to
             the subset of the common OSM surface=* tag values that are


### PR DESCRIPTION
Update segment surface default value to scalar value `unknown`

`road.surface` property contains either a single scalar value taken from the roadSurface enumeration, or a non-empty array of unique road surface rules, which are objects having a geometric scoping property (at) and a value property (value). It is not possible for the property to contain an array of string, so `[unknown]` is not a valid default values

Related issue: https://github.com/OvertureMaps/schema-wg/issues/163

### Testing
All existing tests passed
```
./test.sh
```