### PR TITLE
Fix counterexample use of map_file and verify

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -162,7 +162,7 @@ function examples() {
       continue
     fi
     printf "%s..." "$instance_file"
-    if verify quiet "$instance_file"; then
+    if verify simple "$instance_file"; then
       echo OK
     else
       echo FAILED
@@ -185,17 +185,17 @@ function counterexamples() {
       continue
     fi
     printf "%s..." "$instance_file"
-    declare -a expected_errors
-    if verify quiet "$instance_file"; then
+    declare -a expected_errors_array
+    if verify simple "$instance_file"; then
       echo FAILED
       printf "\ncounterexample instance '%s' is EXPECTED to fail validation but ACTUALLY it passed.\n" "$instance_file"
       exit 1
-    elif [ -z "$yq_installed" ] || ! expected_errors "$instance_file" | mapfile -t expected_errors || [ ${#expected_errors} == 0 ]; then
+    elif [ -z "$yq_installed" ] || mapfile -t expected_errors_array < <(! expected_errors "$instance_file") || [ ${#expected_errors_array} == 0 ]; then
       echo OK
     else
       declare -a actual_errors
-      (verify simple "$instance_file" || true) 2>&1 | mapfile -t actual_errors
-      for expected_error in "${expected_errors[@]}"; do
+      mapfile -t actual_errors < <(verify simple "$instance_file" || true)
+      for expected_error in "${expected_errors_array[@]}"; do
         for actual_error in "${actual_errors[@]}"; do
           if [[ "$actual_error" == *"$expected_error"* ]]; then
             continue 2


### PR DESCRIPTION
# Description

Counterexamples appear to be silently passing, even when expected errors are not present. This is in part due to `verify quiet` swallowing error codes and also `map_file` running in a subshell due to piping, failing to assign the variable where it is needed.

# Reference

https://superuser.com/questions/1348948/cant-pipe-in-bashs-mapfile-but-why

# Testing

Removed `ext_expected_errors` from counterexamples/buildings/bad-class.json and validated a failure was observed when running `./test.sh -m counterexamples "buildings/bad-class.json"`.

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [ ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/173)
