### PR TITLE
Adds the land_cover.mdx page to the schema reference documentation

### DIFF
--- a/docusaurus/docs/reference/base/land_cover.mdx
+++ b/docusaurus/docs/reference/base/land_cover.mdx
@@ -1,0 +1,56 @@
+---
+title: land_cover
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import JSONSchemaViewer from "@theme/JSONSchemaViewer";
+import generateResolverOptions from "@site/src/components/shared-libs/generateResolverOptions"
+import yamlLoad from "@site/src/components/yamlLoad"
+import LandCoverSchema from "!!raw-loader!@site/docs/_schema/base/land_cover.yaml";
+
+import LandCoverExample from "!!raw-loader!@site/docs/_examples/base/land-cover-example.yaml";
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Land Cover
+
+<table>
+  <tbody>
+  <tr>
+    <th>Geometry Type</th>
+    <td>
+      <code>Polygon</code>
+    </td>
+  </tr>
+  <tr>
+    <th>Theme</th>
+    <td><code>base</code></td>
+  </tr>
+  <tr>
+    <th>Type</th>
+    <td><code>land_cover</code></td>
+  </tr>
+  </tbody>
+</table>
+
+
+## Schema
+
+<Tabs>
+  <TabItem value="browsable" label="Browsable" default>
+    <JSONSchemaViewer schema={ yamlLoad(LandCoverSchema) } resolverOptions={ generateResolverOptions({remote: true, yamlBasePath: '/base'})}/>
+  </TabItem>
+  <TabItem value="yaml" label="YAML" default>
+    <CodeBlock language="jsx">{LandCoverSchema}</CodeBlock>
+  </TabItem>
+</Tabs>
+
+## Examples
+
+<Tabs>
+  <TabItem value="1" label="Forest land cover" default>
+    <CodeBlock language="json">{ JSON.stringify(yamlLoad(LandCoverExample), null, 2) }</CodeBlock>
+  </TabItem>
+
+</Tabs>

--- a/docusaurus/src/YAML_FILE_TREE.js
+++ b/docusaurus/src/YAML_FILE_TREE.js
@@ -22,6 +22,7 @@ const _default = {
 
     '/base/defs.yaml': require('!!raw-loader!@site/docs/_schema/base/defs.yaml'),
     '/base/land.yaml': require('!!raw-loader!@site/docs/_schema/base/land.yaml'),
+    '/base/land_cover.yaml': require('!!raw-loader!@site/docs/_schema/base/land_cover.yaml'),
     '/base/land_use.yaml': require('!!raw-loader!@site/docs/_schema/base/land_use.yaml'),
     '/base/water.yaml': require('!!raw-loader!@site/docs/_schema/base/water.yaml'),
 


### PR DESCRIPTION
# Description

*Brief description of the business purpose and effect of the pull request.*

Adds the entry for the land_cover page in the schema reference under `base` theme. 

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

# Testing

https://dfhx9f55j8eg5.cloudfront.net/pr/190/reference/base/land_cover

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [N/A] Add relevant examples.
2. [N/A] Add relevant counterexamples.
3. [N/A] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [N/A] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [X] Update Docusaurus documentation, if an update is required.
6. [X] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/190)
