### PR TITLE
transportation segments: add 'is_covered' flag

### DIFF
--- a/examples/transportation/segment/road/road-covered.yaml
+++ b/examples/transportation/segment/road/road-covered.yaml
@@ -1,0 +1,19 @@
+---
+id: overture:transportation:segment:example:covered
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  # Overture properties
+  theme: transportation
+  type: segment
+  update_time: "2024-04-26T16:12:11-08:00"
+  version: 3
+  subtype: road
+  class: tertiary
+  road:
+    surface:
+      - value: paved
+    flags:
+      - values: [is_covered]

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -297,6 +297,7 @@ properties:
         - is_tunnel
         - is_under_construction
         - is_abandoned
+        - is_covered
     roadSurface:
       description: Physical surface of the road
       type: string


### PR DESCRIPTION
# Description

Since Overture April release, the transportation theme deliveries contain segments with `is_covered` flags. 

As the flag is currently not described in the schema, we get a lot of validation errors (i.e. `369 566` segments in the April release) during Theme Promotion for segments that are covered.

# Reference

1. https://github.com/OvertureMaps/tf-transportation/issues/191

# Testing

I have been testing the schema update by `manually` running `jv` on a segment containing the `is_covered` flag:
1. once before the schema update
2. once after the schema update

After the schema update, the `jv` schema violations disappeared.

# Checklist

1. [x] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/177)
