### PR TITLE
Segment routes

### DIFF
--- a/counterexamples/transportation/segment/bad-route.yaml
+++ b/counterexamples/transportation/segment/bad-route.yaml
@@ -1,0 +1,17 @@
+---
+id: overture:transportation:segment:123
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  theme: transportation
+  type: segment
+  update_time: "2024-04-23T00:00:00-05:00"
+  version: 1
+  subtype: road
+  class: secondary
+  connector_ids: [fooConnector, barConnector]
+  routes:
+    - name: ""
+      ref: 1234

--- a/counterexamples/transportation/segment/bad-route.yaml
+++ b/counterexamples/transportation/segment/bad-route.yaml
@@ -5,6 +5,9 @@ geometry:
   type: LineString
   coordinates: [[0, 0], [1, 1]]
 properties:
+  ext_expected_errors:
+    - "[I#/properties/routes/0/name] [S#/$defs/propertyDefinitions/routes/items/properties/name/minLength] length must be >= 1"
+    - "[I#/properties/routes/0/name] [S#/$defs/propertyDefinitions/routes/items/properties/name/pattern] does not match pattern"
   theme: transportation
   type: segment
   update_time: "2024-04-23T00:00:00-05:00"

--- a/examples/transportation/segment/road/road-with-route.yaml
+++ b/examples/transportation/segment/road/road-with-route.yaml
@@ -1,0 +1,22 @@
+---
+id: overture:transportation:segment:123
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  # Overture properties
+  theme: transportation
+  type: segment
+  update_time: "2024-04-10T00:00:00-05:00"
+  version: 1
+  subtype: road
+  class: motorway
+  connector_ids: [fooConnector, barConnector]
+  routes:
+    - name: I 95
+      network: US:I
+      ref: 95
+      symbol: https://upload.wikimedia.org/wikipedia/commons/6/61/I-95.svg
+      wikidata: Q94967
+      between: [0, 0.5]

--- a/examples/transportation/segment/road/road-with-route.yaml
+++ b/examples/transportation/segment/road/road-with-route.yaml
@@ -16,7 +16,7 @@ properties:
   routes:
     - name: I 95
       network: US:I
-      ref: 95
+      ref: "95"
       symbol: https://upload.wikimedia.org/wikipedia/commons/6/61/I-95.svg
       wikidata: Q94967
       between: [0, 0.5]

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -49,6 +49,7 @@ properties:
             Each entry in this array is the GERS ID of a transportation connector feature.
         uniqueItems: true
         default: []
+      routes: { "$ref": "#/$defs/propertyDefinitions/routes" }
 "$defs":
   propertyDefinitions:
     roadClass:
@@ -308,6 +309,30 @@ properties:
         - dirt
         - paving_stones
         - metal
+    routes:
+      description: Routes this segment belongs to
+      type: array
+      items:
+        type: object
+        unevaluatedProperties: false
+        allOf:
+          - { "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer" }
+        properties:
+          name:
+            description: Full name of the route
+            type: string
+          network:
+            description: Name of the highway system
+            type: string
+          ref:
+            description: Code or number referencing the route
+            type: ["string", "integer"]
+          symbol:
+            description: URL or description of route signage
+            type: string
+          wikidata:
+            description: Wikidata ID
+            type: string
     speed:
       description: >-
         A speed value, i.e. a certain number of distance units

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -326,7 +326,7 @@ properties:
             type: string
           ref:
             description: Code or number referencing the route
-            type: ["string", "integer"]
+            type: string
           symbol:
             description: URL or description of route signage
             type: string

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -321,18 +321,24 @@ properties:
           name:
             description: Full name of the route
             type: string
+            minLength: 1
+            pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
           network:
-            description: Name of the highway system
+            description: Name of the highway system this route belongs to
             type: string
+            minLength: 1
+            pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
           ref:
-            description: Code or number referencing the route
+            description: Code or number used to reference the route
             type: string
+            minLength: 1
+            pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
           symbol:
             description: URL or description of route signage
             type: string
-          wikidata:
-            description: Wikidata ID
-            type: string
+            minLength: 1
+            pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
+          wikidata: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/wikidata" }
     speed:
       description: >-
         A speed value, i.e. a certain number of distance units


### PR DESCRIPTION
# Description

Adds support for segment routes as a top-level property. These are intended to capture [OSM road route relations](https://wiki.openstreetmap.org/wiki/Relation:route#Road_routes), materialized to relevant segments and optionally geometrically scoped.

# Reference

1. https://github.com/OvertureMaps/tf-transportation/issues/52

# Testing

Added new example, tested

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [X] Add relevant examples.
2. [x] Add relevant counterexamples.
3. [x] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [x] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [x] Update Docusaurus documentation, if an update is required.
6. [x] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/166)
