### PR TITLE
[WIP] Strawman Initial Addresses Schema

### DIFF
--- a/examples/addresses/address.yaml
+++ b/examples/addresses/address.yaml
@@ -1,0 +1,18 @@
+---
+id: overture:addresses:addres:1
+type: Feature
+geometry:
+  type: Point
+  coordinates: [-71.2086153, 42.3373725]
+properties:
+  theme: addresses
+  type: address
+  update_time: '2024-04-26T23:55:01-08:00'
+  version: 0
+  country: US
+  country_district: MA
+  region: MA
+  city: NEWTON CENTRE
+  postcode: '02459'
+  street: COMMONWEALTH AVE
+  number: '1000'

--- a/schema/addresses/address.yaml
+++ b/schema/addresses/address.yaml
@@ -1,0 +1,63 @@
+---
+"$schema": https://json-schema.org/draft/2020-12/schema
+title: address
+description:
+  Address points
+type: object
+properties:     # JSON Schema: Top-level object properties.
+  id: { "$ref": ../defs.yaml#/$defs/propertyDefinitions/id }
+  geometry:
+    description:
+      Division geometry MUST be a Point as defined by GeoJSON schema.
+      It represents the approximate location of a position commonly
+      associated with the real-world entity modeled by the division
+      feature.
+    unevaluatedProperties: false
+    allOf:
+      - "$ref": https://geojson.org/schema/Point.json
+  properties:   # GeoJSON: top-level object 'properties' property.
+    unevaluatedProperties: false
+    allOf:
+      - "$ref": ../defs.yaml#/$defs/propertyContainers/overtureFeaturePropertiesContainer
+    properties: # JSON Schema: properties within GeoJSON top-level object 'properties' property
+      country:
+        description: The country code in the Open Addresses distribution
+        allOf:
+          - "$ref": "../defs.yaml#/$defs/propertyDefinitions/iso3166_1Alpha2CountryCode"
+      country_district:
+        description: The region folder name in the Open Addresses distribution
+        type: string
+        minLength: 1
+      region:
+        description: The state/province for the address
+        type: string
+        minLength: 1
+      district:
+        description: The county for the address
+        type: string
+        minLength: 1
+      city:
+        description: The city/locality for the address
+        type: string
+        minLength: 1
+      postcode:
+        description: The postcode for the address
+        type: string
+        minLength: 1
+      street:
+        description: >-
+          The street name associated with this address
+        type: string
+        minLength: 1
+      number:
+        description: >-
+          The house number for this address.  This field may not strictly be a
+          number. Values such as "74B", "189 1/2", "208.5" are common as the
+          number part of an address and they are not part of the "unit" of this
+          address.
+        type: string
+        minLength: 1
+      unit:
+        description: The suite/unit/apartment for the address row
+        type: string
+        minLength: 1

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -21,6 +21,7 @@ description: Common schema definitions shared by all themes
       type: string
       enum:
         - administrative_boundary # DEPRECATED
+        - address
         - boundary
         - building
         - connector
@@ -103,6 +104,7 @@ description: Common schema definitions shared by all themes
       description: Top-level Overture theme this feature belongs to
       type: string
       enum:
+        - addresses
         - admins
         - base
         - buildings

--- a/schema/schema.yaml
+++ b/schema/schema.yaml
@@ -14,6 +14,14 @@ oneOf:
       properties:
         properties:
           properties:
+            theme: { enum: [addresses] }
+            type: { enum: [address] }
+    then: { "$ref": addresses/address.yaml }
+    else: { propertyNames: false }
+  - if:
+      properties:
+        properties:
+          properties:
             theme: { enum: [admins] }
             type: { enum: [administrative_boundary] }
     then: { "$ref": admins/administrative_boundary.yaml }


### PR DESCRIPTION
This is an initial schema for the addresses theme and is not ready to be merged. I'm hoping this sparks discussion with the schema group and the addresses folks.

### Background

We recently decided to use the Open Addresses (OA) address output schema as a starting point for Overture addresses (https://github.com/openaddresses/openaddresses/blob/master/schema/layers/address_conform.json).

### This Pull Request

This initial PR copies OA's by including: 
* region
* district
* city
* postcode
* street
* number
* unit

We can convert OA outputs into this schema pretty straightforward. The schema also includes country and country_district which are pulled from the OA path - e.g. us/ma/... This would allow "us" as the country" and "ma" as the country_district.

### Todo / Questions to Answer
* Which fields if any should be required?
* Should we always add the country from the OA top-level folder into each entry?
* What to do when an address set doesn't contain the region or city but it's probably known. For example: us/ct/city_of_plainfield-addresses-city.geojson has entries like:
```
{"type":"Feature","properties":{"hash":"fd84e78f7c30c1ec","number":"14","street":"PINECREST DR","unit":"","city":"","district":"","region":"","postcode":"","id":""},"geometry":{"type":"Point","coordinates":[-71.9059254,41.7584033]}}
{"type":"Feature","properties":{"hash":"3f059ec63fee9030","number":"558","street":"PUTNAM RD","unit":"","city":"","district":"","region":"","postcode":"","id":""},"geometry":{"type":"Point","coordinates":[-71.900128,41.7582586]}}
```
Note that city and region are blank. Should we replace all of these with "Plainfield" and "CT" here and in similar instances? Another option is to replace these in OA directly with less modification here. (We should follow up with OA).
* How to marry this with the existing address field in places
* How should we reference buildings/places to these addresses? Likely an `address_ids` field or similar.
* More I haven't thought of at the moment
* Would we want to link the country / region / district / city to their divisions? e.g. with country_division_id, etc?
* Would we want to link the address's street to the corresponding transportation segment(s)?

### References

Other address schemas for reference:
* libpostal https://github.com/openvenues/libpostal
* opencage formatting https://github.com/OpenCageData/address-formatting
* How Pelias imports OpenAddresses https://github.com/pelias/openaddresses