### PR TITLE
Linearly reference road width

### DIFF
--- a/counterexamples/transportation/segment/bad-lr-width-missing-items.json
+++ b/counterexamples/transportation/segment/bad-lr-width-missing-items.json
@@ -1,5 +1,5 @@
 {
-  "id": "segment with 0 meters width",
+  "id": "segment with empty road width rules array",
   "type": "Feature",
   "geometry": {
     "type": "LineString",
@@ -11,6 +11,11 @@
     "version": 25,
     "updateTime": "2023-02-23T00:04:00-08:00",
     "subType": "road",
-    "width": 0
+    "road": {
+      "width": []
+    },
+    "extExpectedErrors": [
+      "[I#/properties/road/width] [S#/$defs/propertyDefinitions/road/properties/width/minItems] minimum 1 items required, but found 0 items"
+    ]
   }
 }

--- a/counterexamples/transportation/segment/bad-lr-width.json
+++ b/counterexamples/transportation/segment/bad-lr-width.json
@@ -1,5 +1,5 @@
 {
-  "id": "segment with 0 meters width",
+  "id": "segment with missing value for one of ranges",
   "type": "Feature",
   "geometry": {
     "type": "LineString",
@@ -11,6 +11,14 @@
     "version": 25,
     "updateTime": "2023-02-23T00:04:00-08:00",
     "subType": "road",
-    "width": 0
+    "width": [
+      {
+        "at" : [0, 0.5],
+        "value:" : 1.5
+      },
+      {
+        "at" : [0.5, 1.0]
+      }
+    ]
   }
 }

--- a/examples/transportation/segment/road/road-with-lr-width.yaml
+++ b/examples/transportation/segment/road/road-with-lr-width.yaml
@@ -1,0 +1,24 @@
+---
+id: overture:transportation:segment:123
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  # Custom user properties.
+  extBaz: I am a custom user property...
+  # Overture properties
+  theme: transportation
+  type: segment
+  updateTime: "2023-06-28T00:02:30-08:00"
+  version: 0
+  subType: road
+  level: 1
+  connectors: [fooConnector, barConnector]
+  road:
+    class: secondary
+    width:
+    - at: [0, 0.5]
+      value: 1.5
+    - at: [0.5, 1]
+      value: 2.0

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -14,7 +14,6 @@ properties:
   version: 0
   subType: road
   level: -1
-  width: 10
   connectors: [fooConnector, barConnector] # Topology: To discuss further.
   names:
     primary: Common Road Name
@@ -23,6 +22,8 @@ properties:
     class: secondary
     surface: gravel
     flags: [isLink, isTunnel]
+    width:
+      - value: 10
     restrictions:
       speedLimits:
         - minSpeed: [90, "km/h"]

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -24,7 +24,6 @@ properties:
         then:
           properties:
             road: { "$ref": "#/$defs/propertyDefinitions/road" }
-            width: { "$ref": "#/$defs/propertyDefinitions/roadWidth"}
       - "$ref": ../defs.yaml#/$defs/propertyContainers/overtureFeaturePropertiesContainer
       - "$ref": ../defs.yaml#/$defs/propertyContainers/levelContainer
     properties:
@@ -183,6 +182,30 @@ properties:
                     items: { "$ref": "#/$defs/propertyDefinitions/roadFlag" }
                     uniqueItems: true
           uniqueItems: true
+        width:
+          description: >-
+            Edge-to-edge width of the road modeled by this segment, in
+            meters.
+    
+            Examples: (1) If this segment models a carriageway without
+            sidewalk, this value represents the edge-to-edge width of the
+            carriageway, inclusive of any shoulder. (2) If this segment
+            models a sidewalk by itself, this value represents the
+            edge-to-edge width of the sidewalk. (3) If this segment models a
+            combined sidewalk and carriageway, this value represents the
+            edge-to-edge width inclusive of sidewalk.
+          type: array
+          items:
+            type: object
+            allOf:
+              - { "$ref": "../defs.yaml#/$defs/propertyContainers/atRangeContainer" }
+            properties:
+              value:
+                type: number
+                exclusiveMinimum: 0
+            unevaluatedProperties: false
+          minItems: 1
+          uniqueItems: true
         lanes:
           description: >-
             Describes the layout of lanes on the road plus lane-related
@@ -274,20 +297,6 @@ properties:
         - dirt
         - pavingStones
         - metal
-    roadWidth:
-      description: >-
-        Edge-to-edge width of the road modeled by this segment, in
-        meters.
-
-        Examples: (1) If this segment models a carriageway without
-        sidewalk, this value represents the edge-to-edge width of the
-        carriageway, inclusive of any shoulder. (2) If this segment
-        models a sidewalk by itself, this value represents the
-        edge-to-edge width of the sidewalk. (3) If this segment models a
-        combined sidewalk and carriageway, this value represents the
-        edge-to-edge width inclusive of sidewalk.
-      type: number
-      exclusiveMinimum: 0
     speed:
       description: >-
         A speed value, i.e. a certain number of distance units


### PR DESCRIPTION
# Description

This change enables linear referencing of road width, addressing a known defect in the schema. It also moves the road `"width"` property under the `"road"` property since, especially with LR, width is not an obviously generalized property cutting across the whole schema.

We do not currently combobulate road with at all, so once this change is merged we shall have to.

# Acknowledgements

This PR builds on Ola's work referenced in the below listed issue and her name is consequently kept on the commit.
compat
# Reference

https://github.com/OvertureMaps/schema-wg/issues/151

# Testing

1. Added new compatible examples.
2. Added new tested counterexamples.