### PR TITLE
Segment subclass

### DIFF
--- a/counterexamples/transportation/segment/bad-class.yaml
+++ b/counterexamples/transportation/segment/bad-class.yaml
@@ -1,0 +1,16 @@
+---
+id: overture:transportation:segment:123
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  ext_expected_errors:
+    - "[I#/properties/class] [S#/$defs/propertyDefinitions/class] value must be one of"
+  theme: transportation
+  type: segment
+  update_time: "2024-04-23T00:00:00-05:00"
+  version: 1
+  subtype: road
+  class: sidewalk
+  connector_ids: [fooConnector, barConnector]

--- a/counterexamples/transportation/segment/road/restrictions/access/bad-access-mode.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/access/bad-access-mode.yaml
@@ -22,7 +22,7 @@ properties:
   connector_ids: [fooConnector, barConnector]
   road_surface: gravel
   road_flags:
-    - [is_tunnel]
+    - [is_link, is_tunnel] # Note: `is_link` is deprecated and will be removed in a future release in favor of the link subclass
   access_restrictions:
     - access_type: allowed
       when: {mode: [foo]}

--- a/counterexamples/transportation/segment/road/restrictions/access/bad-access-mode.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/access/bad-access-mode.yaml
@@ -16,10 +16,13 @@ properties:
   version: 1
   subtype: road
   class: secondary
+  subclass: link
+  subclass_rules:
+    - value: link
   connector_ids: [fooConnector, barConnector]
   road_surface: gravel
   road_flags:
-    - [is_link, is_tunnel]
+    - [is_tunnel]
   access_restrictions:
     - access_type: allowed
       when: {mode: [foo]}

--- a/examples/transportation/segment/road/road-alley.yaml
+++ b/examples/transportation/segment/road/road-alley.yaml
@@ -10,7 +10,10 @@ properties:
   update_time: "2024-03-13T16:14:01-08:00"
   version: 5
   subtype: road
-  class: alley
+  class: service
+  subclass_rules:
+    - value: alley
+      between: [0, 0.5]
   access_restrictions:
     - access_type: allowed
       when:

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -24,7 +24,7 @@ properties:
   road_surface:
     - value: gravel
   road_flags:
-    - values: [is_tunnel]
+    - values: [is_link, is_tunnel] # Note: `is_link` is deprecated and will be removed in a future release in favor of the link subclass
   level: -1
   level_rules:
     - value: -1

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -14,6 +14,9 @@ properties:
   version: 3
   subtype: road
   class: secondary
+  subclass: link
+  subclass_rules:
+    - value: link
   connector_ids: [fooConnector, barConnector] # Topology: To discuss further.
   names:
     primary: Common Road Name
@@ -21,7 +24,7 @@ properties:
   road_surface:
     - value: gravel
   road_flags:
-    - values: [is_link, is_tunnel]
+    - values: [is_tunnel]
   level: -1
   level_rules:
     - value: -1

--- a/examples/transportation/segment/road/sidewalk.yaml
+++ b/examples/transportation/segment/road/sidewalk.yaml
@@ -10,7 +10,10 @@ properties:
   update_time: "2024-03-13T16:18:09-08:00"
   version: 1
   subtype: road
-  class: sidewalk
+  class: footway
+  subclass: sidewalk
+  subclass_rules:
+    - value: sidewalk
   connector_ids: [fooConnector, barConnector]
   road_surface:
     - value: paved

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -23,7 +23,7 @@ properties:
         properties:
           class: { "$ref": "#/$defs/propertyDefinitions/roadClass" }
           subclass: { "$ref": "#/$defs/propertyDefinitions/subclass" }
-          subclass_rules: { "$ref": "#/$defs/propertyDefinitions/subclassRulesContainer" }
+          subclass_rules: { "$ref": "#/$defs/propertyContainers/subclassRulesContainer" }
           access_restrictions: { "$ref": "#/$defs/propertyContainers/accessContainer" }
           level: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/level" }
           level_rules: { "$ref": "#/$defs/propertyContainers/levelRulesContainer" }

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -22,6 +22,8 @@ properties:
       - title: "Segment Properties"
         properties:
           class: { "$ref": "#/$defs/propertyDefinitions/roadClass" }
