### PR TITLE
Add MultiLineString as possible geometry of boundary

### DIFF
--- a/schema/divisions/boundary.yaml
+++ b/schema/divisions/boundary.yaml
@@ -13,7 +13,7 @@ properties:     # JSON Schema: Top-level object properties.
       GeoJSON schema.
     unevaluatedProperties: false
     oneOf:
-      - "$ref": https://geojson.org/schema/LineString.json,
+      - "$ref": https://geojson.org/schema/LineString.json
       - "$ref": https://geojson.org/schema/MultiLineString.json
   properties:   # GeoJSON: top-level object 'properties' property.
     unevaluatedProperties: false

--- a/schema/divisions/boundary.yaml
+++ b/schema/divisions/boundary.yaml
@@ -13,7 +13,8 @@ properties:     # JSON Schema: Top-level object properties.
       GeoJSON schema.
     unevaluatedProperties: false
     oneOf:
-      - "$ref": https://geojson.org/schema/LineString.json
+      - "$ref": https://geojson.org/schema/LineString.json,
+      - "$ref": https://geojson.org/schema/MultiLineString.json
   properties:   # GeoJSON: top-level object 'properties' property.
     unevaluatedProperties: false
     required: [subtype, class, divisions]


### PR DESCRIPTION
Currently we have linestring per boundary entity. This implies that if boundary between two divisions is split, by another division of the same subtype, we will have multiple entities representing boundary between two divisions. At this point GERS id is created based on divisions which boundary is separating and boundary geometry. With each change to the divisions the boundary GERS id will change, and it will be unstable.
For example, border between Spain (085e7a023fffffff012656f58e364b88) and France (0854db377fffffff01c2b9178bdd68b1) is split in 3 parts (085e7a023fffffff012ad418147bdcf8, 085e7a023fffffff010a4e09caa458ce, 085e7a023fffffff012656f58e364b88). With change of Spain or France polygon any of these boundaries can get changed GERS due to change in their geometry. If we were to create single entity to represent boundary between these two divisions, we wouldn't need geometry for generating GERS and it would be far more stable and easier to maintain.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/188)
