### PR TITLE
Extend perspectives property to indicate inclusion

### DIFF
--- a/examples/divisions/division/perspectives.yaml
+++ b/examples/divisions/division/perspectives.yaml
@@ -26,7 +26,5 @@ properties:
         subtype: country
         name: Kuzey Kıbrıs
   perspectives:
-    holders:
-      - type: country
-        holder: TR
-    effect: include
+    mode: accepted_by
+    countries: [TR]

--- a/examples/divisions/division/perspectives.yaml
+++ b/examples/divisions/division/perspectives.yaml
@@ -26,5 +26,7 @@ properties:
         subtype: country
         name: Kuzey Kıbrıs
   perspectives:
-    - type: country
-      holder: TR
+    holders:
+      - type: country
+        holder: TR
+    includes: true

--- a/examples/divisions/division/perspectives.yaml
+++ b/examples/divisions/division/perspectives.yaml
@@ -29,4 +29,4 @@ properties:
     holders:
       - type: country
         holder: TR
-    includes: true
+    effect: include

--- a/schema/divisions/defs.yaml
+++ b/schema/divisions/defs.yaml
@@ -89,6 +89,26 @@ description: Common schema definitions for divisions theme
           type: string
           minLength: 1
           pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
+    perspectives:
+      description: Collection of perspectives of single feature.
+      type: object
+      unevaluatedProperties: false
+      required: [holders, includes]
+      properties:
+        holders:
+          description: Array of perspective holders.
+          type: array
+          items: { "$ref": "#/$defs/typeDefinitions/perspective" }
+          minItems: 1
+          uniqueItems: true
+        includes:
+          description:
+            Indicates if all counteries from the collection
+            or all except those in collection acknowledge the feature as is.
+
+            If value is true, only holders within collection see entity as it is represented.
+            If value is false, everyone except those in collection see entity as it is represented.
+          type: boolean
     perspective:
       description:
         A political perspective from which the division is viewed

--- a/schema/divisions/defs.yaml
+++ b/schema/divisions/defs.yaml
@@ -90,17 +90,17 @@ description: Common schema definitions for divisions theme
           minLength: 1
           pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
     perspectives:
-      description: Collection of perspectives of single feature.
+      description: Political perspectives from which division is viewed.
       type: object
       unevaluatedProperties: false
       required: [mode, countries]
       properties:
         mode:
-          description: Mode in which perspective should be used.
+          description: Whether perspective holder accept or dispute this division.
           type: string
           enum: [accepted_by, disputed_by]
         countries:
-          description: Array of counteries with given perspective.
+          description: Countries holding the given mode of perspective.
           type: array
           items: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/iso3166_1Alpha2CountryCode" }
           minItems: 1

--- a/schema/divisions/defs.yaml
+++ b/schema/divisions/defs.yaml
@@ -93,53 +93,18 @@ description: Common schema definitions for divisions theme
       description: Collection of perspectives of single feature.
       type: object
       unevaluatedProperties: false
-      required: [holders, effect]
+      required: [mode, countries]
       properties:
-        holders:
-          description: Array of perspective holders.
+        mode:
+          description: Mode in which perspective should be used.
+          type: string
+          enum: [accepted_by, disputed_by]
+        countries:
+          description: Array of counteries with given perspective.
           type: array
-          items: { "$ref": "#/$defs/typeDefinitions/perspective" }
+          items: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/iso3166_1Alpha2CountryCode" }
           minItems: 1
           uniqueItems: true
-        effect:
-          description:
-            Indicates if all perspective holders from the collection
-            or all except those in collection acknowledge the feature as is.
-
-            If value is "include", only holders within collection see entity as it is represented.
-            If value is "exclude", everyone except those in collection see entity as it is represented.
-          type: string
-          enum: [include, exclude]
-    perspective:
-      description:
-        A political perspective from which the division is viewed
-      type: object
-      unevaluatedProperties: false
-      required: [type, holder]
-      oneOf:
-        - if:
-            properties:
-              type: { enum: [country] }
-          then:
-            properties:
-              holder: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/iso3166_1Alpha2CountryCode" }
-          else:
-            false
-      properties:
-        type:
-          description:
-            Type of perspective
-
-            If the perspective is of type 'country', then the 'holder'
-            property must be an ISO 3166-1 alpha-2 country code
-            identifying the country that holds this perspective.
-          type: string
-          enum:
-            - country   # The perspective is held by the sovereign state
-                        # identified by the ISO-3166-1 alpha-2 country
-                        # code in the 'value' property.
-        holder:
-          type: string
     boundarySideDivision:
       description:
         Represents a division on one side or the other of a boundary

