### PR TITLE
Add is_abandoned flag to segments

### DIFF
--- a/examples/transportation/segment/road/road-abandoned.yaml
+++ b/examples/transportation/segment/road/road-abandoned.yaml
@@ -1,0 +1,17 @@
+---
+id: overture:transportation:segment:789
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  # Overture properties
+  theme: transportation
+  type: segment
+  update_time: "2023-02-23T00:03:15-08:00"
+  version: 2
+  subtype: road
+  road:
+      class: secondary
+      surface: gravel
+      flags: [is_abandoned]

--- a/examples/transportation/segment/road/road-abandoned.yaml
+++ b/examples/transportation/segment/road/road-abandoned.yaml
@@ -12,6 +12,6 @@ properties:
   version: 2
   subtype: road
   road:
-      class: secondary
+      class: tertiary
       surface: gravel
       flags: [is_abandoned]

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -288,6 +288,7 @@ properties:
         - is_link
         - is_tunnel
         - is_under_construction
+        - is_abandoned
     roadSurface:
       description: Physical surface of the road
       type: string


### PR DESCRIPTION
# Description

Adds road flag that allows for identification and downstream filtering of segments that are no longer maintained. These are typically denoted in OSM with `abandoned*=` and `disused*=` tags.

# Reference

1. [Internal issue](https://github.com/OvertureMaps/tf-transportation/issues/85)

# Testing

Ran all tests including against added example.

# Checklist

1. [X] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
4. [ ] Update Docusaurus documentation, if an update is required.
5. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/132)
