### PR TITLE
Fix: missing bracket in places categories list

### DIFF
--- a/task-force-docs/places/overture_categories.csv
+++ b/task-force-docs/places/overture_categories.csv
@@ -645,7 +645,7 @@ massage;[beauty_and_spa,massage]
 nail_salon;[beauty_and_spa,nail_salon]
 onsen;[beauty_and_spa,onsen]
 permanent_makeup;[beauty_and_spa,permanent_makeup]
-tattoo_and_piercing;[beauty_and_spa,tattoo_and_piercing
+tattoo_and_piercing;[beauty_and_spa,tattoo_and_piercing]
 piercing;[beauty_and_spa,tattoo_and_piercing,piercing]
 tattoo;[beauty_and_spa,tattoo_and_piercing,tattoo]
 public_bath_houses;[beauty_and_spa,public_bath_houses]


### PR DESCRIPTION
# Description

I noticed one of the lines in the places categories csv is missing a closing bracket. I've gone ahead and fixed it.

