### PR TITLE
Add alley road class

### DIFF
--- a/examples/transportation/segment/road/road-alley.yaml
+++ b/examples/transportation/segment/road/road-alley.yaml
@@ -18,5 +18,3 @@ properties:
         - allowed:
             when:
               using: [at_destination]
-      speed_limits:
-        - max_speed: [15, "mph"]

--- a/examples/transportation/segment/road/road-alley.yaml
+++ b/examples/transportation/segment/road/road-alley.yaml
@@ -15,6 +15,6 @@ properties:
     class: alley
     restrictions:
       access:
-        - allowed:
-            when:
-              using: [at_destination]
+        - access_type: allowed
+          when:
+            using: [at_destination]

--- a/examples/transportation/segment/road/road-alley.yaml
+++ b/examples/transportation/segment/road/road-alley.yaml
@@ -1,0 +1,22 @@
+---
+id: overture:transportation:segment:1555
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  # Overture properties
+  theme: transportation
+  type: segment
+  update_time: "2023-02-23T00:03:59-08:00"
+  version: 4
+  subtype: road
+  road:
+    class: alley
+    restrictions:
+      access:
+        - allowed:
+            when:
+              using: [at_destination]
+      speed_limits:
+        - max_speed: [15, "mph"]

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -132,6 +132,7 @@ properties:
             - unclassified    # Known roads, paved, but subordinate to all of: motorway, trunk, primary, secondary, tertiary
             - parking_aisle   # Service road intended for parking
             - driveway        # Service road intended for deliveries
+            - alley           # Service road intended for rear entrances, fire exits
             - pedestrian
             - footway
             - sidewalk

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -183,7 +183,7 @@ properties:
           description: >-
             Edge-to-edge width of the road modeled by this segment, in
             meters.
-    
+
             Examples: (1) If this segment models a carriageway without
             sidewalk, this value represents the edge-to-edge width of the
             carriageway, inclusive of any shoulder. (2) If this segment
@@ -303,7 +303,7 @@ properties:
       prefixItems:
         - description: Number of speed units
           type: integer
-          minimum: 20
+          minimum: 15
         - description: One speed unit
           type: string
           enum: [ "km/h", "mph" ]

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -303,7 +303,7 @@ properties:
       prefixItems:
         - description: Number of speed units
           type: integer
-          minimum: 15
+          minimum: 20
         - description: One speed unit
           type: string
           enum: [ "km/h", "mph" ]


### PR DESCRIPTION
# Description

Adds alley as an additional road class, which is the last remaining major service road type (1.7M/7% of service roads).

# Reference

1. [Internal issue](https://github.com/OvertureMaps/tf-transportation/issues/84)

# Testing

Ran tests with sample alley from segment data, included as example.

# Checklist

1. [X] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
4. [ ] Update Docusaurus documentation, if an update is required.
5. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/134)