+          subclass: { "$ref": "#/$defs/propertyDefinitions/subclass" }
+          subclass_rules: { "$ref": "#/$defs/propertyDefinitions/subclassRulesContainer" }
           access_restrictions: { "$ref": "#/$defs/propertyContainers/accessContainer" }
           level: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/level" }
           level_rules: { "$ref": "#/$defs/propertyContainers/levelRulesContainer" }
@@ -76,13 +78,9 @@ properties:
         - living_street   # Similar to residential but has implied legal restriction for motor vehicles (which can vary country by country)
         - trunk
         - unclassified    # Known roads, paved, but subordinate to all of: motorway, trunk, primary, secondary, tertiary
-        - parking_aisle   # Service road intended for parking
-        - driveway        # Service road intended for deliveries
-        - alley           # Service road intended for rear entrances, fire exits
+        - service         # Provides vehicle access to a feature (such as a building), typically not part of the public street network
         - pedestrian
-        - footway
-        - sidewalk
-        - crosswalk
+        - footway         # Minor segments mainly used by pedestrians
         - steps
         - path
         - track
@@ -138,11 +136,11 @@ properties:
       "$comment": >-
         motor_vehicle includes car, truck and motorcycle
     roadFlag:
-      description: Simple flags that can be on or off for a road segment
+      description: >-
+        Simple flags that can be on or off for a road segment. Specifies physical characteristics and can overlap.
       type: string
       enum:
         - is_bridge
-        - is_link
         - is_tunnel
         - is_under_construction
         - is_abandoned
@@ -188,6 +186,18 @@ properties:
             minLength: 1
             pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
           wikidata: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/wikidata" }
+    subclass:
+      description: >-
+        Refines expected usage of the segment, must not overlap.
+      type: string
+      enum:
+        - link             # Connecting stretch (sliproad or ramp) between two road types
+        - sidewalk         # Footway that lies along a road
+        - crosswalk        # Footway that intersects other roads
+        - parking_aisle    # Service road intended for parking
+        - driveway         # Service road intended for deliveries
+        - alley            # Service road intended for rear entrances, fire exits
+        - cycle_crossing   # Cycleway that intersects with other roads
     speed:
       description: >-
         A speed value, i.e. a certain number of distance units
@@ -609,6 +619,16 @@ properties:
         required: [value]
         properties:
           value: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/level" }
+    subclassRulesContainer:
+      description: Set of subclasses scoped along segment
+      type: array
+      items:
+        type: object
+        allOf:
+          - { "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer" }
+        unevaluatedProperties: false
+        properties:
+          value: { "$ref": "#/$defs/propertyDefinitions/subclass" }
     surfaceContainer:
       description: Physical surface of the road. May either be
         specified as a single global value for the segment, or as

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -141,6 +141,7 @@ properties:
       type: string
       enum:
         - is_bridge
+        - is_link # Note: `is_link` is deprecated and will be removed in a future release in favor of the link subclass
         - is_tunnel
         - is_under_construction
         - is_abandoned


### PR DESCRIPTION
# Description

The current segmentation process exclusively uses OSM's `highway=` tag during merging of segments. This results in segments that no longer distinguish the subparts. Here are some examples that contain two incompatible classes (sidewalk, crosswalk) which currently fallback to `footway`, causing the differentiating classes to be lost:
<img width="1000" alt="Screenshot 2024-04-30 at 4 47 42 PM" src="https://github.com/OvertureMaps/schema/assets/5924884/07ca8d63-a94b-450e-a06d-ca2d3ae38c45">

Service roads and footways are the most impacted and we can't fully capture the road network with our schema as it stands. The proposal is to add a new scope-able `subclasses` property.

# Reference

1. https://github.com/OvertureMaps/tf-transportation/issues/248
2. https://wiki.overturemaps.org/display/PROJ/Footway+and+Service+Road+Segmentation+Error+Handling

# Testing

Verified tests passed

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [X] Add relevant examples.
2. [X] Add relevant counterexamples.
3. [X] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [X] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [x] Update Docusaurus documentation, if an update is required.
6. [x] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/180)
