### PR TITLE
Docs fix - clarify example for temporally scoped lane rule

### DIFF
--- a/docusaurus/docs/themes/transportation/scoping-rules.mdx
+++ b/docusaurus/docs/themes/transportation/scoping-rules.mdx
@@ -351,7 +351,7 @@ absolute form without a list of rules.
 Consider the following two examples of road segments. On the left is a section
 from a simple two-lane bidirectional city street in which there is always one
 lane of traffic flowing in each direction. On the right is a section from a
-one-way city street in which one of the lanes is only available for driving at
+one-way city street in which two of the lanes are only available for driving at
 certain times of the day, being reserved for parking at other times. In the
 example on the left, the lane list is specified absolutely; while in the example
 on the right, it is given as a list of [Temporally-scoped](#temporal-scoping-opening-hours)


### PR DESCRIPTION
Fix to avoid confusion when reading the example for temporally scoped lane rule. 

Example in question:
``` 
  road:
    lanes:
      - value:
          - direction: forward
          - direction: forward
      - during: Mo-Fr 15:00-18:00
        value:
          - direction: forward
          - direction: forward
          - direction: forward
          - direction: forward
```

Link to docs page: https://docs.overturemaps.org/themes/transportation/scoping-rules