### PR TITLE
Convert class to subtype and introduce class in buildings

### DIFF
--- a/examples/buildings/building-polygon.yaml
+++ b/examples/buildings/building-polygon.yaml
@@ -22,7 +22,8 @@ properties:
   update_time: "2023-06-06T10:30:00-08:00"
   height: 21.34
   num_floors: 4
-  class: civic
+  subtype: transportation
+  class: parking
   sources:
   - property: ""
     dataset: microsoftMLBuildings,

--- a/examples/buildings/osm/outline.yaml
+++ b/examples/buildings/osm/outline.yaml
@@ -25,6 +25,7 @@ properties:
   names:
     primary: Valentina by Alta
   num_floors: 8
+  subtype: commercial
   class: commercial
   sources:
   - property: ''

--- a/schema/buildings/building.yaml
+++ b/schema/buildings/building.yaml
@@ -105,7 +105,7 @@ properties:
           - office
           - outbuilding
           - parking
-          - pavillion
+          - pavilion
           - presbytery
           - public
           - religious
@@ -137,7 +137,7 @@ properties:
           - townhouse
           - train_station
           - transformer_tower
-          - transportatio
+          - transportation
           - trullo
           - university
           - warehouse

--- a/schema/buildings/building.yaml
+++ b/schema/buildings/building.yaml
@@ -25,27 +25,123 @@ properties:
       - "$ref": ../defs.yaml#/$defs/propertyContainers/levelContainer
       - "$ref": ./defs.yaml#/shapeContainer
     properties:
-      class:
+      subtype:
         description: >-
           A broad category of the building type/purpose. When the
           current use of the building does not match the built purpose,
-          the class should be set to represent the current use of the
+          the subtype should be set to represent the current use of the
           building.
         type: string
         enum:
-          - residential
-          - outbuilding
           - agricultural
-          - commercial
-          - industrial
-          - education
-          - service
-          - religious
           - civic
-          - transportation
-          - medical
+          - commercial
+          - education
           - entertainment
+          - industrial
+          - medical
           - military
+          - outbuilding
+          - parking
+          - religious
+          - residential
+          - service
+          - transportation
+      class:
+        description: >-
+          Further delineation of the building's built purpose.
+        type: string
+        enum:
+          - agricultural
+          - allotment_house
+          - apartments
+          - barn
+          - beach_hut
+          - boathouse
+          - bungalow
+          - bunker
+          - cabin
+          - carport
+          - cathedral
+          - chapel
+          - church
+          - civic
+          - clinic
+          - college
+          - commercial
+          - cowshed
+          - detached
+          - digester
+          - dormitory
+          - duplex
+          - dwelling_house
+          - factory
+          - farm
+          - farm_auxiliary
+          - fire_station
+          - garage
+          - garages
+          - ger
+          - glasshouse
+          - government
+          - government_office
+          - grandstand
+          - greenhouse
+          - guardhouse
+          - hangar
+          - hospital
+          - hotel
+          - house
+          - houseboat
+          - hut
+          - industrial
+          - kindergarten
+          - kiosk
+          - manufacture
+          - marketplace
+          - military
+          - monastary
+          - mosque
+          - office
+          - outbuilding
+          - parking
+          - pavillion
+          - presbytery
+          - public
+          - religious
+          - residential
+          - restaurant
+          - retail
+          - school
+          - semi
+          - semidetached_house
+          - service
+          - shed
+          - shop
+          - shrine
+          - silo
+          - slurry_tank
+          - sports_centre
+          - sports_hall
+          - stable
+          - stadium
+          - static_caravan
+          - stilt_house
+          - storage_tank
+          - sty
+          - supermarket
+          - synagogue
+          - temple
+          - terrace
+          - toilets
+          - townhouse
+          - train_station
+          - transformer_tower
+          - transportatio
+          - trullo
+          - university
+          - warehouse
+          - wayside_shrine
       has_parts:
         description: Flag indicating whether the building has parts
         type: boolean

--- a/schema/buildings/building.yaml
+++ b/schema/buildings/building.yaml
@@ -99,7 +99,7 @@ properties:
           - manufacture
           - marketplace
           - military
-          - monastary
+          - monastery
           - mosque
           - office
           - outbuilding

--- a/schema/buildings/building.yaml
+++ b/schema/buildings/building.yaml
@@ -42,7 +42,6 @@ properties:
           - medical
           - military
           - outbuilding
-          - parking
           - religious
           - residential
           - service

--- a/schema/buildings/defs.yaml
+++ b/schema/buildings/defs.yaml
@@ -22,10 +22,10 @@ shapeContainer:
       type: number
     min_floor:
       description: >-
