### PR TITLE
transportation segments: add travel mode 'vehicle'

### DIFF
--- a/examples/transportation/segment/road/restrictions/road-restrictions-access.yaml
+++ b/examples/transportation/segment/road/restrictions/road-restrictions-access.yaml
@@ -24,7 +24,7 @@ properties:
         - access_type: allowed
           when:
             heading: forward
-            mode: [car, hgv]
+            mode: [vehicle]
         - access_type: allowed
           when:
             heading: forward

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -123,7 +123,7 @@ properties:
         Enumerates possible travel modes. Some modes represent groups
         of modes.
       type: string
-      enum: [ motor_vehicle, car, truck, motorcycle, foot, bicycle, bus, hgv, hov, emergency ]
+      enum: [ vehicle, motor_vehicle, car, truck, motorcycle, foot, bicycle, bus, hgv, hov, emergency ]
       "$comment": >-
         motor_vehicle includes car, truck and motorcycle
     road:


### PR DESCRIPTION
# Description

Travel mode = `vehicle` is a valid value within the travel mode taxonomy, see [here](https://docs.overturemaps.org/guides/transportation/travel-modes/#vehicle-attribute-scoping-vehicle). Some segments in the Transportation Theme deliveries do contain access restrictions with references to the `vehicle` travel mode. 
As the value is currently not described in the schema, we get a lot of validation errors (i.e. `98 151` in the April release) during Theme Promotion.

# Reference

1. https://github.com/OvertureMaps/tf-transportation/issues/192

# Testing

I have been testing the schema update by manually running `jv` on a segment containing a `vehicle` travel mode access restriction:
1. once before the schema update
2. once after the schema update

After the schema update, the `jv` schema violations disappeared.

# Checklist

1. [x] Add relevant examples.
3. [ ] Add relevant counterexamples.
4. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
5. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
6. [ ] Update Docusaurus documentation, if an update is required.
7. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/178)
