### PR TITLE
Adding additional locality type names to admins/defs.yaml.

### DIFF
--- a/schema/admins/defs.yaml
+++ b/schema/admins/defs.yaml
@@ -7,7 +7,7 @@ description: Common schema definitions for admins theme
     localityType:
       description: Describes the entity's type in the categorical nomenclature used locally.
       type: string
-      enum: [country, county, state, region, province, district, city, town, village, hamlet, borough, suburb, neighborhood, municipality]
+      enum: [country, county, state, region, province, district, city, town, village, hamlet, borough, suburb, neighborhood, municipality, department, parish, governorate]
       "$comment": >-
         country      = Distinct geographical and political region or territory that is governed by a sovereign power or government. It is usually defined by its borders, which are recognized by other countries and international organizations
                        Examples: United States
@@ -65,6 +65,18 @@ description: Common schema definitions for admins theme
                        Examples: Arame, Maranhão, Brazil
                                  Vračar, Belgrade, Serbia
                                  Arecibo, Puerto Rico
+        department = Another name for a political and administrative division of a state
+                       Examples: Departamento Deseado, Argentina
+                                 Departamento de Santa Cruz, Bolivia
+                                 Le département d'Indre-et-Loire, France
+        parish = Administrative division of a state, usually deriving from previously ecclestiastical grounds
+                       Examples: Canillo, Andorra
+                                 Saint David Parish, Dominica
+                                 Trinity, Jersey
+        governorate = Administrative division of a state headed by a governor
+                       Examples: El Wadi El Gedid Governorate, Egypt
+                                 Dhi Qar Governorate, Iraq
+                                 Al-Ahsa Governorate, Saudi Arabia
     adminLevel:
       description: Hierarchical level for administrative entity or border. E.g. in United States, Country locality representing United States has adminLevel=1, States have adminLevel=2, Counties have adminLevel=3.
       type: integer


### PR DESCRIPTION
Adding three additional locality type names to admin schema.

A bit of statistics to back the change:
'department' - appears as a type of locality in 4% of the world's admins.
'parish' and 'governorate' - each appear as a type of locality in 3% of the world's admins.
For comparison, 'state' appears as a locality type in 3.3% of admins, while 'district' is by far the most popular with 22%.