-        The "start" floor of this building or part. Indicates that the building or part is "floating" and its bottom-most floor is above 
-        ground level, usually because it is part of a larger building in which some parts do reach down to ground level. An example is a 
-        building that has an entry road or driveway at ground level into an interior courtyard, where part of the building bridges above 
-        the entry road. This property may sometimes be populated when min_height is missing and in these cases can be used as a proxy 
+        The "start" floor of this building or part. Indicates that the building or part is "floating" and its bottom-most floor is above
+        ground level, usually because it is part of a larger building in which some parts do reach down to ground level. An example is a
+        building that has an entry road or driveway at ground level into an interior courtyard, where part of the building bridges above
+        the entry road. This property may sometimes be populated when min_height is missing and in these cases can be used as a proxy
         for min_height.
       type: integer
       exclusiveMinimum: 0
@@ -90,7 +90,7 @@ shapeContainer:
       description: >-
         Bearing of the roof ridge line in degrees.
       type: number
-      exclusiveMinimum: 0
+      inclusiveMinimum: 0
       exclusiveMaximum: 360
     roof_orientation:
       description: >-

--- a/task-force-docs/buildings/building_class_query.sql
+++ b/task-force-docs/buildings/building_class_query.sql
@@ -1,201 +1,122 @@
 CASE
-    -- Agricultural
+    -- Certain building tags become the class value to further describe the building subtype
     WHEN tags['building'] IN (
-            'agricultural',
-            'barn',
-            'cowshed',
-            'farm',
-            'farm_auxiliary',
-            'glasshouse',
-            'greenhouse',
-            'silo',
-            'stable',
-            'sty'
-        ) THEN 'agricultural'
 
-    -- Civic
-    WHEN tags['building'] IN (
-            'civic',
-            'fire_station',
-            'government',
-            'government_office',
-            'public'
-    ) OR tags['amenity'] IN (
-            'animal_shelter',
-            'community_centre',
-            'courthouse',
-            'fire_station',
-            'library',
-            'police',
-            'post_office',
-            'public_bath',
-            'public_building',
-            'ranger_station',
-            'shelter',
-            'social_centre',
-            'townhall',
-            'veterinary'
-        ) THEN 'civic'
+        -- Agricultural
+        'agricultural',
+        'barn',
+        'cowshed',
+        'farm',
+        'farm_auxiliary',
+        'glasshouse',
+        'greenhouse',
+        'silo',
+        'stable',
+        'sty',
 
-    --Commercial
-    WHEN tags['building'] IN (
-            'commercial',
-            'hotel',
-            'kiosk',
-            'marketplace',
-            'office',
-            'restaurant',
-            'retail',
-            'shop',
-            'supermarket',
-            'warehouse'
-        ) OR tags['amenity'] IN (
-            'bar',
-            'cafe',
-            'fast_food',
-            'food_court',
-            'fuel',
-            'ice_cream',
-            'pub',
-            'restaurant'
-        ) THEN 'commercial'
+        -- Civic
+        'civic',
+        'fire_station',
+        'government',
+        'government_office',
+        'public',
 
-    --Education
-    WHEN tags['building'] IN (
-            'college',
-            'kindergarten',
-            'school',
-            'university'
-        ) OR tags['amenity'] IN (
-            'college',
-            'driving_school',
-            'kindergarten',
-            'music_school',
-            'school',
-            'university'
-        ) THEN 'education'
+        --Commercial
+        'commercial',
+        'hotel',
+        'kiosk',
+        'marketplace',
+        'office',
+        'restaurant',
+        'retail',
+        'shop',
+        'supermarket',
+        'warehouse',
 
-    --Entertainment
-    WHEN tags['building'] IN (
-            'grandstand',
-            'pavillion',
-            'sports_centre',
-            'sports_hall',
-            'stadium'
-        ) OR tags['amenity'] IN (
-            'casino',
-            'conference_centre',
-            'events_venue',
-            'cinema',
-            'theatre',
-            'arts_centre',
-            'nightclub'
-        ) OR tags['tourism'] IN (
-            'aquarium',
-            'attraction',
-            'gallery',
-            'museum'
-        ) THEN 'entertainment'
+        --Education
+        'college',
+        'kindergarten',
+        'school',
+        'university',
 
-    --Industrial
-    WHEN tags['building'] IN (
-            'factory',
-            'industrial',
-            'manufacture'
-        ) THEN 'industrial'
+        --Entertainment
+        'grandstand',
+        'pavillion',
+        'sports_centre',
+        'sports_hall',
+        'stadium',
 
