### PR TITLE
Delete `primary` sub-property from division's `local_type`

### DIFF
--- a/counterexamples/divisions/division/bad-names.yaml
+++ b/counterexamples/divisions/division/bad-names.yaml
@@ -22,5 +22,5 @@ properties:
   norms:
     driving_side: left
   ext_expected_errors:
-    - "[I#/properties/names/primary] [S#/$defs/propertyDefinitions/commonNames/properties/primary/type] expected string, but got null"
+    - "[I#/properties/names/primary] [S#/$defs/propertyDefinitions/allNames/properties/primary/type] expected string, but got null"
     - additionalProperties 'a-b-c-d-e-f-g-h-i-j-k-l' not allowed

--- a/examples/divisions/division/dependency.yaml
+++ b/examples/divisions/division/dependency.yaml
@@ -11,7 +11,7 @@ properties:
   version: 0
   subtype: dependency
   local_type:
-    primary: territory
+    en: territory
   names:
     primary: Puerto Rico
     common:

--- a/examples/divisions/division/hierarchies-multiple.yaml
+++ b/examples/divisions/division/hierarchies-multiple.yaml
@@ -11,7 +11,7 @@ properties:
   version: 0
   subtype: borough
   local_type:
-    primary: borough
+    en: borough
   names:
     primary: The Bronx
   country: US

--- a/examples/divisions/division/population.yaml
+++ b/examples/divisions/division/population.yaml
@@ -11,7 +11,7 @@ properties:
   version: 0
   subtype: region
   local_type:
-    primary: province
+    en: province
   names:
     primary: Ontario
   sources:

--- a/examples/divisions/division/region.yaml
+++ b/examples/divisions/division/region.yaml
@@ -11,7 +11,7 @@ properties:
   version: 0
   subtype: region
   local_type:
-    primary: state
+    en: state
   names:
     primary: New York
   sources:

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -206,9 +206,13 @@ description: Common schema definitions shared by all themes
       type: object
       required: [primary]
       unevaluatedProperties: false
-      allOf:
-        - { "$ref": "#/$defs/propertyDefinitions/commonNames" }
       properties:
+        primary:
+          description: The most commonly used name.
+          type: string
+          minLength: 1
+          pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
+        common: { "$ref": "#/$defs/propertyDefinitions/commonNames" }
         rules:
           description: >-
             Rules for names that cannot be specified in the simple
@@ -220,26 +224,17 @@ description: Common schema definitions shared by all themes
           items: { "$ref": "#/$defs/propertyDefinitions/nameRule" }
           minItems: 1
     commonNames:
+      description: The common translations of the name.
       type: object
-      required: [primary]
-      properties:
-        primary:
-          description: The most commonly used name.
+      minProperties: 1
+      additionalProperties: false
+      patternProperties:
+        "^[a-zA-Z]{2,3}(-[a-zA-Z]{4})?(-[a-zA-Z]{2})?$":
+          "$comment": >-
+            This is an incomplete pattern for BCP47 language tags.
           type: string
           minLength: 1
           pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
-        common:
-          description: The common translations of the name.
-          type: object
-          minProperties: 1
-          additionalProperties: false
-          patternProperties:
-            "^[a-zA-Z]{2,3}(-[a-zA-Z]{4})?(-[a-zA-Z]{2})?$":
-              "$comment": >-
-                This is an incomplete pattern for BCP47 language tags.
-              type: string
-              minLength: 1
-              pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
     iso3166_1Alpha2CountryCode:
       description: ISO 3166-1 alpha-2 country code.
       type: string


### PR DESCRIPTION
# Description

*Brief description of the business purpose and effect of the pull request.*

This change deletes the `primary` sub-property from a division's `local_type` property and deletes a redundant level of nesting.

## Before

```yaml
local_type:
  primary: territory
  common:
    en: territory
    fr: territoire
```

## After

```yaml
local_type:
  en: territory
  fr: territoire
```



# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

1. The decision to make this change was made in the Admin Task Force meeting of [2024-03-04](https://github.com/OvertureMaps/tf-admin/issues/51) as a fast-follow on the main [Divisions](https://github.com/OvertureMaps/schema/pull/130) PR.
2. The reason for making the change is that we couldn't articulate a good objective basis for favoring one translation over another as "primary" and felt that doing so could lead to unnecessary controversy in multi-lingual jurisdictions. We felt that it is a different situation than with the "primary" name of the `names` structure because the name of a feature is much more local and primary preferences should tend to even out, whereas with `local_type` we would want to be able to have a single "national" policy to make the data programmatically friendly. But a single policy would tend to globally prefer one translation over another so we decided to drop "primary" instead.

# Testing

*Brief description of the testing done for this change showing why you are confident it works as expected and does not introduce regressions. Provide sample output data where appropriate.* 

Updated examples and counterexamples.

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [ ] Add relevant examples.
3. [ ] Add relevant counterexamples.
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/139)
