### PR TITLE
Adding max speed limitation and then setting sensible limites for min…

### DIFF
--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -318,7 +318,8 @@ properties:
         value:
           description: Speed value
           type: integer
-          minimum: 20
+          minimum: 1
+          maximum: 350
         unit:
           description: Speed unit
           type: string


### PR DESCRIPTION
… and max

# Description


The minimum speed was set too high and there was no check for maximum speed. 

# Reference


1. https://github.com/OvertureMaps/tf-transportation/issues/193

# Testing

*Brief description of the testing done for this change showing why you are confident it works as expected and does not introduce regressions. Provide sample output data where appropriate.* 

Using the automated test suite

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [ ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/<PUT THE PR # HERE>)
