### PR TITLE
Buildings roof height: eave_height -> roof_height

### DIFF
--- a/examples/buildings/building-part-basic.yaml
+++ b/examples/buildings/building-part-basic.yaml
@@ -28,6 +28,7 @@ properties:
   roof_shape: dome
   roof_orientation: across
   roof_direction: 23.4
+  roof_height: 3.4
   sources:
   - property: ""
     dataset: microsoftMLBuildings

--- a/schema/buildings/defs.yaml
+++ b/schema/buildings/defs.yaml
@@ -102,6 +102,8 @@ shapeContainer:
     roof_color:
       description: The color (name or color triplet) of the roof of a building or building part in hexadecimal
       type: string
-    eave_height:
-      description: The height of the building eave in meters
+    roof_height:
+      description: >-
+        The height of the building roof in meters. This represents the distance from the beginning of the roof
+        line to the top of the roof.
       type: number

--- a/schema/buildings/defs.yaml
+++ b/schema/buildings/defs.yaml
@@ -104,6 +104,6 @@ shapeContainer:
       type: string
     roof_height:
       description: >-
-        The height of the building roof in meters. This represents the distance from the beginning of the roof
-        line to the highest point of the roof.
+        The height of the building roof in meters. This represents the distance
+        from the base of the roof to the highest point of the roof.
       type: number

--- a/schema/buildings/defs.yaml
+++ b/schema/buildings/defs.yaml
@@ -105,5 +105,5 @@ shapeContainer:
     roof_height:
       description: >-
         The height of the building roof in meters. This represents the distance from the beginning of the roof
-        line to the top of the roof.
+        line to the highest point of the roof.
       type: number


### PR DESCRIPTION
Replace eave_height with roof_height. Overture release data has not populated eave_height up to now so this shouldn't have downstream effects for users other than the column name change.

Use roof height instead of eave_height. The buildings task force decided that roof height was more standard and easier to reason about than providing the eave_height value. 

1. [x ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [x ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/<PUT THE PR # HERE>)
