### PR TITLE
[Patch] - Adds the rest of `level` to the necessary base queries

### DIFF
--- a/task-force-docs/base/infrastructure.sql
+++ b/task-force-docs/base/infrastructure.sql
@@ -231,7 +231,7 @@ SELECT
     tags['surface'] AS surface,
 
     -- Overture's concept of `layer` is called level
-    tags['layer'] AS level,
+    TRY_CAST(tags['layer'] AS int) AS level,
 
     -- Wikidata is a top-level property in the OSM Container
     tags['wikidata'] as wikidata,

--- a/task-force-docs/base/land.sql
+++ b/task-force-docs/base/land.sql
@@ -133,7 +133,7 @@ SELECT
     tags['wikidata'] as wikidata,
 
     -- Overture's concept of `layer` is called level
-    tags['layer'] AS level,
+    TRY_CAST(tags['layer'] AS int) AS level,
 
     -- Elevation as integer (meters above sea level)
     TRY_CAST(tags['ele'] AS integer) AS elevation,
@@ -307,6 +307,7 @@ SELECT
         )
     ) ] as sources,
     NULL AS wikidata,
+    NULL AS level,
     NULL AS elevation,
     wkt AS wkt_geometry
 FROM {daylight_earth_table}

--- a/task-force-docs/base/land_use.sql
+++ b/task-force-docs/base/land_use.sql
@@ -15,6 +15,7 @@ SELECT
     sources,
     wikidata,
     surface,
+    level,
     elevation,
     wkt_geometry
 FROM (
@@ -273,7 +274,7 @@ FROM (
         ) ] AS sources,
 
         -- Overture's concept of `layer` is called level
-        tags['layer'] AS level,
+        TRY_CAST(tags['layer'] AS int) AS level,
 
         -- Wikidata is a top-level property in the OSM Container
         tags['wikidata'] as wikidata,

--- a/task-force-docs/base/water.sql
+++ b/task-force-docs/base/water.sql
@@ -85,7 +85,7 @@ SELECT
     tags['wikidata'] as wikidata,
 
     -- Overture's concept of `layer` is called level
-    tags['layer'] AS level,
+    TRY_CAST(tags['layer'] AS int) AS level,
 
     -- Elevation is common on some ponds / lakes.
     TRY_CAST(tags['ele'] AS integer) AS elevation,
@@ -324,6 +324,7 @@ SELECT
     ) ] as sources,
     -- Wikidata is a top-level property in the OSM Container
     NULL as wikidata,
+    0 as level, -- it's the ocean, does it go lower?
     -- Other type=water top-level attributes
     0 AS elevation,
     TRUE AS is_salt,


### PR DESCRIPTION
# Description

Patch update to https://github.com/OvertureMaps/schema/pull/194 to actually include `level` and ensure that it's an integer. 

# Reference

 - https://github.com/OvertureMaps/schema/pull/194

# Testing

Tested on Airflow — ✅ 

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [N/A] Add relevant examples.
2. [N/A] Add relevant counterexamples.
3. [N/A] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [N/A] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [N/A] Update Docusaurus documentation, if an update is required.
6. [N/A] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/196)
