### PR TITLE
Building classes update

### DIFF
--- a/schema/buildings/building.yaml
+++ b/schema/buildings/building.yaml
@@ -93,6 +93,7 @@ properties:
           - industrial
           - kindergarten
           - kiosk
+          - library
           - manufacture
           - military
           - monastery
@@ -101,6 +102,7 @@ properties:
           - outbuilding
           - parking
           - pavilion
+          - post_office
           - presbytery
           - public
           - religious

--- a/task-force-docs/buildings/building_class_query.sql
+++ b/task-force-docs/buildings/building_class_query.sql
@@ -1,4 +1,11 @@
 CASE
+    -- Prioritize these amenity tags when present because they are also used to determine subtype:
+    WHEN tags['amenity'] IN (
+        'library',
+        'parking',
+        'post_office'
+    ) THEN tags['amenity']
+
     -- Certain building tags become the class value to further describe the building subtype
     WHEN tags['building'] IN (
 
@@ -111,5 +118,7 @@ CASE
         'train_station',
         'transportation'
     ) THEN tags['building']
+
+    -- No other allowed classes
     ELSE NULL
 END


### PR DESCRIPTION
# Description

The Overture buildings theme has `subtype` and `class` attributes meant to describe the built purpose of the building. In most cases, the built purpose and the primary occupant are in sync. An apartment building, for example: `residential` and `apartment` subtype and class are assigned based on the single OSM tag: `building=apartments`

We currently use a combination of the `building` and `amenity` tags from OSM to determine the appropriate _subtype_ value for an Overture building. 

In most cases, the `class` is simply the value of the `building` tag, especially when there is a valid wiki entry for that particular building value.

This PR expands on the previous definition of class for buildings to include specific amenity tags that are either already an official [Overture place category](https://github.com/OvertureMaps/schema/blob/main/task-force-docs/places/overture_categories.csv) or can be matched to one. 

# Reference


# Testing

- [x] Tested on Airflow

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [N/A] Add relevant examples.
2. [N/A] Add relevant counterexamples.
3. [N/A] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [N/A] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [N/A] Update Docusaurus documentation, if an update is required.
6. [N/A] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/195)
