### PR TITLE
add path road class

### DIFF
--- a/examples/transportation/segment/road/road-path.yaml
+++ b/examples/transportation/segment/road/road-path.yaml
@@ -1,0 +1,22 @@
+---
+id: overture:transportation:segment:1516
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  theme: transportation
+  type: segment
+  update_time: "2024-03-08T01:03:34-08:00"
+  version: 5
+  subtype: road
+  class: path
+  road:
+    surface:
+      - value: dirt
+    restrictions:
+      access:
+        - access_type: allowed
+          when: {mode: [foot]}
+        - access_type: denied
+          when: {mode: [bicycle]}

--- a/examples/transportation/segment/road/road-path.yaml
+++ b/examples/transportation/segment/road/road-path.yaml
@@ -11,12 +11,3 @@ properties:
   version: 5
   subtype: road
   class: path
-  road:
-    surface:
-      - value: dirt
-    restrictions:
-      access:
-        - access_type: allowed
-          when: {mode: [foot]}
-        - access_type: denied
-          when: {mode: [bicycle]}

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -73,6 +73,7 @@ properties:
         - sidewalk
         - crosswalk
         - steps
+        - path
         - track
         - cycleway
         - bridleway       # Similar to track but has implied access only for horses
@@ -325,7 +326,7 @@ properties:
             - mph
       required:
         - value
-        - unit  
+        - unit
       unevaluatedProperties: false
     purposeOfUse:
       description: >-


### PR DESCRIPTION
# Description

Add `path` as a new road class. Discussion and approval can be found in [this wiki page](https://wiki.overturemaps.org/display/PROJ/Highway%3Dpath).

# Reference
1. https://github.com/OvertureMaps/tf-transportation/issues/53
2. https://github.com/OvertureMaps/tf-transportation/pull/171

# Testing

Ran tests with sample path from combobulate data, included as example.

# Checklist
1. [x] Add relevant examples.
3. [ ] Add relevant counterexamples.
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website
[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/154)