-    --Medical
-    WHEN tags['building'] IN (
-            'clinic',
-            'hospital'
-        ) OR tags['amenity'] IN (
-            'clinic',
-            'dentist',
-            'doctors',
-            'hospital',
-            'pharmacy'
-        ) THEN 'medical'
+        --Industrial
+        'factory',
+        'industrial',
+        'manufacture',
 
-    --Military
-    WHEN tags['building'] IN (
-            'bunker',
-            'military'
-        ) THEN 'military'
+        --Medical
+        'clinic',
+        'hospital',
 
-    --Outbuilding
-    WHEN tags['building'] IN (
-            'allotment_house',
-            'carport',
-            'outbuilding',
-            'shed'
-        ) THEN 'outbuilding'
+        --Military
+        'bunker',
+        'military',
 
-    --Religious
-    WHEN tags['building'] IN (
-            'cathedral',
-            'chapel',
-            'church',
-            'monastary',
-            'mosque',
-            'presbytery',
-            'religious',
-            'shrine',
-            'synagogue',
-            'temple',
-            'wayside_shrine'
-        ) OR tags['amenity'] = 'place_of_worship'
-        THEN 'religious'
+        --Outbuilding
+        'allotment_house',
+        'carport',
+        'outbuilding',
+        'shed',
 
-    --Residential
-    WHEN tags['building'] IN (
-            'apartments',
-            'bungalow',
-            'cabin',
-            'detached',
-            'dormitory',
-            'duplex',
-            'dwelling_house',
-            'garage',
-            'garages',
-            'ger',
-            'house',
-            'houseboat',
-            'hut',
-            'residential',
-            'semi',
-            'semidetached_house',
-            'static_caravan',
-            'stilt_house',
-            'terrace',
-            'townhouse',
-            'trullo'
-        ) OR tags['amenity'] IN (
-            'nursing_home'
-        ) THEN 'residential'
+        --Religious
+        'cathedral',
+        'chapel',
+        'church',
+        'monastary',
+        'mosque',
+        'presbytery',
+        'religious',
+        'shrine',
+        'synagogue',
+        'temple',
+        'wayside_shrine',
 
-    --Service
-    WHEN tags['building'] IN (
-            'beach_hut',
-            'boathouse',
-            'digester',
-            'guardhouse',
-            'service',
-            'slurry_tank',
-            'storage_tank',
-            'toilets',
-            'transformer_tower'
-        ) THEN 'service'
+        --Residential
+        'apartments',
+        'bungalow',
+        'cabin',
+        'detached',
+        'dormitory',
+        'duplex',
+        'dwelling_house',
+        'garage',
+        'garages',
+        'ger',
+        'house',
+        'houseboat',
+        'hut',
+        'residential',
+        'semi',
+        'semidetached_house',
+        'static_caravan',
+        'stilt_house',
+        'terrace',
+        'townhouse',
+        'trullo',
 
-    --Transportation
-    WHEN tags['building'] IN (
-            'hangar',
-            'train_station',
-            'parking',
-            'transportation'
-        ) OR tags['amenity'] IN (
-            'bicycle_parking',
-            'bus_station',
-            'parking'
-        ) THEN 'transportation'
+        --Service
+        'beach_hut',
+        'boathouse',
+        'digester',
+        'guardhouse',
+        'service',
+        'slurry_tank',
+        'storage_tank',
+        'toilets',
+        'transformer_tower',
+
+        -- Transportation
+        'hangar',
+        'parking',
+        'train_station',
+        'transportation'
+    ) THEN tags['building']
     ELSE NULL
 END

