### PR TITLE
Removed temporal scoping and isPrivate from road flags

### DIFF
--- a/counterexamples/transportation/segment/road/bad-road-flags-invalid-isPrivate-flag.json
+++ b/counterexamples/transportation/segment/road/bad-road-flags-invalid-isPrivate-flag.json
@@ -1,0 +1,21 @@
+{
+    "id": "invalidIsPrivateFlag",
+    "type": "Feature",
+    "geometry": {
+      "type": "LineString",
+      "coordinates": [[2, 2], [3, 3]]
+    },
+    "properties": {
+      "theme": "transportation",
+      "type": "segment",
+      "version": 19,
+      "updateTime": "2023-02-23T00:04:00-08:00",
+      "subType": "road",
+      "road": {
+        "flags": ["isPrivate"]
+      },
+      "extExpectedErrors": [
+        "[I#/properties/road/flags/0] [S#/$defs/propertyDefinitions/roadFlag/enum] value must be one of \"isBridge\", \"isLink\", \"isTunnel\", \"isUnderConstruction\""
+      ]
+    }
+  }

--- a/counterexamples/transportation/segment/road/bad-road-invalid-temporal-scoping.json
+++ b/counterexamples/transportation/segment/road/bad-road-invalid-temporal-scoping.json
@@ -1,0 +1,22 @@
+{
+  "id": "invalidTemporalScoping",
+  "type": "Feature",
+  "geometry": {
+    "type": "LineString",
+    "coordinates": [[2, 2], [3, 3]]
+  },
+  "properties": {
+    "theme": "transportation",
+    "type": "segment",
+    "version": 19,
+    "updateTime": "2023-02-23T00:04:00-08:00",
+    "subType": "road",
+    "road": {
+      "flags": ["isBridge"],
+      "during": "Mo-Sa 09:00-12:00, We 15:00-18:00"
+    },
+    "extExpectedErrors": [
+      "[I#/properties/road/during] [S#/$defs/propertyDefinitions/road/unevaluatedProperties] not allowed"
+    ]
+  }
+} 

--- a/examples/transportation/segment/road/road-rules.yaml
+++ b/examples/transportation/segment/road/road-rules.yaml
@@ -24,10 +24,8 @@ properties:
       - value: paved
         at: [0.25, 1]
     flags:
-      - values: [isPrivate, isBridge]
+      - values: [isBridge]
       - values: []
         at: [0.5, 0.75]
       - values: [isTunnel]
         at: [0.75, 0.9]
-      - values: [isPrivate]
-        during: Mo-Sa 09:00-12:00, We 15:00-18:00

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -22,7 +22,7 @@ properties:
     # no access nor lanes information -> means by default road is accessible in both directions with at least one lane in each direction
     class: secondary
     surface: gravel
-    flags: [isLink, isTunnel, isPrivate]
+    flags: [isLink, isTunnel]
     restrictions:
       speedLimits:
         - minSpeed: [90, "km/h"]

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -176,7 +176,6 @@ properties:
               - type: object
                 allOf:
                   - { "$ref": "../defs.yaml#/$defs/propertyContainers/atRangeContainer" }
-                  - { "$ref": "#/$defs/propertyContainers/duringContainer" }
                 unevaluatedProperties: false
                 properties:
                   values:
@@ -262,7 +261,6 @@ properties:
       enum:
         - isBridge
         - isLink
-        - isPrivate
         - isTunnel
         - isUnderConstruction
     roadSurface:


### PR DESCRIPTION
This PR removes temporal scoping and `isPrivate` flag from `road.flags` property.
Issue: https://github.com/OvertureMaps/schema-wg/issues/144

### Testing
Tested by modifying examples and creating new counterexamples accordingly and running test script.

### Acceptance Criteria
1. Delete temporal scoping from the `flags` property.
2. Delete `isPrivate` flag from the `roadFlag` enumeration.
3. Update the documentation for the `flags` enumeration to explain that flags represent physical state. (documentation for `road.flags` property already relays this information)