### PR TITLE
🚨DO NOT MERGE UNTIL 2/15 🚨 Country and sub-division ISO code validation

### DIFF
--- a/counterexamples/admins/locality/invalid-country-code-exceeded-max-length.json
+++ b/counterexamples/admins/locality/invalid-country-code-exceeded-max-length.json
@@ -1,0 +1,46 @@
+{
+    "type": "Feature",
+    "properties": {
+      "theme": "admins",
+      "type": "locality",
+      "version": 0,
+      "updateTime": "2023-02-22T23:55:01-08:00",
+      "subType": "administrativeLocality",
+      "localityType": "country",
+      "adminLevel": 1,
+      "isoCountryCodeAlpha2": "USA",
+      "defaultLanguage": "english",
+      "drivingSide": "right",
+      "contextId": "northAmericaId",
+      "extExpectedErrors": [
+        "[I#/properties/isoCountryCodeAlpha2] [S#/$defs/propertyDefinitions/isoCountryCodeAlpha2/pattern] does not match pattern '^[A-Z]{2}$'"
+      ]
+    },
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -61.8743292,
+            48.8068635
+          ],
+          [
+            -78.4016703,
+            26.273714
+          ],
+          [
+            -120.7749598,
+            32.2499745
+          ],
+          [
+            -126.928757,
+            49.0378679
+          ],
+          [
+            -61.8743292,
+            48.8068635
+          ]
+        ]
+      ]
+    }
+  }

--- a/counterexamples/admins/locality/invalid-country-code-less-than-min-length.json
+++ b/counterexamples/admins/locality/invalid-country-code-less-than-min-length.json
@@ -1,0 +1,46 @@
+{
+    "type": "Feature",
+    "properties": {
+      "theme": "admins",
+      "type": "locality",
+      "version": 0,
+      "updateTime": "2023-02-22T23:55:01-08:00",
+      "subType": "administrativeLocality",
+      "localityType": "country",
+      "adminLevel": 1,
+      "isoCountryCodeAlpha2": "U",
+      "defaultLanguage": "english",
+      "drivingSide": "right",
+      "contextId": "northAmericaId",
+      "extExpectedErrors": [
+        "[I#/properties/isoCountryCodeAlpha2] [S#/$defs/propertyDefinitions/isoCountryCodeAlpha2/pattern] does not match pattern '^[A-Z]{2}$'"
+      ]
+    },
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -61.8743292,
+            48.8068635
+          ],
+          [
+            -78.4016703,
+            26.273714
+          ],
+          [
+            -120.7749598,
+            32.2499745
+          ],
+          [
+            -126.928757,
+            49.0378679
+          ],
+          [
+            -61.8743292,
+            48.8068635
+          ]
+        ]
+      ]
+    }
+  }

--- a/counterexamples/admins/locality/invalid-sub-country-code-exceeded-max-length.json
+++ b/counterexamples/admins/locality/invalid-sub-country-code-exceeded-max-length.json
@@ -1,0 +1,46 @@
+{
+    "type": "Feature",
+    "properties": {
+      "theme": "admins",
+      "type": "locality",
+      "version": 0,
+      "updateTime": "2023-02-22T23:55:01-08:00",
+      "subType": "administrativeLocality",
+      "localityType": "country",
+      "adminLevel": 1,
+      "isoSubCountryCode": "US-NYCC",
+      "defaultLanguage": "english",
+      "drivingSide": "right",
+      "contextId": "northAmericaId",
+      "extExpectedErrors": [
+        "[I#/properties/isoSubCountryCode] [S#/$defs/propertyDefinitions/isoSubCountryCode/pattern] does not match pattern '^[A-Z]{2}-[A-Z0-9]{1,3}$'"
+      ]
+    },
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -61.8743292,
+            48.8068635
+          ],
+          [
+            -78.4016703,
+            26.273714
+          ],
+          [
+            -120.7749598,
+            32.2499745
+          ],
+          [
+            -126.928757,
+            49.0378679
+          ],
+          [
+            -61.8743292,
+            48.8068635
+          ]
+        ]
+      ]
+    }
+  }