--- a/task-force-docs/buildings/building_subtype_query.sql
+++ b/task-force-docs/buildings/building_subtype_query.sql
@@ -1,0 +1,200 @@
+CASE
+    -- Agricultural
+    WHEN tags['building'] IN (
+            'agricultural',
+            'barn',
+            'cowshed',
+            'farm',
+            'farm_auxiliary',
+            'glasshouse',
+            'greenhouse',
+            'silo',
+            'stable',
+            'sty'
+        ) THEN 'agricultural'
+
+    -- Civic
+    WHEN tags['building'] IN (
+            'civic',
+            'fire_station',
+            'government',
+            'government_office',
+            'public'
+    ) OR tags['amenity'] IN (
+            'animal_shelter',
+            'community_centre',
+            'courthouse',
+            'fire_station',
+            'library',
+            'police',
+            'post_office',
+            'public_bath',
+            'public_building',
+            'ranger_station',
+            'shelter',
+            'social_centre',
+            'townhall',
+            'veterinary'
+        ) THEN 'civic'
+
+    --Commercial
+    WHEN tags['building'] IN (
+            'commercial',
+            'hotel',
+            'kiosk',
+            'marketplace',
+            'office',
+            'restaurant',
+            'retail',
+            'shop',
+            'supermarket',
+            'warehouse'
+        ) OR tags['amenity'] IN (
+            'bar',
+            'cafe',
+            'fast_food',
+            'food_court',
+            'fuel',
+            'ice_cream',
+            'pub',
+            'restaurant'
+        ) THEN 'commercial'
+
+    --Education
+    WHEN tags['building'] IN (
+            'college',
+            'kindergarten',
+            'school',
+            'university'
+        ) OR tags['amenity'] IN (
+            'college',
+            'driving_school',
+            'kindergarten',
+            'music_school',
+            'school',
+            'university'
+        ) THEN 'education'
+
+    --Entertainment
+    WHEN tags['building'] IN (
+            'grandstand',
+            'pavillion',
+            'sports_centre',
+            'sports_hall',
+            'stadium'
+        ) OR tags['amenity'] IN (
+            'casino',
+            'conference_centre',
+            'events_venue',
+            'cinema',
+            'theatre',
+            'arts_centre',
+            'nightclub'
+        ) OR tags['tourism'] IN (
+            'aquarium',
+            'attraction',
+            'gallery',
+            'museum'
+        ) THEN 'entertainment'
+
+    --Industrial
+    WHEN tags['building'] IN (
+            'factory',
+            'industrial',
+            'manufacture'
+        ) THEN 'industrial'
+
+    --Medical
+    WHEN tags['building'] IN (
+            'clinic',
+            'hospital'
+        ) OR tags['amenity'] IN (
+            'clinic',
+            'dentist',
+            'doctors',
+            'hospital',
+            'pharmacy'
+        ) THEN 'medical'
+
+    --Military
+    WHEN tags['building'] IN (
+            'bunker',
+            'military'
+        ) THEN 'military'
+
+    --Outbuilding
+    WHEN tags['building'] IN (
+            'allotment_house',
+            'carport',
+            'outbuilding',
+            'shed'
+        ) THEN 'outbuilding'
+
+    --Religious
+    WHEN tags['building'] IN (
+            'cathedral',
+            'chapel',
+            'church',
+            'monastary',
+            'mosque',
+            'presbytery',
+            'religious',
+            'shrine',
+            'synagogue',
+            'temple',
+            'wayside_shrine'
+        ) OR tags['amenity'] = 'place_of_worship'
+        THEN 'religious'
+
+    --Residential
+    WHEN tags['building'] IN (
+            'apartments',
+            'bungalow',
+            'cabin',
+            'detached',
+            'dormitory',
+            'duplex',
+            'dwelling_house',
+            'garage',
+            'garages',
+            'ger',
+            'house',
+            'houseboat',
+            'hut',
+            'residential',
+            'semi',
+            'semidetached_house',
+            'static_caravan',
+            'stilt_house',
+            'terrace',
+            'townhouse',
+            'trullo'
+        ) OR tags['amenity'] IN (
+            'nursing_home'
+        ) THEN 'residential'
+
+    --Service
+    WHEN tags['building'] IN (
+            'beach_hut',
+            'boathouse',
+            'digester',
+            'guardhouse',
+            'service',
+            'slurry_tank',
+            'storage_tank',
+            'toilets',
+            'transformer_tower'
+        ) THEN 'service'
+
+    -- Transportation
+    WHEN tags['building'] IN (
+            'hangar',
+            'parking',
+            'train_station',
+            'transportation'
+        ) OR tags['amenity'] IN (
+            'bus_station',
+            'parking'
+        ) THEN 'transportation'
+    ELSE NULL
+END


### PR DESCRIPTION
# Description

The _building_ type is the only Overture type that includes `class` without a `subtype`. This is mostly because the building schema was decided before other themes started using the term `subtype`. 

A backlog issue for buildings has been to promote `class` to `subtype` to match the rest of Overture. 

Additionally, the current allowed `class` values are not granular enough for specific rendering cases, primarily parking garages. There is only `class=transportation`, which includes more than just parking.

This PR promotes `class` to `subtype` and introduces new `class` values for buildings. The majority of the time, the `class` tag should simply be the value of OSM's `building` tag.

This allows anyone to use the current `class` types as `subtype` (backwards compatible) and introduces new `class` values that allow for more detail, like `parking`.

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

1. TODO.

# Testing

*Brief description of the testing done for this change showing why you are confident it works as expected and does not introduce regressions. Provide sample output data where appropriate.* 

TODO.

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [x] Add relevant examples.
4. [ ] Add relevant counterexamples.
5. [x] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
6. [x] Update in-schema documentation using plain English written in complete sentences, if an update is required.
7. [ ] Update Docusaurus documentation, if an update is required.
8. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/183)
