### PR TITLE
Restructure and remove mixed schema types for speed_limits property

### DIFF
--- a/counterexamples/transportation/segment/road/restrictions/bad-speed-limits-empty-rule.json
+++ b/counterexamples/transportation/segment/road/restrictions/bad-speed-limits-empty-rule.json
@@ -13,9 +13,9 @@
     "subtype": "road",
     "road": {
       "restrictions": {
-        "speed_limits": [
-          { }
-        ]
+        "speed_limits": {
+
+        }
       }
     }
   }

--- a/counterexamples/transportation/segment/road/restrictions/bad-speed-limits-mode.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/bad-speed-limits-mode.yaml
@@ -23,5 +23,7 @@ properties:
       - [is_link, is_tunnel]
     restrictions:
       speed_limits:
-        - max_speed: [110, "mph"]
+        - max_speed:
+            value: 110
+            unit: mph
           when: {mode: [foo]}

--- a/examples/transportation/docusaurus/geometric-scoping.yaml
+++ b/examples/transportation/docusaurus/geometric-scoping.yaml
@@ -14,6 +14,10 @@ properties:
     restrictions:
       speed_limits:
         - at: [0, 0.15]
-          max_speed: [100, "km/h"]
+          max_speed:
+            value: 100
+            unit: km/h
         - at: [0.15, 1]
-          max_speed: [60, "km/h"]
+          max_speed:
+            value: 60
+            unit: km/h

--- a/examples/transportation/docusaurus/lanes-hov.yaml
+++ b/examples/transportation/docusaurus/lanes-hov.yaml
@@ -20,8 +20,8 @@ properties:
     restrictions:
       speed_limits:
         - max_speed:
-            - 100
-            - "km/h"
+            value: 100
+            unit: km/h
     lanes:
       # one-way road with access and speed limit restrictions
       # digitization: S->N

--- a/examples/transportation/docusaurus/speed-limits-01-simple.yaml
+++ b/examples/transportation/docusaurus/speed-limits-01-simple.yaml
@@ -15,4 +15,6 @@ properties:
   road:
     restrictions:
       speed_limits:
-        - max_speed: [30, "km/h"]
+        - max_speed:
+            value: 30
+            unit: km/h

--- a/examples/transportation/docusaurus/speed-limits-02-directional.yaml
+++ b/examples/transportation/docusaurus/speed-limits-02-directional.yaml
@@ -15,9 +15,13 @@ properties:
   road:
     restrictions:
       speed_limits:
-        - max_speed: [70, "mph"]
+        - max_speed:
+            value: 70
+            unit: mph
         - #when: TODO: Uncomment and re-introduce `when` once this issue is sorted: schema-wg #155.
           mode: [hgv]
             # TODO: Uncomment below once this issue is sorted: schema-wg #155.
             # proceeding: { inDirection: forward }
-          max_speed: [65, "mph"]
+          max_speed:
+            value: 65
+            unit: mph

--- a/examples/transportation/docusaurus/speed-limits-03-variable-max.yaml
+++ b/examples/transportation/docusaurus/speed-limits-03-variable-max.yaml
@@ -17,5 +17,7 @@ properties:
   road:
     restrictions:
       speed_limits:
-        - max_speed: [100, "km/h"]
+        - max_speed:
+            value: 100
+            unit: km/h
           is_max_speed_variable: true

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-hov-occupancy-scoped.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-hov-occupancy-scoped.yaml
@@ -16,8 +16,8 @@ properties:
     restrictions:
       speed_limits:
         - max_speed:
-            - 100
-            - "km/h"
+            value: 100
+            unit: km/h
     lanes:
       # one-way road with access and speed limit restrictions
       # digitization: S->N

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-hov.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-hov.yaml
@@ -16,8 +16,8 @@ properties:
     restrictions:
       speed_limits:
         - max_speed:
-            - 100
-            - "km/h"
+            value: 100
+            unit: km/h
     lanes:
       # one-way road with access and speed limit restrictions
       # digitization: S->N

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-speed-limits.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-speed-limits.yaml
@@ -16,8 +16,8 @@ properties:
     restrictions:
       speed_limits:
         - max_speed:
-            - 100
-            - "km/h"
+            value: 100
+            unit: km/h
     lanes:
       # two-way road with access and speed limit restrictions
       # digitization: S->N
@@ -49,7 +49,7 @@ properties:
                     is_at_most: 3
           speed_limits:
             - max_speed:
-                - 80
-                - "km/h"
+                value: 80
+                unit: km/h
               mode:
                 - hgv

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -28,13 +28,21 @@ properties:
       - value: 10
     restrictions:
       speed_limits:
-        - min_speed: [90, "km/h"]
-          max_speed: [110, "mph"]
+        - min_speed:
+            value: 90
+            unit: km/h
+          max_speed:
+            value: 110
+            unit: mph
           mode_not: [ "truck" ]
           is_max_speed_variable: true
-        - max_speed: [55, "mph"]
+        - max_speed:
+            value: 55
+            unit: mph
           mode: [ "truck" ]
-        - max_speed: [30, "km/h"]
+        - max_speed:
+            value: 30
+            unit: km/h
           at: [0.25, 0.50]
           during: Mo-Sa 09:00-12:00, We 15:00-18:00
       prohibited_transitions:

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -299,15 +299,22 @@ properties:
       description: >-
         A speed value, i.e. a certain number of distance units
         travelled per unit time.
-      type: array
-      prefixItems:
-        - description: Number of speed units
+      type: object
+      properties:
+        value:
+          description: Speed value
           type: integer
           minimum: 20
-        - description: One speed unit
+        unit:
+          description: Speed unit
           type: string
-          enum: [ "km/h", "mph" ]
-      additionalItems: false
+          enum: 
+            - km/h
+            - mph
+      required:
+        - value
+        - unit  
+      unevaluatedProperties: false
     accessOption:
       description: Effect of an access restriction rule
       type: string


### PR DESCRIPTION
# Description

This PR remodels the `road.restrictions.speed_limits` type to only allow `value` and `unit` properties. The `unit` property uses current speed unit enumeration as the enumerated value domain. This also ensures that `road.restrictions.speed_limits` does not handle mixed schema types

# Reference

https://github.com/OvertureMaps/tf-transportation/issues/99

# Testing

Tested using test script

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [x] Add relevant examples.
2. [x] Add relevant counterexamples.
3. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
4. [ ] Update Docusaurus documentation, if an update is required.
5. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/141)
