### PR TITLE
Switch schema url to schema.overturemaps.org

### DIFF
--- a/docusaurus/docs/overview/index.mdx
+++ b/docusaurus/docs/overview/index.mdx
@@ -8,13 +8,9 @@ title: Introduction
 
 The Overture Map consists of global datasets structured by a unified schema, referenced with a universal identification system and available to everyone under a [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode) license.
 
-Overture currently offers [data](https://github.com/OvertureMaps/data) across five themes: **buildings, places, transportation, admins and base**. 
+Overture currently offers [data](https://github.com/OvertureMaps/data) across five themes: **buildings, places, transportation, admins and base**.
 
-In this documentation, you'll find explanatory and reference material about the Overture Map [feature model](/overview/feature-model), [schema](./reference) and data [themes](./themes). You'll also find an overview of the [Global Entity Reference System (GERS)](./gers), the universal ID system designed by Overture to make data conflation easier. [Tutorials and guides in the How-to section](https://labs.overturemaps.org/how-to/) will help you start exploring and using the Overture Map. 
-
-<!--
-Add sections: What can I use the Overture Map for?; Overture Map architecture; Underlying technology
--->
+In this documentation, you'll find explanatory and reference material about the Overture Map [feature model](/overview/feature-model), [schema](./reference) and data [themes](./themes)
 
 ## The Overture Maps Foundation's Vision
 **Address the core, enable the periphery.** The Overture schema doesn't solve every problem. It offers complete, out-of-the-box solutions for the most fundamental "core" use cases. At the same time, the schema's extensible structure enables a wide range of other use cases ("the periphery").

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -84,11 +84,14 @@ const config = {
             position: 'left',
             label: 'Schema Reference',
           },
-          // {
-          //   type: 'docSidebar',
-          //   sidebarId: 'gers',
-          //   label: 'Global Entity Reference System',
-          // },
+          {
+            to: 'https://overturemaps.org/news-blogs/',
+            label: 'Blog',
+          },
+          {
+            to: 'https://docs.overturemaps.org/community/',
+            label: 'Community',
+          },
         ],
       },
       footer: {

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -5,7 +5,7 @@ const {themes} = require('prism-react-renderer');
 const lightCodeTheme = themes.github;
 const darkCodeTheme = themes.dracula;
 
-const defaultUrl = 'https://docs.overturemaps.org';
+const defaultUrl = 'https://schema.overturemaps.org';
 const defaultBaseUrl = '/';
 
 function getFromEnvironment(variableName, defaultValue) {
@@ -74,22 +74,21 @@ const config = {
         },
         items: [
           {
+            to: 'https://docs.overturemaps.org/',
+            label: 'Docs',
+            target: ''
+          },
+          {
             type: 'docSidebar',
             sidebarId: 'docs',
             position: 'left',
-            label: 'Data Schema',
+            label: 'Schema Reference',
           },
-          {
-            type: 'docSidebar',
-            sidebarId: 'gers',
-            // docId: 'gers/gers',
-            label: 'Global Entity Reference System',
-          },
-          {
-            to: 'https://labs.overturemaps.org/how-to/',
-            label: 'How-to Guides',
-            target: ''
-          },
+          // {
+          //   type: 'docSidebar',
+          //   sidebarId: 'gers',
+          //   label: 'Global Entity Reference System',
+          // },
         ],
       },
       footer: {

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -127,23 +127,6 @@ const sidebars = {
       ]
     }
   ],
-
-  gers: [
-    {
-      type: 'category',
-      label: 'Global Entity Reference System',
-      collapsed: true,
-      items: [
-        {
-          type: 'doc',
-          id:'gers/gers',
-          label: 'Overview'
-        },
-        'gers/scenarios',
-        'gers/terminology'
-      ]
-    },
-  ]
 };
 
 module.exports = sidebars;


### PR DESCRIPTION
For seemless restructuring, we'll need to start with this PR directly to `main`. 

Required: 
- [x] Create schema.overturemaps.org with a CNAME entry to overturemaps.github.io (the same way that docs.overturemaps.org is set up)
- [x] Change the Github [Pages settings for this (`schema`) repository ](https://github.com/OvertureMaps/schema/settings/pages) to have the custom domain of `schema.overturemaps.org`.
- [x] (On this branch) Update [`docusaurus.config.js`](https://github.com/OvertureMaps/schema/blob/documentation-switch-on-main/docusaurus/docusaurus.config.js#L87) to match the header from the how-to repo. 
- [ ] Accept this PR.
- [ ] Rebase dev on `main`

See it in action: https://dfhx9f55j8eg5.cloudfront.net/pr/160

Reference: https://github.com/OvertureMaps/tf-developer-advocacy/issues/107

@seanmcilroy29 @robcraig-LF 

Note @vcschapp: We just need to move this repo off `docs.overturemaps.org` to (somewhere) for now to get the real docs set up. Once docs.overturemaps.org is up and running, I will work on integrating the schema reference into "docs.overturemaps.org/schema" — then we can even talk about publishing "schema artifacts" in this repo at schema.overturemaps.org (which this repo will already be set up for!) 