--- a/schema/divisions/defs.yaml
+++ b/schema/divisions/defs.yaml
@@ -93,7 +93,7 @@ description: Common schema definitions for divisions theme
       description: Collection of perspectives of single feature.
       type: object
       unevaluatedProperties: false
-      required: [holders, includes]
+      required: [holders, effect]
       properties:
         holders:
           description: Array of perspective holders.
@@ -101,14 +101,15 @@ description: Common schema definitions for divisions theme
           items: { "$ref": "#/$defs/typeDefinitions/perspective" }
           minItems: 1
           uniqueItems: true
-        includes:
+        effect:
           description:
-            Indicates if all counteries from the collection
+            Indicates if all perspective holders from the collection
             or all except those in collection acknowledge the feature as is.
 
-            If value is true, only holders within collection see entity as it is represented.
-            If value is false, everyone except those in collection see entity as it is represented.
-          type: boolean
+            If value is "include", only holders within collection see entity as it is represented.
+            If value is "exclude", everyone except those in collection see entity as it is represented.
+          type: string
+          enum: [include, exclude]
     perspective:
       description:
         A political perspective from which the division is viewed

--- a/schema/divisions/division.yaml
+++ b/schema/divisions/division.yaml
@@ -138,10 +138,8 @@ properties:     # JSON Schema: Top-level object properties.
           the default political perspective. If this property is
           present, then this division is seen from the political
           perspectives enumerated in the list.
-        type: array
-        items: { "$ref": "./defs.yaml#/$defs/typeDefinitions/perspective" }
-        minItems: 1
-        uniqueItems: true
+        allOf: 
+          - "$ref": "./defs.yaml#/$defs/typeDefinitions/perspectives"
       norms:
         description:
           Collects information about local norms and rules within the

--- a/schema/divisions/division.yaml
+++ b/schema/divisions/division.yaml
@@ -130,14 +130,34 @@ properties:     # JSON Schema: Top-level object properties.
         allOf:
           - "$ref": "../defs.yaml#/$defs/propertyDefinitions/id"
       perspectives:
-        description:
+        description: >-
           Political perspectives from which this division is considered
           to be an accurate representation.
-
-          If this property is absent, then this division is seen from
-          the default political perspective. If this property is
-          present, then this division is seen from the political
-          perspectives enumerated in the list.
+      
+          If this property is absent, then this division is not known to
+          be disputed from any political perspective. Consequently,
+          there is only one division feature representing the entire
+          real world entity.
+      
+          If this property is present, it means the division represents
+          one of several alternative perspectives on the same real-world
+          entity.
+      
+          There are two modes of perspective:
+          
+            1. `accepted_by` means the representation of the division is
+               accepted by the listed entities and would be included on
+               a map drawn from their perspective.
+      
+            2. `disputed_by` means the representation of the division is
+               disputed by the listed entities and would be excluded
+               from a map drawn from their perspective.
+              
+          When drawing a map from the perspective of a given country,
+          one would start by gathering all the undisputed divisions
+          (with no `perspectives` property), and then adding to that
+          first all divisions explicitly accepted by the country, and
+          second all divisions not explicitly disputed by the country.
         allOf: 
           - "$ref": "./defs.yaml#/$defs/typeDefinitions/perspectives"
       norms:


### PR DESCRIPTION
# Description

Current perspectives representation allows for same entity to be simultaneously allowed by set of countries and disputed by another set. This would require us to do additional checks and would be overall inconsistent. Entity could have holder X allowing it, holder Y disputing it, and what about any other holder Z? To resolve this, single entity can be allowed by set 
of countries and disputed by the rest of the world by default or disputed by set of countries and allowed by the rest of the world.
This will allow us to say perspective from country X covers all entities having that country as allowed by or not having it as disputed by perspective.
In that sense it will make data more consistent by default.
We currently only support countries to dispute entities but are open to extending list of entity types which could dispute any entity.

Example (also in test):
Previous implementation:
```
  perspectives:
    - type: country
      holder: TR
```
Current implementation:
```
  perspectives:
    mode: accepted_by
    countries: [TR]
```

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [x] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [x] Update in-schema documentation using plain English written in complete sentences, if an update is required.
4. [ ] Update Docusaurus documentation, if an update is required.
5. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/162)
