### PR TITLE
add sort_key as an optional cartographic property

### DIFF
--- a/examples/base/land-cover-example.yaml
+++ b/examples/base/land-cover-example.yaml
@@ -11,6 +11,7 @@ properties:
   cartography:
     min_zoom: 11
     max_zoom: 23
+    sort_key: 2
   sources:
     - record_id: x123
       property: ""

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -364,3 +364,12 @@ description: Common schema definitions shared by all themes
               type: integer
               minimum: 0
               maximum: 23
+            sort_key:
+              description: >-
+                An ascending numeric that defines the recommended order features
+                should be drawn in. Features with lower number should be shown on top
+                of features with a higher number.
+              type: integer
+              default: 0
+              
+          


### PR DESCRIPTION
## Cartographic Property: sort_key

A common concept in web mapping is the "sort key," which defines the order in which features within a layer should be drawn. Features with higher precedence are placed first to ensure that the most important features are rendered and visible before less critical ones, enhancing the map's clarity and usability. 

### Disambiguation

**level** refers to the real world _z-order_ of a feature in comparison with other features in the dataset. For example, 2 raised highways will have ascending level values to describe their relative altitudes to each other. You would expect to see level=3 overlap level=1.

**sort_key** is a cartographic hint for map makers for feature based rendering and is especially important in labeling. For example, one may create an importance metric for cities. Plugging this into a sort-key property in a map rendering would ensure the important cities are placed before others.

**layer**  refers to the stacking order of different types of map data. For example, the water layer would rendered above a parks layer so that ponds will be visible within the park.

### Background
Common vector tile renderers like [MapLibre](https://maplibre.org/maplibre-style-spec/) support the concept of sorting for [circles](https://maplibre.org/maplibre-style-spec/layers/#circle-sort-key), [line](https://maplibre.org/maplibre-style-spec/layers/#line-sort-key), [polygons](https://maplibre.org/maplibre-style-spec/layers/#fill-sort-key), and [symbols](https://maplibre.org/maplibre-style-spec/layers/#symbol-sort-key). 

A variety of libraries also support sorting when features are tiled, such as [Tippecanoe](https://github.com/felt/tippecanoe?tab=readme-ov-file#reordering-features-within-each-tile). This reduces the need for adding specific sort properties when styling.

### Examples
The "sort_key" helps polygonal features by prioritizing which polygons are drawn first, ensuring that more significant or relevant polygons are not obscured by less important ones. In the case of our new land cover layer, features overlap each other to prevent slivers and gaps during tiling. The fill-sort-key style property in MapLibre could be used to ensure cartographic preference of how these features are ordered.

| Subtype  | Sort_Key |
|----------|----------|
| urban    | 1        |
| forest   | 2        |
| barren   | 3        |
| shrub    | 4        |
| grass    | 5        |
| crop     | 6        |
| wetland  | 7        |
| mangrove | 8        |
| moss     | 9        |
| snow     | 10       |


When labeling, the "sort_key" assists by determining the order in which labels are placed, helping to avoid overlaps and ensuring that the most crucial labels are visible and readable. In the image below, sorting is used to ensure important locality labels are shown. 

<img width="1124" alt="Screenshot 2024-05-23 at 8 58 36 AM" src="https://github.com/OvertureMaps/schema/assets/5178200/527ccb6d-a83a-42e8-9e58-d1e7d01fa723">
Red boxes represent labels that could not be placed.

### Proposed change
This PR adds sort_key as an optional cartographic property to the land_cover layer in the base theme. We will add the sort_key defined in the table above to subsequent releases. 