--- a/counterexamples/admins/locality/invalid-sub-country-code-less-than-min-length.json
+++ b/counterexamples/admins/locality/invalid-sub-country-code-less-than-min-length.json
@@ -1,0 +1,46 @@
+{
+    "type": "Feature",
+    "properties": {
+      "theme": "admins",
+      "type": "locality",
+      "version": 0,
+      "updateTime": "2023-02-22T23:55:01-08:00",
+      "subType": "administrativeLocality",
+      "localityType": "country",
+      "adminLevel": 1,
+      "isoSubCountryCode": "US",
+      "defaultLanguage": "english",
+      "drivingSide": "right",
+      "contextId": "northAmericaId",
+      "extExpectedErrors": [
+        "[I#/properties/isoSubCountryCode] [S#/$defs/propertyDefinitions/isoSubCountryCode/pattern] does not match pattern '^[A-Z]{2}-[A-Z0-9]{1,3}$'"
+      ]
+    },
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -61.8743292,
+            48.8068635
+          ],
+          [
+            -78.4016703,
+            26.273714
+          ],
+          [
+            -120.7749598,
+            32.2499745
+          ],
+          [
+            -126.928757,
+            49.0378679
+          ],
+          [
+            -61.8743292,
+            48.8068635
+          ]
+        ]
+      ]
+    }
+  }

--- a/examples/admins/locality/iso-sub-country-code-locality.yaml
+++ b/examples/admins/locality/iso-sub-country-code-locality.yaml
@@ -1,0 +1,37 @@
+---
+type: Feature
+geometry:
+  coordinates:
+  - -122.3183680
+  - 47.6238307
+  type: Point
+properties:
+  theme: admins
+  type: locality
+  updateTime: '2023-02-22T23:55:01-08:00'
+  version: 0
+  subType: administrativeLocality
+  adminLevel: 1
+  defaultLanguage: en
+  drivingSide: right
+  isoCountryCodeAlpha2: US
+  isoSubCountryCode: US-NY
+  localityType: country
+  names:
+    primary: United States
+    common:
+      en: United States
+      es: Estados Unidos
+    rules:
+      - variant: alternate
+        value: States
+      - variant: official
+        value: United States of America
+      - variant: short
+        value: US
+      - variant: short
+        language: en
+        value: US
+      - variant: short
+        language: en
+        value: U.S.

--- a/schema/admins/defs.yaml
+++ b/schema/admins/defs.yaml
@@ -73,9 +73,15 @@ description: Common schema definitions for admins theme
     isoCountryCodeAlpha2:
       description: ISO 3166-1 alpha-2 country code.
       type: string
+      minLength: 2
+      maxLength: 2  
+      pattern: ^[A-Z]{2}$
     isoSubCountryCode:
       description: ISO-3166-2 Country subdivision code.
       type: string
+      minLength: 4
+      maxLength: 6
+      pattern: ^[A-Z]{2}-[A-Z0-9]{1,3}$ 
     defaultLanguage:
       description: Most common language used within the area.
       "$ref": "../defs.yaml#/$defs/propertyDefinitions/language"


### PR DESCRIPTION
This PR adds validation to the definitions of `isoCountryCodeAlpha2` and `isoSubCountryCode` properties in the admin schema.
Issue: https://github.com/OvertureMaps/schema-wg/issues/117

### Testing
Tested by modifying examples and creating new counterexamples accordingly and running test script.

### Details
The following validation was added to `isoCountryCodeAlpha2`
    - `"minLength": 2`
    - `"maxLength": 2`
    - `"pattern": "^[A-Z]{2}$"`

The following validation was added to `isoSubCountryCode`
    - `"minLength": 4`
    - `"maxLength": 6`
    - `"pattern": "^[A-Z]{2}-[A-Z0-9]{1,3}$"`
    - This validation comes from the ISO reference guide: https://www.iso.org/obp/ui/en/#iso:std:iso:3166:-2:ed-4:v1:en
<img width="798" alt="image" src="https://github.com/OvertureMaps/schema/assets/46388171/a4ff616c-4e6d-4a8b-bb08-f042638e1dfc">