### PR TITLE
Fixed typos and removed non-wiki values

### DIFF
--- a/schema/buildings/building.yaml
+++ b/schema/buildings/building.yaml
@@ -65,14 +65,12 @@ properties:
           - chapel
           - church
           - civic
-          - clinic
           - college
           - commercial
           - cowshed
           - detached
           - digester
           - dormitory
-          - duplex
           - dwelling_house
           - factory
           - farm
@@ -83,7 +81,6 @@ properties:
           - ger
           - glasshouse
           - government
-          - government_office
           - grandstand
           - greenhouse
           - guardhouse
@@ -97,7 +94,6 @@ properties:
           - kindergarten
           - kiosk
           - manufacture
-          - marketplace
           - military
           - monastery
           - mosque
@@ -109,14 +105,12 @@ properties:
           - public
           - religious
           - residential
-          - restaurant
           - retail
           - school
           - semi
           - semidetached_house
           - service
           - shed
-          - shop
           - shrine
           - silo
           - slurry_tank
@@ -133,7 +127,6 @@ properties:
           - temple
           - terrace
           - toilets
-          - townhouse
           - train_station
           - transformer_tower
           - transportation
@@ -141,6 +134,7 @@ properties:
           - university
           - warehouse
           - wayside_shrine
+
       has_parts:
         description: Flag indicating whether the building has parts
         type: boolean

--- a/task-force-docs/buildings/building_class_query.sql
+++ b/task-force-docs/buildings/building_class_query.sql
@@ -18,18 +18,14 @@ CASE
         'civic',
         'fire_station',
         'government',
-        'government_office',
         'public',
 
         --Commercial
         'commercial',
         'hotel',
         'kiosk',
-        'marketplace',
         'office',
-        'restaurant',
         'retail',
-        'shop',
         'supermarket',
         'warehouse',
 
@@ -41,7 +37,7 @@ CASE
 
         --Entertainment
         'grandstand',
-        'pavillion',
+        'pavilion',
         'sports_centre',
         'sports_hall',
         'stadium',
@@ -52,7 +48,6 @@ CASE
         'manufacture',
 
         --Medical
-        'clinic',
         'hospital',
 
         --Military
@@ -69,7 +64,7 @@ CASE
         'cathedral',
         'chapel',
         'church',
-        'monastary',
+        'monastery',
         'mosque',
         'presbytery',
         'religious',
@@ -84,7 +79,6 @@ CASE
         'cabin',
         'detached',
         'dormitory',
-        'duplex',
         'dwelling_house',
         'garage',
         'garages',
@@ -98,7 +92,6 @@ CASE
         'static_caravan',
         'stilt_house',
         'terrace',
-        'townhouse',
         'trullo',
 
         --Service

--- a/task-force-docs/buildings/building_subtype_query.sql
+++ b/task-force-docs/buildings/building_subtype_query.sql
@@ -78,7 +78,7 @@ CASE
     --Entertainment
     WHEN tags['building'] IN (
             'grandstand',
-            'pavillion',
+            'pavilion',
             'sports_centre',
             'sports_hall',
             'stadium'
@@ -135,7 +135,7 @@ CASE
             'cathedral',
             'chapel',
             'church',
-            'monastary',
+            'monastery',
             'mosque',
             'presbytery',
             'religious',

--- a/task-force-docs/buildings/building_subtype_query.sql
+++ b/task-force-docs/buildings/building_subtype_query.sql
@@ -1,4 +1,5 @@
 CASE
+    -- Prioritize the `building` tag to determine the subtype
     -- Agricultural
     WHEN tags['building'] IN (
             'agricultural',
@@ -20,24 +21,9 @@ CASE
             'government',
             'government_office',
             'public'
-    ) OR tags['amenity'] IN (
-            'animal_shelter',
-            'community_centre',
-            'courthouse',
-            'fire_station',
-            'library',
-            'police',
-            'post_office',
-            'public_bath',
-            'public_building',
-            'ranger_station',
-            'shelter',
-            'social_centre',
-            'townhall',
-            'veterinary'
-        ) THEN 'civic'
+    ) THEN 'civic'
 
-    --Commercial
+    -- Commercial
     WHEN tags['building'] IN (
             'commercial',
             'hotel',
@@ -49,80 +35,45 @@ CASE
             'shop',
             'supermarket',
             'warehouse'
-        ) OR tags['amenity'] IN (
-            'bar',
-            'cafe',
-            'fast_food',
-            'food_court',
-            'fuel',
-            'ice_cream',
-            'pub',
-            'restaurant'
         ) THEN 'commercial'
 
-    --Education
+    -- Education
     WHEN tags['building'] IN (
             'college',
             'kindergarten',
             'school',
             'university'
-        ) OR tags['amenity'] IN (
-            'college',
-            'driving_school',
-            'kindergarten',
-            'music_school',
-            'school',
-            'university'
         ) THEN 'education'
 
