### PR TITLE
Allowing multiple capital division ids

### DIFF
--- a/counterexamples/divisions/division/bad-capital-division-id.yaml
+++ b/counterexamples/divisions/division/bad-capital-division-id.yaml
@@ -19,6 +19,6 @@ properties:
         name: A division with an invalid capital_division_id property.
   norms:
     driving_side: right
-  capital_division_id: '    '
+  capital_division_ids: ['    ']
   ext_expected_errors:
-    - "[I#/properties/capital_division_id] [S#/$defs/propertyDefinitions/id/pattern] does not match pattern"
+    - "[I#/properties/capital_division_ids] [S#/$defs/propertyDefinitions/id/pattern] does not match pattern"

--- a/examples/divisions/division/country.yaml
+++ b/examples/divisions/division/country.yaml
@@ -19,4 +19,4 @@ properties:
         name: United States
   norms:
     driving_side: right
-  capital_division_id: example:division:locality:washington_dc
+  capital_division_ids: [ example:division:locality:washington_dc ]

--- a/examples/divisions/division/dependency.yaml
+++ b/examples/divisions/division/dependency.yaml
@@ -35,5 +35,5 @@ properties:
         name: United States
   norms:
     driving_side: right
-  capital_division_id: example:division:locality:san_juan
+  capital_division_ids: [ example:division:locality:san_juan ]
   parent_division_id: example:division:country:us

--- a/examples/divisions/division/multiple_capital_division.yaml
+++ b/examples/divisions/division/multiple_capital_division.yaml
@@ -1,0 +1,31 @@
+---
+id: example:division:region:pl-04
+type: Feature
+geometry:
+  type: Point
+  coordinates: [18.3392939, 53.3220016]
+properties:
+  theme: divisions
+  type: division
+  update_time: "2024-02-23T15:53:17Z"
+  version: 0
+  subtype: region
+  local_type:
+    en: province
+  names:
+    primary: Woj Kujawsko-Pomorskie
+  sources:
+    - property: ""
+      dataset: OpenStreetMap
+      record_id: R223407.V254
+  country: PL
+  region: PL-04
+  hierarchies:
+    - - division_id: example:division:country:pl
+        subtype: country
+        name: Poland
+      - division_id: example:division:region:pl-04
+        subtype: region
+        name: Woj Kujawsko-Pomorskie
+  capital_division_ids: [ example:division:locality:bydgoszcz, example:division:locality:torun]
+  parent_division_id: example:division:country:pl

--- a/examples/divisions/division/population.yaml
+++ b/examples/divisions/division/population.yaml
@@ -27,6 +27,6 @@ properties:
       - division_id: example:division:region:ca-on
         subtype: region
         name: Ontario
-  capital_division_id: example:division:locality:toronto
+  capital_division_ids: [ example:division:locality:toronto ]
   parent_division_id: example:division:country:ca
   population: 13550900

--- a/examples/divisions/division/region.yaml
+++ b/examples/divisions/division/region.yaml
@@ -27,5 +27,5 @@ properties:
       - division_id: example:division:region:us-ny
         subtype: region
         name: New York
-  capital_division_id: example:division:locality:albany
+  capital_division_ids: [ example:division:locality:albany ]
   parent_division_id: example:division:country:us

--- a/schema/divisions/division.yaml
+++ b/schema/divisions/division.yaml
@@ -174,7 +174,7 @@ properties:     # JSON Schema: Top-level object properties.
           this property will refer to the division IDs of the capital
           cities, county seats, etc. of a division.
         type: array
-        minItems: 0
+        minItems: 1
         uniqueItems: true
         items: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/id" }
       wikidata: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/wikidata" }

--- a/schema/divisions/division.yaml
+++ b/schema/divisions/division.yaml
@@ -168,11 +168,13 @@ properties:     # JSON Schema: Top-level object properties.
         description: Population of the division
         type: integer
         minimum: 0
-      capital_division_id:
+      capital_division_ids:
         description:
-          Division ID of this division's capital division. If present,
-          this property will refer to the division ID of the capital
-          city, county seat, etc. of a division.
-        allOf:
-          - "$ref": "../defs.yaml#/$defs/propertyDefinitions/id"
+          Division IDs of this division's capital divisions. If present,
+          this property will refer to the division IDs of the capital
+          cities, county seats, etc. of a division.
+        type: array
+        minItems: 0
+        uniqueItems: true
+        items: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/id" }
       wikidata: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/wikidata" }


### PR DESCRIPTION
Single division can have multiple capitals example: [Województwo kujawsko-pomorskie](https://pl.wikipedia.org/wiki/pl:Wojew%C3%B3dztwo%20kujawsko-pomorskie?uselang=en)
To support this, I changed capital_division_id property to capital_division_ids where instead of single division id, it will accept multiple ids.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/192)