-    --Entertainment
+    -- Entertainment
     WHEN tags['building'] IN (
             'grandstand',
             'pavilion',
             'sports_centre',
             'sports_hall',
             'stadium'
-        ) OR tags['amenity'] IN (
-            'casino',
-            'conference_centre',
-            'events_venue',
-            'cinema',
-            'theatre',
-            'arts_centre',
-            'nightclub'
-        ) OR tags['tourism'] IN (
-            'aquarium',
-            'attraction',
-            'gallery',
-            'museum'
         ) THEN 'entertainment'
 
-    --Industrial
+    -- Industrial
     WHEN tags['building'] IN (
             'factory',
             'industrial',
             'manufacture'
         ) THEN 'industrial'
 
-    --Medical
+    -- Medical
     WHEN tags['building'] IN (
             'clinic',
             'hospital'
-        ) OR tags['amenity'] IN (
-            'clinic',
-            'dentist',
-            'doctors',
-            'hospital',
-            'pharmacy'
         ) THEN 'medical'
 
-    --Military
+    -- Military
     WHEN tags['building'] IN (
             'bunker',
             'military'
         ) THEN 'military'
 
-    --Outbuilding
+    -- Outbuilding
     WHEN tags['building'] IN (
             'allotment_house',
             'carport',
@@ -130,7 +81,7 @@ CASE
             'shed'
         ) THEN 'outbuilding'
 
-    --Religious
+    -- Religious
     WHEN tags['building'] IN (
             'cathedral',
             'chapel',
@@ -143,10 +94,9 @@ CASE
             'synagogue',
             'temple',
             'wayside_shrine'
-        ) OR tags['amenity'] = 'place_of_worship'
-        THEN 'religious'
+        ) THEN 'religious'
 
-    --Residential
+    -- Residential
     WHEN tags['building'] IN (
             'apartments',
             'bungalow',
@@ -169,11 +119,9 @@ CASE
             'terrace',
             'townhouse',
             'trullo'
-        ) OR tags['amenity'] IN (
-            'nursing_home'
         ) THEN 'residential'
 
-    --Service
+    -- Service
     WHEN tags['building'] IN (
             'beach_hut',
             'boathouse',
@@ -192,9 +140,76 @@ CASE
             'parking',
             'train_station',
             'transportation'
-        ) OR tags['amenity'] IN (
+        ) THEN 'transportation'
+
+    -- Consider any amenity / tourism tags if no other building tag was present
+    WHEN tags['amenity'] IN ('nursing_home') THEN 'residential'
+
+    WHEN  tags['amenity'] IN (
             'bus_station',
             'parking'
         ) THEN 'transportation'
+
+    WHEN tags['amenity'] IN ('place_of_worship') THEN 'religious'
+
+    WHEN tags['amenity'] IN (
+            'clinic',
+            'dentist',
+            'doctors',
+            'hospital',
+            'pharmacy'
+        ) THEN 'medical'
+
+    WHEN tags['amenity'] IN (
+            'casino',
+            'conference_centre',
+            'events_venue',
+            'cinema',
+            'theatre',
+            'arts_centre',
+            'nightclub'
+        ) OR tags['tourism'] IN (
+            'aquarium',
+            'attraction',
+            'gallery',
+            'museum'
+        ) THEN 'entertainment'
+
+    WHEN tags['amenity'] IN (
+            'bar',
+            'cafe',
+            'fast_food',
+            'food_court',
+            'fuel',
+            'ice_cream',
+            'pub',
+            'restaurant'
+        ) THEN 'commercial'
+
+    WHEN tags['amenity'] IN (
+            'animal_shelter',
+            'community_centre',
+            'courthouse',
+            'fire_station',
+            'library',
+            'police',
+            'post_office',
+            'public_bath',
+            'public_building',
+            'ranger_station',
+            'shelter',
+            'social_centre',
+            'townhall',
+            'veterinary'
+        ) THEN 'civic'
+
+     WHEN tags['amenity'] IN (
+            'college',
+            'driving_school',
+            'kindergarten',
+            'music_school',
+            'school',
+            'university'
+        ) THEN 'education'
     ELSE NULL
 END


### PR DESCRIPTION
This is a patch to https://github.com/OvertureMaps/schema/pull/183

It does the following: 
1. Fixes typos
2. Only allows `building` values from OSM to pass through to `class` if there are more than 1,000 instances of them in OSM and they have a WIKI page. (i.e., `duplex` is not a valid class because it's not the preferred tag in OSM and it has inconsistent coverage). However, we still use `duplex` to determine if a building is in the `residential` subtype, as we did before.