### PR TITLE
Segment restructure

### DIFF
--- a/counterexamples/transportation/segment/road/bad-road-flags-duplicate-flag.json
+++ b/counterexamples/transportation/segment/road/bad-road-flags-duplicate-flag.json
@@ -15,6 +15,11 @@
     "update_time": "2024-03-14T08:05:36-08:00",
     "subtype": "road",
     "class": "primary",
+    "road_flags": [
+      {
+        "values": ["is_tunnel", "is_tunnel"]
+      }
+    ],
     "road": {
       "flags": [
         {

--- a/counterexamples/transportation/segment/road/bad-road-flags-invalid-flag.json
+++ b/counterexamples/transportation/segment/road/bad-road-flags-invalid-flag.json
@@ -15,6 +15,11 @@
     "update_time": "2024-03-14T08:08:07-08:00",
     "subtype": "road",
     "class": "primary",
+    "road_flags": [
+      {
+        "values": ["foo"]
+      }
+    ],
     "road": {
       "flags": [
         {

--- a/counterexamples/transportation/segment/road/bad-road-flags-invalid-is_private-flag.json
+++ b/counterexamples/transportation/segment/road/bad-road-flags-invalid-is_private-flag.json
@@ -12,6 +12,11 @@
       "update_time": "2024-03-14T08:08:17-08:00",
       "subtype": "road",
       "class": "primary",
+      "road_flags": [
+        {
+          "values": ["is_private"]
+        }
+      ],
       "road": {
         "flags": [
           {

--- a/counterexamples/transportation/segment/road/bad-road-flags-invalid-string-value.json
+++ b/counterexamples/transportation/segment/road/bad-road-flags-invalid-string-value.json
@@ -8,6 +8,7 @@
     "properties": {
       "ext_expected_errors": [
         "[I#/properties/road/flags/0] [S#/$defs/propertyDefinitions/road/properties/flags/items/type] expected object, but got string"
+        "[I#/properties/road_flags/0] [S#/$defs/propertyDefinitions/road/road_flags/items/type] expected object, but got string"
       ],
       "theme": "transportation",
       "type": "segment",
@@ -15,6 +16,7 @@
       "update_time": "2024-03-14T08:08:27-08:00",
       "subtype": "road",
       "class": "primary",
+      "road_flags": ["is_tunnel"],
       "road": {
         "flags": ["is_tunnel"]
       }

--- a/counterexamples/transportation/segment/road/bad-road-flags-invalid-string-value.json
+++ b/counterexamples/transportation/segment/road/bad-road-flags-invalid-string-value.json
@@ -7,7 +7,7 @@
     },
     "properties": {
       "ext_expected_errors": [
-        "[I#/properties/road/flags/0] [S#/$defs/propertyDefinitions/road/properties/flags/items/type] expected object, but got string"
+        "[I#/properties/road/flags/0] [S#/$defs/propertyDefinitions/road/properties/flags/items/type] expected object, but got string",
         "[I#/properties/road_flags/0] [S#/$defs/propertyDefinitions/road/road_flags/items/type] expected object, but got string"
       ],
       "theme": "transportation",

--- a/counterexamples/transportation/segment/road/bad-road-invalid-min-occupancy-value.json
+++ b/counterexamples/transportation/segment/road/bad-road-invalid-min-occupancy-value.json
@@ -12,6 +12,23 @@
       "update_time": "2024-03-14T08:08:38-08:00",
       "subtype": "road",
       "class": "primary",
+      "road_flags": [
+        {
+          "values": ["is_tunnel"]
+        }
+      ],
+      "lanes": [
+        {
+          "value": [
+            {
+              "direction": "backward",
+              "restrictions": {
+                "min_occupancy": 0
+              }
+            }
+          ]
+        }
+      ],
       "road": {
         "flags": [
           {
@@ -30,7 +47,6 @@
             ]
           }
         ]
-
       },
       "ext_expected_errors": [
         "[I#/properties/road/lanes/0/value/0/restrictions/min_occupancy] [S#/$defs/propertyDefinitions/lane/properties/restrictions/properties/min_occupancy/minimum] must be >= 1 but found 0"

--- a/counterexamples/transportation/segment/road/bad-road-invalid-min-occupancy.json
+++ b/counterexamples/transportation/segment/road/bad-road-invalid-min-occupancy.json
@@ -12,6 +12,27 @@
       "update_time": "2024-03-14T08:08:37-08:00",
       "subtype": "road",
       "class": "primary",
+      "road_flags": [
+        {
+          "values": ["is_tunnel"]
+        }
+      ],
+      "lanes": [
+        {
+          "value": [
+            {
+              "direction": "forward",
+              "restrictions": {
+                "min_occupancy": [
+                  {
+                    "is_at_least": 3
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
       "road": {
         "flags": [
           {

--- a/counterexamples/transportation/segment/road/bad-road-invalid-temporal-scoping.json
+++ b/counterexamples/transportation/segment/road/bad-road-invalid-temporal-scoping.json
@@ -12,6 +12,14 @@
     "update_time": "2024-03-14T08:08:39-08:00",
     "subtype": "road",
     "class": "primary",
+    "road_flags": [
+      {
+        "values": ["is_bridge"]
+      }
+    ],
+    "when": {
+      "during": "Mo-Sa 09:00-12:00, We 15:00-18:00"
+    },
     "road": {
       "flags": [
         {
@@ -23,7 +31,8 @@
       }
     },
     "ext_expected_errors": [
-      "[I#/properties/road/when] [S#/$defs/propertyDefinitions/road/unevaluatedProperties] not allowed"
+      "[I#/properties/road/when] [S#/$defs/propertyDefinitions/road/unevaluatedProperties] not allowed",
+      "[I#/properties/when] [S#/$defs/propertyDefinitions/unevaluatedProperties] not allowed"
     ]
   }
-} 
+}

--- a/counterexamples/transportation/segment/road/bad-road-level-invalid-value.yaml
+++ b/counterexamples/transportation/segment/road/bad-road-level-invalid-value.yaml
@@ -14,7 +14,7 @@ properties:
   connector_ids: [fooConnector, barConnector]
   level_rules:
     - value: 1.5
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     level:
       - value: 1.5
   ext_expected_errors:

--- a/counterexamples/transportation/segment/road/bad-road-level-invalid-value.yaml
+++ b/counterexamples/transportation/segment/road/bad-road-level-invalid-value.yaml
@@ -12,6 +12,8 @@ properties:
   subtype: road
   class: secondary
   connector_ids: [fooConnector, barConnector]
+  level_rules:
+    - value: 1.5
   road:
     level:
       - value: 1.5

--- a/counterexamples/transportation/segment/road/bad-road-level-unsupported-properties.yaml
+++ b/counterexamples/transportation/segment/road/bad-road-level-unsupported-properties.yaml
@@ -15,7 +15,7 @@ properties:
   level_rules:
     - value: 1
       foo: bar
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     level:
       - value: 1
         foo: bar

--- a/counterexamples/transportation/segment/road/bad-road-level-unsupported-properties.yaml
+++ b/counterexamples/transportation/segment/road/bad-road-level-unsupported-properties.yaml
@@ -12,6 +12,9 @@ properties:
   subtype: road
   class: secondary
   connector_ids: [fooConnector, barConnector]
+  level_rules:
+    - value: 1
+      foo: bar
   road:
     level:
       - value: 1

--- a/counterexamples/transportation/segment/road/bad-road-surface-invalid-rule-value.json
+++ b/counterexamples/transportation/segment/road/bad-road-surface-invalid-rule-value.json
@@ -12,6 +12,11 @@
     "update_time": "2024-03-14T08:08:49-08:00",
     "subtype": "road",
     "class": "primary",
+    "road_surface": [
+      {
+        "value": "hot mess"
+      }
+    ],
     "road": {
       "surface": [
         {

--- a/counterexamples/transportation/segment/road/restrictions/access/bad-access-mode.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/access/bad-access-mode.yaml
@@ -23,7 +23,7 @@ properties:
   access_restrictions:
     - access_type: allowed
       when: {mode: [foo]}
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     surface: gravel
     flags:
       - [is_link, is_tunnel]

--- a/counterexamples/transportation/segment/road/restrictions/access/bad-access-mode.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/access/bad-access-mode.yaml
@@ -17,9 +17,15 @@ properties:
   subtype: road
   class: secondary
   connector_ids: [fooConnector, barConnector]
+  road_surface: gravel
+  road_flags:
+    - [is_link, is_tunnel]
+  access_restrictions:
+    - access_type: allowed
+      when: {mode: [foo]}
   road:
     surface: gravel
-    flags: 
+    flags:
       - [is_link, is_tunnel]
     restrictions:
       access:

--- a/counterexamples/transportation/segment/road/restrictions/access/bad-access-restrictions-vehicle.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/access/bad-access-restrictions-vehicle.yaml
@@ -15,6 +15,9 @@ properties:
   subtype: road
   class: secondary
   connector_ids: [fooConnector, barConnector]
+  access_restrictions:
+    - access_type: allowed
+      when: {vehicle: {axle_count: {is_foo: 5}}}
   road:
     restrictions:
       access:
@@ -23,3 +26,5 @@ properties:
   ext_expected_errors:
     - "[I#/properties/road/restrictions/access/0/when/vehicle/axle_count] [S#/$defs/propertyDefinitions/integerRelation/oneOf] oneOf failed"
     - "[I#/properties/road/restrictions/access/0/when/vehicle/axle_count/is_foo] [S#/$defs/propertyDefinitions/integerRelation/unevaluatedProperties] not allowed"
+    - "[I#/properties/road/access_restrictions/0/when/vehicle/axle_count] [S#/$defs/propertyDefinitions/integerRelation/oneOf] oneOf failed"
+    - "[I#/properties/road/access_restrictions/0/when/vehicle/axle_count/is_foo] [S#/$defs/propertyDefinitions/integerRelation/unevaluatedProperties] not allowed"

--- a/counterexamples/transportation/segment/road/restrictions/access/bad-access-restrictions-vehicle.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/access/bad-access-restrictions-vehicle.yaml
@@ -18,7 +18,7 @@ properties:
   access_restrictions:
     - access_type: allowed
       when: {vehicle: {axle_count: {is_foo: 5}}}
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: allowed

--- a/counterexamples/transportation/segment/road/restrictions/access/bad-access-unsupported-properties.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/access/bad-access-unsupported-properties.yaml
@@ -15,7 +15,7 @@ properties:
     - access_type: denied
       when:
         baz: qux
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - foo: bar

--- a/counterexamples/transportation/segment/road/restrictions/access/bad-access-unsupported-properties.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/access/bad-access-unsupported-properties.yaml
@@ -10,6 +10,11 @@ properties:
   class: tertiary
   version: 1
   update_time: "2024-03-14T08:10:55-08:00"
+  access_restrictions:
+    - foo: bar
+    - access_type: denied
+      when:
+        baz: qux
   road:
     restrictions:
       access:
@@ -21,3 +26,6 @@ properties:
     - "[I#/properties/road/restrictions/access/0] [S#/$defs/propertyContainers/accessContainer/items/required] missing properties: 'access_type'"
     - "[I#/properties/road/restrictions/access/0/foo] [S#/$defs/propertyContainers/accessContainer/items/unevaluatedProperties] not allowed"
     - "[I#/properties/road/restrictions/access/1/when/baz] [S#/$defs/propertyContainers/accessContainer/items/properties/when/unevaluatedProperties] not allowed"
+    - "[I#/properties/access/0] [S#/$defs/propertyContainers/accessContainer/items/required] missing properties: 'access_type'"
+    - "[I#/properties/access/0/foo] [S#/$defs/propertyContainers/accessContainer/items/unevaluatedProperties] not allowed"
+    - "[I#/properties/access/1/when/baz] [S#/$defs/propertyContainers/accessContainer/items/properties/when/unevaluatedProperties] not allowed"

--- a/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/bad-sequence-duplicate-entry.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/bad-sequence-duplicate-entry.yaml
@@ -13,6 +13,13 @@ properties:
   class: primary
   connector_ids:
     - overture:transportation:example:connector:1
+  prohibited_transitions:
+    - sequence:
+        - segment_id: foo
+          connector_id: bar
+        - segment_id: foo
+          connector_id: bar
+      final_heading: forward
   road:
     restrictions:
       prohibited_transitions:

--- a/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/bad-sequence-duplicate-entry.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/bad-sequence-duplicate-entry.yaml
@@ -20,7 +20,7 @@ properties:
         - segment_id: foo
           connector_id: bar
       final_heading: forward
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       prohibited_transitions:
         - sequence:

--- a/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/bad-sequence-empty.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/bad-sequence-empty.yaml
@@ -13,6 +13,9 @@ properties:
   class: primary
   connector_ids:
     - overture:transportation:example:connector:1
+  prohibited_transitions:
+    - sequence: []
+      final_heading: forward
   road:
     restrictions:
       prohibited_transitions:

--- a/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/bad-sequence-empty.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/bad-sequence-empty.yaml
@@ -16,7 +16,7 @@ properties:
   prohibited_transitions:
     - sequence: []
       final_heading: forward
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       prohibited_transitions:
         - sequence: []

--- a/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/missing-final-heading.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/missing-final-heading.yaml
@@ -17,7 +17,7 @@ properties:
     - sequence:
         - segment_id: foo
           connector_id: bar
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       prohibited_transitions:
         - sequence:

--- a/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/missing-final-heading.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/missing-final-heading.yaml
@@ -13,6 +13,10 @@ properties:
   class: primary
   connector_ids:
     - overture:transportation:example:connector:1
+  prohibited_transitions:
+    - sequence:
+        - segment_id: foo
+          connector_id: bar
   road:
     restrictions:
       prohibited_transitions:

--- a/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/unsupported-properties.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/unsupported-properties.yaml
@@ -10,6 +10,14 @@ properties:
   class: residential
   version: 1
   update_time: "2024-03-14T08:12:00-08:00"
+  prohibited_transitions:
+    - sequence:
+        - connector_id: connector1
+          segment_id: segment1
+      final_heading: backward
+      foo: bar
+      when:
+        baz: qux
   road:
     restrictions:
       prohibited_transitions:
@@ -23,3 +31,5 @@ properties:
   ext_expected_errors:
     - "[I#/properties/road/restrictions/prohibited_transitions/0/foo] [S#/$defs/propertyDefinitions/road/properties/restrictions/properties/prohibited_transitions/items/unevaluatedProperties] not allowed"
     - "[I#/properties/road/restrictions/prohibited_transitions/0/when/baz] [S#/$defs/propertyDefinitions/road/properties/restrictions/properties/prohibited_transitions/items/properties/when/unevaluatedProperties] not allowed"
+    - "[I#/properties/prohibited_transitions/0/foo] [S#/$defs/propertyDefinitions/restrictions/properties/prohibited_transitions/items/unevaluatedProperties] not allowed"
+    - "[I#/properties/prohibited_transitions/0/when/baz] [S#/$defs/propertyDefinitions/restrictions/properties/prohibited_transitions/items/properties/when/unevaluatedProperties] not allowed"

--- a/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/unsupported-properties.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/unsupported-properties.yaml
@@ -18,7 +18,7 @@ properties:
       foo: bar
       when:
         baz: qux
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       prohibited_transitions:
         - sequence:

--- a/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-empty-rule.json
+++ b/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-empty-rule.json
@@ -12,6 +12,9 @@
     "update_time": "2024-03-14T08:25:53-08:00",
     "subtype": "road",
     "class": "primary",
+    "speed_limits": [
+      {}
+    ],
     "road": {
       "restrictions": {
         "speed_limits": [

--- a/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-invalid-type.json
+++ b/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-invalid-type.json
@@ -12,6 +12,7 @@
     "update_time": "2024-03-14T08:14:05-08:00",
     "subtype": "road",
     "class": "primary",
+    "speed_limits": {},
     "road": {
       "restrictions": {
         "speed_limits": {}

--- a/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-mode.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-mode.yaml
@@ -9,6 +9,7 @@ properties:
   ext_baz: I am a custom user property...
   ext_expected_errors:
     - "[I#/properties/road/restrictions/speed_limits/0/when/mode/0] [S#/$defs/propertyDefinitions/travelMode/enum] value must be one of"
+    - "[I#/properties/speed_limits/0/when/mode/0] [S#/$defs/propertyDefinitions/travelMode/enum] value must be one of"
   # Overture properties
   theme: transportation
   type: segment
@@ -17,6 +18,11 @@ properties:
   subtype: road
   class: secondary
   connector_ids: [fooConnector, barConnector]
+  speed_limits:
+    - max_speed:
+        value: 110
+        unit: mph
+      when: {mode: [foo]}
   road:
     restrictions:
       speed_limits:

--- a/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-mode.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-mode.yaml
@@ -23,7 +23,7 @@ properties:
         value: 110
         unit: mph
       when: {mode: [foo]}
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       speed_limits:
         - max_speed:

--- a/docusaurus/docs/schema/attributes/scoping-rules.mdx
+++ b/docusaurus/docs/schema/attributes/scoping-rules.mdx
@@ -261,21 +261,13 @@ to privately-authorized individuals, such as condo unit owners:
 
 #### Vehicle attributes scoping
 
-<!--
-TODO: Once https://github.com/OvertureMaps/schema-wg/issues/147 is
-      fixed, remove the commenting around the tabs to enable the
-      example, and remove the comments around the access restrictions
-      in the example.
-
 <Tabs>
   <TabItem value="description" label="Description" default>
-
--->
 
 Vehicle attribute scoping limits the scope of a parent value to apply
 only when the vehicle in use meets certain criteria.
 
-The property construct `when: { vehicle: { ... } }` applies vehicle
+The property construct `when: { vehicle: [{ dimension: ..., comparison: ..., value: ... }] }` applies vehicle
 attributes scoping to a parent value.
 
 Note that vehicle attribute scoping can overlap to some degree with
@@ -284,7 +276,6 @@ rules may be scoped to the travel mode "heavy goods vehicle", while
 another equivalent access rule could be scoped to the vehicle attribute
 "gross vehicle weight".
 
-<!--
   </TabItem>
   <TabItem value="example" label="Example" default>
 
@@ -292,8 +283,6 @@ another equivalent access rule could be scoped to the vehicle attribute
 
   </TabItem>
 </Tabs>
-
--->
 
 
 <!--
@@ -384,7 +373,7 @@ properties:
   version: 0
   update_time: "2023-06-16T15:57:00-06:00"
   subtype: road
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     lanes:
       - value:
           - direction: forward

--- a/docusaurus/docs/schema/attributes/transportation/roads.mdx
+++ b/docusaurus/docs/schema/attributes/transportation/roads.mdx
@@ -50,16 +50,16 @@ granularities. For example, a single road segment can represent a:
 
 ### Road class
 
-The `road.class` property of a road specifies its general purpose of use
+The `class` property of a road specifies its general purpose of use
 and its relative importance within the transportation network. The
-`road.class` property also helps establish reasonable default values.
+`class` property also helps establish reasonable default values.
 For example, the class `sidewalk` implies that the default
 [access restrictions](#access-restrictions) for the segment allow access for the [travel mode](/schema/attributes/transportation/travel-modes) `foot` and deny access to all other
-travel modes. Unlike many road segment properties, a road segment's `road.class`
+travel modes. Unlike many road segment properties, a road segment's `class`
 property does not support [geometric scoping](/schema/attributes/scoping-rules#geometric-scoping-linear-referencing) (linear referencing). Consequently whenever a linear range of real-world road makes a class transition (for example, between secondary and residential), the Overture transportation
 [segmentation](/schema/attributes/transportation/shape-connectivity#segmentation) algorithm will generate a segment split.
 
-Every road segment has a class. If the `road.class` property is missing
+Every road segment has a class. If the `class` property is missing
 from a road segment, the default value `unknown` is assumed. The unknown
 road class is meant to be a temporary value until a more specific class
 is known.
@@ -75,25 +75,25 @@ case, it is similar to, but not the same as, OSM's `highway=*` tag.
 
 ### Surface
 
-The `road.surface` property of a road indicates its physical surface. If
+The `road_surface` property of a road indicates its physical surface. If
 omitted, a reasonable default value should be assumed based on the
-`road.class`.
+`class`.
 
-Like many road segment properties, the `road.surface` property supports[geometric scoping](/schema/attributes/scoping-rules#geometric-scoping-linear-referencing)
+Like many road segment properties, the `road_surface` property supports[geometric scoping](/schema/attributes/scoping-rules#geometric-scoping-linear-referencing)
 >>>>>>> ba43714b1e41da1e832b12aaa504a0527dd69d4a
 (linear referencing). Consequently, the effective road surface may vary
 along different sub-ranges of a road segment's geometry.
 
 ### Flags
 
-The `road.flags` property of a road is a set of named flag values
+The `road_flags` property of a road is a set of named flag values
 indicating the presence or absence of simple physical characteristics.
 
 For example, a road segment with
-`road.flags = [is_link, is_under_construction]` is a link segment that is
+`road_flags = [is_link, is_under_construction]` is a link segment that is
 physically under construction.
 
-Like many road segment properties, the `road.flags` property supports [geometric scoping](/schema/attributes/scoping-rules#geometric-scoping-linear-referencing). Consequently, the applicable road flags may vary along different sub-ranges of a road segment's geometry.
+Like many road segment properties, the `road_flags` property supports [geometric scoping](/schema/attributes/scoping-rules#geometric-scoping-linear-referencing). Consequently, the applicable road flags may vary along different sub-ranges of a road segment's geometry.
 
 ## Restrictions
 
@@ -110,7 +110,7 @@ resolve.)
 
 The implied access restrictions may be modified for the road segment as
 a whole by providing an explicit value for the property
-`road.restrictions.access`. (Access restrictions may also be specified
+`access_restrictions`. (Access restrictions may also be specified
 at the level of individual [lanes](#lanes), as explained elsewhere.)
 
 It is technically possible to specify a blanket access grant or refusal
@@ -161,7 +161,7 @@ to the specific application to resolve.)
 Overture Maps takes a permissive-by-default approach to transition
 restrictions. By default, all implied transitions are allowed. The
 set of allowed transitions may be reduced by adding explicit transition
-restrictions in the `road.restrictions.prohibited_transitions` property.
+restrictions in the `prohibited_transitions` property.
 
 Turn restrictions come in two flavors: simple and via: a simple turn
 restriction allows a simple regulation to be stated, such as "No right
@@ -330,7 +330,7 @@ limits.
 
 The implied speed limits may be configured for the whole road segment by
 providing an explicit value for the property
-`road.restrictions.speed_limits`. Note: granular speed limits can also be
+`speed_limits`. Note: granular speed limits can also be
 specified at the level of individual [lanes](#lanes), as explained
 elsewhere.
 
@@ -345,17 +345,6 @@ As with access restrictions and turn restrictions, speed limits can be specified
 
   <TabItem value="speedLimitDirectional" label="Different speed limit for northbound trucks" default>
 
-<!--
-
-TODO: Fix https://github.com/OvertureMaps/schema-wg/issues/155 and the
-      example text, then remove this comment and the below statement
-      about work in progress.
--->
-
-🐞 *There is an open issue with the schema that results in this example
-not being fully functional in the current release. We are working to
-correct it in an upcoming release.* 🐞
-
 <CodeBlock language="yaml">{ ExampleSpeedLimitsDirectional }</CodeBlock>
 
   </TabItem>
@@ -369,12 +358,12 @@ correct it in an upcoming release.* 🐞
 
 ## Lanes
 
-A road may optionally carry a `road.lanes` property which, if present, contains
+A road may optionally carry a `lanes` property which, if present, contains
 a list of rules that can be used to resolve the applicable traffic lane block
 for the road. A lane block is a list of lane objects. Each lane object in the
 block describes the physical structure and properties applicable to one the
 road's traffic lanes at a granularity sufficient to support the navigation use
-case. Note that the `road.lanes` property applies to traffic lanes, not to
+case. Note that the `lanes` property applies to traffic lanes, not to
 parking lanes.
 
 ### Use cases for lanes
@@ -387,8 +376,8 @@ granular turn-by-turn or maneuver-by-maneuver navigation applications.
 
 ### Default lane structure
 
-If the `road.lanes` property is omitted from a road segment, reasonable
-default values should be assumed based on `road.class` and the
+If the `lanes` property is omitted from a road segment, reasonable
+default values should be assumed based on `class` and the
 road-level [access restrictions](#access-restrictions). For example, for
 a stock two-way road segment of class `primary` with no heading-scoped
 access restrictions, a reasonable assumption is two lanes, one
@@ -556,7 +545,7 @@ to release soon.
 The traffic lane structure of a road segment can be different at different
 points along the segment, or at different times of the day, or both.
 Consequently, instead of having a static lane block, road segments carry a list of lane block [rules](/schema/attributes/scoping-rules#rules-and-rule-based-properties)
-in the optional `road.lanes`  property.
+in the optional `lanes`  property.
 
 - A rule may be scoped [geometrically](/schema/attributes/scoping-rules#geometric-scoping-linear-referencing),
 which allows linear referencing to be used to specify the portion of the

--- a/docusaurus/docs/schema/attributes/transportation/roads.mdx
+++ b/docusaurus/docs/schema/attributes/transportation/roads.mdx
@@ -30,7 +30,7 @@ import ExampleTurnRestriction2Connector1 from '!!raw-loader!@site/docs/_examples
 import ExampleTurnRestriction2Connector2 from '!!raw-loader!@site/docs/_examples/transportation/docusaurus/turn-restriction-02-connector2.yaml';
 
 In the Overture Maps `transportation` theme, a road is any kind of road,
-street or path, including a dedicated path for walking or cycling, but excluding a railway. Road segments comprise the majority of ground-based transportation segments. Roads are modeled using[segment](/schema/reference/transportation/segment) features with the `subtype` property value set to the value `road`.
+street or path, including a dedicated path for walking or cycling, but excluding a railway. Road segments comprise the majority of ground-based transportation segments. Roads are modeled using [segment](/schema/reference/transportation/segment) features with the `subtype` property value set to the value `road`.
 
 ## Geometry and granularity
 
@@ -40,7 +40,7 @@ road being modeled. Road segments support modeling the road network at a range o
 granularities. For example, a single road segment can represent a:
 
 - bidirectional street including all of its lanes and sidewalks.
-- sidewalk by itself. (🚧 Note: the pedestrian model is under construction.)
+- sidewalk by itself.
 - one-way street or one direction of a dual carriageway.
 - single lane or single section of a multi-lane highway.
 - dedicated cycleway.
@@ -79,14 +79,12 @@ The `road_surface` property of a road indicates its physical surface. If
 omitted, a reasonable default value should be assumed based on the
 `class`.
 
-Like many road segment properties, the `road_surface` property supports[geometric scoping](/schema/attributes/scoping-rules#geometric-scoping-linear-referencing)
->>>>>>> ba43714b1e41da1e832b12aaa504a0527dd69d4a
-(linear referencing). Consequently, the effective road surface may vary
+Like many road segment properties, the `road_surface` property supports [geometric scoping](/schema/attributes/scoping-rules#geometric-scoping-linear-referencing) (linear referencing). Consequently, the effective road surface may vary
 along different sub-ranges of a road segment's geometry.
 
 ### Flags
 
-The `road_flags` property of a road is a set of named flag values
+The `road_flags` property of a segment is a set of named flag values
 indicating the presence or absence of simple physical characteristics.
 
 For example, a road segment with

--- a/docusaurus/docs/schema/attributes/transportation/travel-modes.mdx
+++ b/docusaurus/docs/schema/attributes/transportation/travel-modes.mdx
@@ -75,7 +75,7 @@ Our criteria for recognizing a proposed new travel mode are:
    *intersects* with, other similar travel modes which are already
    recognized in the Overture schema.
 - the proposed new travel mode should preferably not be trivially
-   expressible using another existing [scoping property](/schema/attributes/scoping-rules#scoped-values-and-scoping-properties).(*An example of such a trivially-expressible concept might be a three-axle vehicle which is more appropriately phrased as `vehicle: { axle_count: { is_equal_to: 3 } }`.*)
+   expressible using another existing [scoping property](/schema/attributes/scoping-rules#scoped-values-and-scoping-properties).(*An example of such a trivially-expressible concept might be a three-axle vehicle which is more appropriately phrased as `vehicle: [{dimension: axle_count, comparison: equal_to, value: 3}]`.*)
 - the proposed new travel mode must be supported by existing data in at
    least one of Overture's upstream data sources.
 

--- a/examples/transportation/docusaurus/access-restriction-01-blanket.yaml
+++ b/examples/transportation/docusaurus/access-restriction-01-blanket.yaml
@@ -13,6 +13,8 @@ properties:
   update_time: "2024-03-13T16:34:44-08:00"
   subtype: road
   class: residential
+  access_restrictions:
+    - access_type: denied
   road:
     restrictions:
       access:

--- a/examples/transportation/docusaurus/access-restriction-01-blanket.yaml
+++ b/examples/transportation/docusaurus/access-restriction-01-blanket.yaml
@@ -15,7 +15,7 @@ properties:
   class: residential
   access_restrictions:
     - access_type: denied
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/docusaurus/access-restriction-02-private-with-deliveries.yaml
+++ b/examples/transportation/docusaurus/access-restriction-02-private-with-deliveries.yaml
@@ -13,6 +13,14 @@ properties:
   update_time: "2024-03-14T16:32:53-08:00"
   subtype: road
   class: residential
+  access_restrictions:
+    - access_type: denied
+    - access_type: allowed
+      when: { recognized: [as_private] }
+    - access_type: allowed
+      when:
+        using: [to_deliver]
+        during: Mo-Fr 08:30-16:30
   road:
     restrictions:
       access:

--- a/examples/transportation/docusaurus/access-restriction-02-private-with-deliveries.yaml
+++ b/examples/transportation/docusaurus/access-restriction-02-private-with-deliveries.yaml
@@ -21,7 +21,7 @@ properties:
       when:
         using: [to_deliver]
         during: Mo-Fr 08:30-16:30
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
+++ b/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
@@ -13,6 +13,11 @@ properties:
   update_time: "2024-03-13T16:34:51-08:00"
   subtype: road
   class: residential
+  access_restrictions:
+    - access_type: denied
+      when: { mode: [motor_vehicle] }
+    - access_type: allowed
+      when: { using: [at_destination] }
   road:
     restrictions:
       access:

--- a/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
+++ b/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
@@ -18,7 +18,7 @@ properties:
       when: { mode: [motor_vehicle] }
     - access_type: allowed
       when: { using: [at_destination] }
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/docusaurus/access-restriction-04-axle-limit.yaml
+++ b/examples/transportation/docusaurus/access-restriction-04-axle-limit.yaml
@@ -21,7 +21,7 @@ properties:
           - dimension: axle_count
             comparison: greater_than_equal
             value: 5
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/docusaurus/access-restriction-04-axle-limit.yaml
+++ b/examples/transportation/docusaurus/access-restriction-04-axle-limit.yaml
@@ -13,10 +13,21 @@ properties:
   update_time: "2024-03-13T16:35:17-08:00"
   subtype: road
   class: motorway
+  access_restrictions:
+    - access_type: denied
+      when:
+        mode: [hgv]
+        vehicle:
+          - dimension: axle_count
+            comparison: greater_than_equal
+            value: 5
   road:
     restrictions:
       access:
         - access_type: denied
           when:
             mode: [hgv]
-            vehicle: { axle_count: { is_at_least: 5 } }
+            vehicle:
+              - dimension: axle_count
+                comparison: greater_than_equal
+                value: 5

--- a/examples/transportation/docusaurus/access-restriction.yaml
+++ b/examples/transportation/docusaurus/access-restriction.yaml
@@ -25,7 +25,7 @@ properties:
   access_restrictions:
     - access_type: denied
       when: {mode: [foot]}
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     surface:
       - value: paved
     restrictions:

--- a/examples/transportation/docusaurus/access-restriction.yaml
+++ b/examples/transportation/docusaurus/access-restriction.yaml
@@ -22,6 +22,9 @@ properties:
     - overture:transportation:example:simple-road-connector-2
   names:
     primary: SR 520
+  access_restrictions:
+    - access_type: denied
+      when: {mode: [foot]}
   road:
     surface:
       - value: paved

--- a/examples/transportation/docusaurus/geometric-scoping.yaml
+++ b/examples/transportation/docusaurus/geometric-scoping.yaml
@@ -20,7 +20,7 @@ properties:
       max_speed:
         value: 60
         unit: km/h
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       speed_limits:
         - between: [0, 0.15]

--- a/examples/transportation/docusaurus/geometric-scoping.yaml
+++ b/examples/transportation/docusaurus/geometric-scoping.yaml
@@ -11,6 +11,15 @@ properties:
   update_time: "2024-03-13T16:35:37-08:00"
   subtype: road
   class: primary
+  speed_limits:
+    - between: [0, 0.15]
+      max_speed:
+        value: 100
+        unit: km/h
+    - between: [0.15, 1]
+      max_speed:
+        value: 60
+        unit: km/h
   road:
     restrictions:
       speed_limits:

--- a/examples/transportation/docusaurus/lanes-absolute-form.yaml
+++ b/examples/transportation/docusaurus/lanes-absolute-form.yaml
@@ -17,7 +17,7 @@ properties:
     - value:
       - direction: backward
       - direction: forward
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     lanes:
       - value:
         - direction: backward

--- a/examples/transportation/docusaurus/lanes-absolute-form.yaml
+++ b/examples/transportation/docusaurus/lanes-absolute-form.yaml
@@ -13,6 +13,10 @@ properties:
   update_time: "2024-03-13T16:35:47-08:00"
   subtype: road
   class: secondary
+  lanes:
+    - value:
+      - direction: backward
+      - direction: forward
   road:
     lanes:
       - value:

--- a/examples/transportation/docusaurus/lanes-hov.yaml
+++ b/examples/transportation/docusaurus/lanes-hov.yaml
@@ -15,6 +15,31 @@ properties:
   update_time: "2024-03-13T16:35:53-08:00"
   version: 2
   class: secondary
+  lanes:
+      # one-way road with access and speed limit restrictions
+      # digitization: S->N
+      # |   |   |   |
+      # |   |   |   | => max speeds: 100 km/h for whole segment
+      # | h |   |   |    but on lane 2 is limited to 80 km/h for hgv vehicles
+      # | o |   |   |
+      # | v |   |   |
+      # |   |   |   |
+      # | 0 | 1 | 2 |
+      - value:
+        - direction: forward # lane 0 -> hov only
+          restrictions:
+           access:
+             - access_type: allowed
+               when:
+                 mode:
+                   - hov
+           min_occupancy: 3
+        - direction: forward # lane 1
+        - direction: forward # lane 2
+  speed_limits:
+    - max_speed:
+        value: 100
+        unit: km/h
   road:
     restrictions:
       speed_limits:

--- a/examples/transportation/docusaurus/lanes-hov.yaml
+++ b/examples/transportation/docusaurus/lanes-hov.yaml
@@ -40,7 +40,7 @@ properties:
     - max_speed:
         value: 100
         unit: km/h
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       speed_limits:
         - max_speed:

--- a/examples/transportation/docusaurus/lanes-resolution-segment-01.yaml
+++ b/examples/transportation/docusaurus/lanes-resolution-segment-01.yaml
@@ -24,7 +24,7 @@ properties:
       value:
         - direction: backward
         - direction: forward
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     lanes: # A list of two geometrically-scoped rules for resolving the lane block.
       - between: [0, 0.67]
         value:

--- a/examples/transportation/docusaurus/lanes-resolution-segment-01.yaml
+++ b/examples/transportation/docusaurus/lanes-resolution-segment-01.yaml
@@ -14,6 +14,16 @@ properties:
   connector_ids: [lanes-resolution-example-connector]
   subtype: road
   class: motorway
+  lanes: # A list of two geometrically-scoped rules for resolving the lane block.
+    - between: [0, 0.67]
+      value:
+        - direction: backward
+        - direction: forward
+        - direction: forward
+    - between: [0.67, 1]
+      value:
+        - direction: backward
+        - direction: forward
   road:
     lanes: # A list of two geometrically-scoped rules for resolving the lane block.
       - between: [0, 0.67]

--- a/examples/transportation/docusaurus/lanes-resolution-segment-02.yaml
+++ b/examples/transportation/docusaurus/lanes-resolution-segment-02.yaml
@@ -18,7 +18,7 @@ properties:
     - value:  # A lane block rule containing one globally-applicable lane block.
       - direction: forward
       - direction: backward
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     lanes:
       - value:  # A lane block rule containing one globally-applicable lane block.
         - direction: forward

--- a/examples/transportation/docusaurus/lanes-resolution-segment-02.yaml
+++ b/examples/transportation/docusaurus/lanes-resolution-segment-02.yaml
@@ -14,6 +14,10 @@ properties:
   connector_ids: [lanes-resolution-example-connector]
   subtype: road
   class: motorway
+  lanes:
+    - value:  # A lane block rule containing one globally-applicable lane block.
+      - direction: forward
+      - direction: backward
   road:
     lanes:
       - value:  # A lane block rule containing one globally-applicable lane block.

--- a/examples/transportation/docusaurus/lanes-rule-form.yaml
+++ b/examples/transportation/docusaurus/lanes-rule-form.yaml
@@ -15,6 +15,16 @@ properties:
   update_time: "2024-03-15T09:35:16-08:00"
   subtype: road
   class: primary
+  lanes:
+    - value:
+        - direction: forward
+        - direction: forward
+    - when: {during: Mo-Fr 15:00-18:00}
+      value:
+        - direction: forward
+        - direction: forward
+        - direction: forward
+        - direction: forward
   road:
     lanes:
       - value:

--- a/examples/transportation/docusaurus/lanes-rule-form.yaml
+++ b/examples/transportation/docusaurus/lanes-rule-form.yaml
@@ -25,7 +25,7 @@ properties:
         - direction: forward
         - direction: forward
         - direction: forward
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     lanes:
       - value:
           - direction: forward

--- a/examples/transportation/docusaurus/simple-road.yaml
+++ b/examples/transportation/docusaurus/simple-road.yaml
@@ -25,7 +25,7 @@ properties:
       - direction: forward
   road_surface:
     - value: paved
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     surface:
       - value: paved
     lanes:

--- a/examples/transportation/docusaurus/simple-road.yaml
+++ b/examples/transportation/docusaurus/simple-road.yaml
@@ -19,6 +19,12 @@ properties:
     - overture:transportation:example:simple-road-connector-2
   names:
     primary: Nicola Street
+  lanes:
+    - value:
+      - direction: backward
+      - direction: forward
+  road_surface:
+    - value: paved
   road:
     surface:
       - value: paved

--- a/examples/transportation/docusaurus/speed-limits-01-simple.yaml
+++ b/examples/transportation/docusaurus/speed-limits-01-simple.yaml
@@ -13,6 +13,10 @@ properties:
   update_time: "2024-03-13T16:36:53-08:00"
   subtype: road
   class: residential
+  speed_limits:
+    - max_speed:
+        value: 30
+        unit: km/h
   road:
     restrictions:
       speed_limits:

--- a/examples/transportation/docusaurus/speed-limits-01-simple.yaml
+++ b/examples/transportation/docusaurus/speed-limits-01-simple.yaml
@@ -17,7 +17,7 @@ properties:
     - max_speed:
         value: 30
         unit: km/h
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       speed_limits:
         - max_speed:

--- a/examples/transportation/docusaurus/speed-limits-02-directional.yaml
+++ b/examples/transportation/docusaurus/speed-limits-02-directional.yaml
@@ -13,6 +13,12 @@ properties:
   update_time: "2024-03-13T16:36:56-08:00"
   subtype: road
   class: secondary
+  speed_limits:
+    - max_speed: {value: 70, unit: "mph"}
+    - when:
+        mode: [hgv]
+        heading: forward
+      max_speed: {value: 65, unit: "mph"}
   road:
     restrictions:
       speed_limits:

--- a/examples/transportation/docusaurus/speed-limits-02-directional.yaml
+++ b/examples/transportation/docusaurus/speed-limits-02-directional.yaml
@@ -19,7 +19,7 @@ properties:
         mode: [hgv]
         heading: forward
       max_speed: {value: 65, unit: "mph"}
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       speed_limits:
         - max_speed: {value: 70, unit: "mph"}

--- a/examples/transportation/docusaurus/speed-limits-03-variable-max.yaml
+++ b/examples/transportation/docusaurus/speed-limits-03-variable-max.yaml
@@ -20,7 +20,7 @@ properties:
         value: 100
         unit: km/h
       is_max_speed_variable: true
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       speed_limits:
         - max_speed:

--- a/examples/transportation/docusaurus/speed-limits-03-variable-max.yaml
+++ b/examples/transportation/docusaurus/speed-limits-03-variable-max.yaml
@@ -15,6 +15,11 @@ properties:
   update_time: "2024-03-13T16:36:57-08:00"
   subtype: road
   class: motorway
+  speed_limits:
+    - max_speed:
+        value: 100
+        unit: km/h
+      is_max_speed_variable: true
   road:
     restrictions:
       speed_limits:

--- a/examples/transportation/docusaurus/subjective-heading-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-heading-scoping.yaml
@@ -17,6 +17,13 @@ properties:
   update_time: "2024-03-13T16:37:21-08:00"
   subtype: road
   class: primary
+  access_restrictions:
+    - access_type: denied
+      when: { heading: backward }
+    - access_type: allowed
+      when:
+        heading: backward
+        mode: [bus]
   road:
     restrictions:
       access:

--- a/examples/transportation/docusaurus/subjective-heading-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-heading-scoping.yaml
@@ -24,7 +24,7 @@ properties:
       when:
         heading: backward
         mode: [bus]
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/docusaurus/subjective-status-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-status-scoping.yaml
@@ -18,7 +18,7 @@ properties:
     - access_type: denied
     - access_type: allowed
       when: { recognized: [as_private] }
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/docusaurus/subjective-status-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-status-scoping.yaml
@@ -14,6 +14,10 @@ properties:
   update_time: "2024-03-13T16:33:10-08:00"
   subtype: road
   class: tertiary
+  access_restrictions:
+    - access_type: denied
+    - access_type: allowed
+      when: { recognized: [as_private] }
   road:
     restrictions:
       access:

--- a/examples/transportation/docusaurus/subjective-usage-purpose-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-usage-purpose-scoping.yaml
@@ -13,6 +13,10 @@ properties:
   update_time: "2024-03-13T16:33:12-08:00"
   subtype: road
   class: tertiary
+  access_restrictions:
+    - access_type: denied
+    - access_type: allowed
+      when: { using: [as_customer, at_destination] }
   road:
     restrictions:
       access:

--- a/examples/transportation/docusaurus/subjective-usage-purpose-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-usage-purpose-scoping.yaml
@@ -17,7 +17,7 @@ properties:
     - access_type: denied
     - access_type: allowed
       when: { using: [as_customer, at_destination] }
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/docusaurus/subjective-vehicle-attributes-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-vehicle-attributes-scoping.yaml
@@ -14,8 +14,21 @@ properties:
   update_time: "2024-03-13T16:33:14-08:00"
   subtype: road
   class: residential
+  access_restrictions:
+    - access_type: denied
+      when:
+        vehicle:
+          - dimension: weight
+            comparison: greater_than
+            value: 23
+            unit: 't'
   road:
     restrictions:
       access:
         - access_type: denied
-          when: { vehicle: { weight: { is_more_than: { value: 23, unit: 't' } } } }
+          when:
+            vehicle:
+              - dimension: weight
+                comparison: greater_than
+                value: 23
+                unit: 't'

--- a/examples/transportation/docusaurus/subjective-vehicle-attributes-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-vehicle-attributes-scoping.yaml
@@ -22,7 +22,7 @@ properties:
             comparison: greater_than
             value: 23
             unit: 't'
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/docusaurus/temporal-scoping.yaml
+++ b/examples/transportation/docusaurus/temporal-scoping.yaml
@@ -14,6 +14,11 @@ properties:
   update_time: "2024-03-14T16:33:07-08:00"
   subtype: road
   class: unknown
+  access_restrictions:
+    - access_type: denied
+      when:
+        mode: [bus]
+        during: "Mo-Fr 15:00-18:00"
   road:
     restrictions:
       access:

--- a/examples/transportation/docusaurus/temporal-scoping.yaml
+++ b/examples/transportation/docusaurus/temporal-scoping.yaml
@@ -19,7 +19,7 @@ properties:
       when:
         mode: [bus]
         during: "Mo-Fr 15:00-18:00"
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/docusaurus/turn-restriction-01-source.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-01-source.yaml
@@ -23,7 +23,7 @@ properties:
           connector_id: overture:transportation:example:simple-turn-restriction-connector2
         final_heading: forward
         when: {heading: forward}
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       prohibited_transitions:
          - sequence:

--- a/examples/transportation/docusaurus/turn-restriction-01-source.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-01-source.yaml
@@ -17,6 +17,12 @@ properties:
   connector_ids:
     - overture:transportation:example:simple-turn-restriction-connector1
     - overture:transportation:example:simple-turn-restriction-connector2
+  prohibited_transitions:
+      - sequence:
+        - segment_id: overture:transportation:example:simple-turn-restriction-target
+          connector_id: overture:transportation:example:simple-turn-restriction-connector2
+        final_heading: forward
+        when: {heading: forward}
   road:
     restrictions:
       prohibited_transitions:

--- a/examples/transportation/docusaurus/turn-restriction-02-source.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-source.yaml
@@ -24,6 +24,18 @@ properties:
     - overture:transportation:example:via-turn-restriction-connector1
   names:
     primary: Arborway
+  prohibited_transitions:
+    - sequence:
+        - segment_id: overture:transportation:example:via-turn-restriction-target
+          connector_id: overture:transportation:example:via-turn-restriction-connector2
+        - segment_id: overture:transportation:example:via-turn-restriction-via
+          connector_id: overture:transportation:example:via-turn-restriction-connector1
+      final_heading: forward
+      when:
+        heading: forward
+        during: Mo-Fr 06:00-09:00, 15:00-19:00
+  road_surface:
+    - value: paved
   road:
     surface:
       - value: paved

--- a/examples/transportation/docusaurus/turn-restriction-02-source.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-source.yaml
@@ -36,7 +36,7 @@ properties:
         during: Mo-Fr 06:00-09:00, 15:00-19:00
   road_surface:
     - value: paved
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     surface:
       - value: paved
     restrictions:

--- a/examples/transportation/docusaurus/turn-restriction-02-target.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-target.yaml
@@ -22,6 +22,8 @@ properties:
     - overture:transportation:example:via-turn-restriction-connector2
   names:
     primary: Arborway
+  road_surface:
+    - value: paved
   road:
     surface:
       - value: paved

--- a/examples/transportation/docusaurus/turn-restriction-02-target.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-target.yaml
@@ -24,6 +24,6 @@ properties:
     primary: Arborway
   road_surface:
     - value: paved
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     surface:
       - value: paved

--- a/examples/transportation/docusaurus/turn-restriction-02-via.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-via.yaml
@@ -22,6 +22,6 @@ properties:
     primary: Washington Street
   road_surface:
     - value: paved
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     surface:
       - value: paved

--- a/examples/transportation/docusaurus/turn-restriction-02-via.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-via.yaml
@@ -20,6 +20,8 @@ properties:
     - overture:transportation:example:via-turn-restriction-connector2
   names:
     primary: Washington Street
+  road_surface:
+    - value: paved
   road:
     surface:
       - value: paved

--- a/examples/transportation/segment/road/lanes/lanes-flow-alternating.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-flow-alternating.yaml
@@ -12,6 +12,13 @@ properties:
   subtype: road
   class: primary
   connector_ids: [fooConnector, barConnector]
+  road_surface:
+    - value: paved
+  lanes:
+    - value:
+        # This models a single-lane road whose direction alternates
+        # on a regular rhythm (by default instructed by signals).
+        - direction: alternating
   road:
     surface:
       - value: paved

--- a/examples/transportation/segment/road/lanes/lanes-flow-alternating.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-flow-alternating.yaml
@@ -19,7 +19,7 @@ properties:
         # This models a single-lane road whose direction alternates
         # on a regular rhythm (by default instructed by signals).
         - direction: alternating
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     surface:
       - value: paved
     lanes:

--- a/examples/transportation/segment/road/lanes/lanes-flow-reversible.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-flow-reversible.yaml
@@ -12,6 +12,23 @@ properties:
   subtype: road
   class: primary
   connector_ids: [fooConnector, barConnector]
+  road_surface:
+    - value: paved
+  lanes:
+    - value:
+        # This models a single-lane road whose direction is
+        # completely reversible at arbitrary times.
+      - direction: reversible
+        restrictions:
+          access:
+            - access_type: allowed
+              when:
+                heading: forward
+                during: Mo-Su 00:00-12:00
+            - access_type: allowed
+              when:
+                heading: backward
+                during: Mo-Su 12:00-24:00
   road:
     surface:
       - value: paved

--- a/examples/transportation/segment/road/lanes/lanes-flow-reversible.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-flow-reversible.yaml
@@ -29,7 +29,7 @@ properties:
               when:
                 heading: backward
                 during: Mo-Su 12:00-24:00
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     surface:
       - value: paved
     lanes:

--- a/examples/transportation/segment/road/lanes/lanes-on-straight-road-lr.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-on-straight-road-lr.yaml
@@ -12,6 +12,37 @@ properties:
   class: primary
   update_time: "2024-03-13T16:19:03-08:00"
   version: 1
+  lanes:
+    # Example shows modelling of new lane being introduced on a straight road which is a single segment
+    # whole lanes attribute is represented in LR way to keep LR referencing in root level of modeled attribute.
+    #
+    #    |0|1|
+    #    | |  \
+    #    | | | |
+    #    |0|1|2|
+    #    | | | |
+    #    | |  /
+    #    |0|1|
+    # digitization: S -> N
+    - between: # two lanes between <0% and 10%) of segment
+        - 0
+        - 0.1
+      value:
+        - direction: forward # lane 0
+        - direction: forward # lane 1
+    - between: # three lanes between <10% and 70%) of segment
+        - 0.1
+        - 0.7
+      value:
+        - direction: forward
+        - direction: forward
+        - direction: forward
+    - between: # two lanes again between <70% and 100%> of segment
+        - 0.7
+        - 1
+      value:
+        - direction: forward
+        - direction: forward
   road:
     lanes:
       # Example shows modelling of new lane being introduced on a straight road which is a single segment

--- a/examples/transportation/segment/road/lanes/lanes-on-straight-road-lr.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-on-straight-road-lr.yaml
@@ -43,7 +43,7 @@ properties:
       value:
         - direction: forward
         - direction: forward
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     lanes:
       # Example shows modelling of new lane being introduced on a straight road which is a single segment
       # whole lanes attribute is represented in LR way to keep LR referencing in root level of modeled attribute.

--- a/examples/transportation/segment/road/lanes/lanes-temporal.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-temporal.yaml
@@ -11,6 +11,12 @@ properties:
   class: living_street
   version: 1
   update_time: "2024-03-14T16:34:01-08:00"
+  lanes:
+    - value:
+        - direction: forward
+        - direction: backward
+      when:
+        during: "Mo-Fr 08:00-18:00"
   road:
     lanes:
       - value:

--- a/examples/transportation/segment/road/lanes/lanes-temporal.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-temporal.yaml
@@ -17,7 +17,7 @@ properties:
         - direction: backward
       when:
         during: "Mo-Fr 08:00-18:00"
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     lanes:
       - value:
           - direction: forward

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-access-for-travel-modes.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-access-for-travel-modes.yaml
@@ -11,6 +11,39 @@ properties:
   class: secondary
   update_time: "2024-03-13T16:21:30-08:00"
   version: 2
+  lanes:
+    - value:
+      # two-way road with access restrictions for specific travel modes
+      # digitization: S->N
+      # |   ||   |   |   |
+      # |   ||   |   |   |
+      # |   ||   |   |   |
+      # |   ||   |   |   |
+      # |   ||   |   |   |
+      # | 0 || 1 | 2 | 3 |
+      - direction: backward # lane 0 not allowed for trucks (heavy good vehicles)
+        restrictions:
+          access:
+            - access_type: denied
+              when:
+                mode:
+                  - hgv
+      - direction: forward # lane 1
+      - direction: forward # lane 2 not allowed for buses and trucks
+        restrictions:
+          access:
+            - access_type: denied
+              when:
+                mode:
+                  - hgv
+                  - bus
+      - direction: forward # lane 3 - allowed only for bicycles
+        restrictions:
+          access:
+            - access_type: allowed
+              when:
+                mode:
+                  - bicycle
   road:
     lanes:
       - value:

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-access-for-travel-modes.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-access-for-travel-modes.yaml
@@ -44,7 +44,7 @@ properties:
               when:
                 mode:
                   - bicycle
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     lanes:
       - value:
         # two-way road with access restrictions for specific travel modes

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-access-with-lr.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-access-with-lr.yaml
@@ -11,6 +11,26 @@ properties:
   class: secondary
   update_time: "2024-03-13T16:21:45-08:00"
   version: 2
+  lanes:
+    - value:
+      # two-way road with access restrictions for specific travel modes
+      # digitization: S->N
+      # |   ||   |   |
+      # |   ||   |   |
+      # |   ||   |   | <- from that moment lane 2 starts to be a bus only lane
+      # |   ||   |   |
+      # |   ||   |   |
+      # | 0 || 1 | 2 |
+      - direction: backward # lane 0
+      - direction: forward # lane 1
+      - direction: forward # lane 2 from its 60% of length (till the end) it is allowed only for buses (before 60% mark it is available for all vehicles)
+        restrictions:
+          access:
+            - access_type: allowed
+              when:
+                mode:
+                  - bus
+              between: [0.6, 1]
   road:
     lanes:
       - value:

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-access-with-lr.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-access-with-lr.yaml
@@ -31,7 +31,7 @@ properties:
                 mode:
                   - bus
               between: [0.6, 1]
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     lanes:
       - value:
         # two-way road with access restrictions for specific travel modes

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-hov-occupancy-scoped.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-hov-occupancy-scoped.yaml
@@ -11,6 +11,32 @@ properties:
   class: secondary
   update_time: "2024-03-13T16:21:56-08:00"
   version: 2
+  speed_limits:
+    - max_speed:
+        value: 100
+        unit: km/h
+  lanes:
+    - value:
+      # one-way road with access and speed limit restrictions
+      # digitization: S->N
+      # |   |   |   |
+      # |   |   |   | => max speeds: 100 km/h for whole segment
+      # | h |   |   |    but on lane 2 is limited to 80 km/h for hgv vehicles
+      # | o |   |   |
+      # | v |   |   |
+      # |   |   |   |
+      # | 0 | 1 | 2 |
+      - direction: forward # lane 0 -> hov only that allows also bicycles
+        restrictions:
+          access:
+            - access_type: allowed
+              when:
+                mode:
+                  - hov
+                  - bicycle
+          min_occupancy: 3
+      - direction: forward # lane 1
+      - direction: forward # lane 2
   road:
     restrictions:
       speed_limits:

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-hov-occupancy-scoped.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-hov-occupancy-scoped.yaml
@@ -37,7 +37,7 @@ properties:
           min_occupancy: 3
       - direction: forward # lane 1
       - direction: forward # lane 2
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       speed_limits:
         - max_speed:

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-hov.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-hov.yaml
@@ -36,7 +36,7 @@ properties:
           min_occupancy: 3
       - direction: forward # lane 1
       - direction: forward # lane 2
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       speed_limits:
         - max_speed:

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-hov.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-hov.yaml
@@ -11,6 +11,31 @@ properties:
   class: secondary
   update_time: "2024-03-13T16:21:50-08:00"
   version: 2
+  speed_limits:
+    - max_speed:
+        value: 100
+        unit: km/h
+  lanes:
+    - value:
+      # one-way road with access and speed limit restrictions
+      # digitization: S->N
+      # |   |   |   |
+      # |   |   |   | => max speeds: 100 km/h for whole segment
+      # | h |   |   |    but on lane 2 is limited to 80 km/h for hgv vehicles
+      # | o |   |   |
+      # | v |   |   |
+      # |   |   |   |
+      # | 0 | 1 | 2 |
+      - direction: forward # lane 0 -> hov only
+        restrictions:
+          access:
+            - access_type: allowed
+              when:
+                mode:
+                  - hov
+          min_occupancy: 3
+      - direction: forward # lane 1
+      - direction: forward # lane 2
   road:
     restrictions:
       speed_limits:

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-speed-limits.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-speed-limits.yaml
@@ -50,7 +50,7 @@ properties:
                 unit: km/h
               when:
                 mode: [hgv]
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       speed_limits:
         - max_speed:

--- a/examples/transportation/segment/road/lanes/restrictions/lanes-speed-limits.yaml
+++ b/examples/transportation/segment/road/lanes/restrictions/lanes-speed-limits.yaml
@@ -11,6 +11,45 @@ properties:
   class: secondary
   update_time: "2024-03-13T16:21:59-08:00"
   version: 2
+  speed_limits:
+    - max_speed:
+        value: 100
+        unit: km/h
+  lanes:
+    - value:
+      # two-way road with access and speed limit restrictions
+      # digitization: S->N
+      # |   ||   |   |
+      # |   ||   |   | => max speeds: 100 km/h for whole segment
+      # |   ||   |   |    but on lane 2 is limited to 80 km/h for hgv vehicles
+      # |   ||   |   |
+      # |   ||   |   |
+      # | 0 || 1 | 2 |
+      - direction: backward # no restriction -> lane available for all vehicles and all can drive with maximum speed 100 km/h
+      - direction: forward # lane 1  -> hgv vehicles cannot use that lane
+        restrictions:
+          access:
+            - access_type: denied
+              when:
+                mode: [hgv]
+      - direction: forward # lane 2 - available for all vehicles except hgv vehicles if their weight is more than 3 tons, and they must limit their speed to 80 km/h
+        # for all other vehicles segment speed limit (100 km/h) applies
+        restrictions:
+          access:
+            - access_type: denied
+              when:
+                mode: [hgv]
+                vehicle:
+                  - dimension: weight
+                    comparison: greater_than
+                    value: 3
+                    unit: 't'
+          speed_limits:
+            - max_speed:
+                value: 80
+                unit: km/h
+              when:
+                mode: [hgv]
   road:
     restrictions:
       speed_limits:
@@ -42,8 +81,10 @@ properties:
                 when:
                   mode: [hgv]
                   vehicle:
-                    weight:
-                      is_more_than: { value: 3, unit: 't'}
+                    - dimension: weight
+                      comparison: greater_than
+                      value: 3
+                      unit: 't'
             speed_limits:
               - max_speed:
                   value: 80

--- a/examples/transportation/segment/road/restrictions/road-restrictions-access.yaml
+++ b/examples/transportation/segment/road/restrictions/road-restrictions-access.yaml
@@ -66,7 +66,7 @@ properties:
             comparison: less_than
             value: 12
             unit: 'ft'
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/segment/road/restrictions/road-restrictions-access.yaml
+++ b/examples/transportation/segment/road/restrictions/road-restrictions-access.yaml
@@ -11,6 +11,61 @@ properties:
   class: primary
   version: 2
   update_time: "2024-03-16T16:23:20-08:00"
+  access_restrictions:
+    - access_type: denied
+      between: [ 0, 0.5 ]
+    - access_type: denied
+      when:
+        during: PH
+    - access_type: denied
+      when: {heading: forward}
+    - access_type: allowed
+      when:
+        heading: forward
+        mode: [vehicle]
+    - access_type: allowed
+      when:
+        heading: forward
+        using: [at_destination]
+    - access_type: allowed
+      when:
+        heading: forward
+        recognized: [as_employee]
+    - access_type: allowed
+      when:
+        heading: forward
+        vehicle:
+          - dimension: axle_count
+            comparison: less_than
+            value: 3
+          - dimension: weight
+            comparison: less_than_equal
+            value: 600
+            unit: 'kg'
+          - dimension: height
+            comparison: less_than
+            value: 12
+            unit: 'ft'
+    - access_type: denied
+      between: [0.25, 0.5]
+      when:
+        heading: forward
+        during: PH
+        mode: [car, hgv]
+        using: [at_destination]
+        recognized: [as_employee]
+        vehicle:
+          - dimension: axle_count
+            comparison: less_than
+            value: 3
+          - dimension: weight
+            comparison: less_than_equal
+            value: 600
+            unit: 'kg'
+          - dimension: height
+            comparison: less_than
+            value: 12
+            unit: 'ft'
   road:
     restrictions:
       access:
@@ -37,9 +92,17 @@ properties:
           when:
             heading: forward
             vehicle:
-              axle_count: {is_less_than: 3}
-              weight: {is_at_most: {value: 600, unit: 'kg'}}
-              height: {is_less_than: {value: 12, unit: 'ft'}}
+              - dimension: axle_count
+                comparison: less_than
+                value: 3
+              - dimension: weight
+                comparison: less_than_equal
+                value: 600
+                unit: 'kg'
+              - dimension: height
+                comparison: less_than
+                value: 12
+                unit: 'ft'
         - access_type: denied
           between: [0.25, 0.5]
           when:
@@ -49,6 +112,14 @@ properties:
             using: [at_destination]
             recognized: [as_employee]
             vehicle:
-              axle_count: { is_less_than: 3 }
-              weight: { is_at_most: { value: 600, unit: 'kg' } }
-              height: { is_less_than: { value: 12, unit: 'ft' } }
+              - dimension: axle_count
+                comparison: less_than
+                value: 3
+              - dimension: weight
+                comparison: less_than_equal
+                value: 600
+                unit: 'kg'
+              - dimension: height
+                comparison: less_than
+                value: 12
+                unit: 'ft'

--- a/examples/transportation/segment/road/restrictions/road-restrictions-prohibited-transitions.yaml
+++ b/examples/transportation/segment/road/restrictions/road-restrictions-prohibited-transitions.yaml
@@ -90,7 +90,7 @@ properties:
             comparison: less_than
             value: 12
             unit: 'ft'
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       prohibited_transitions:
         - sequence:

--- a/examples/transportation/segment/road/restrictions/road-restrictions-prohibited-transitions.yaml
+++ b/examples/transportation/segment/road/restrictions/road-restrictions-prohibited-transitions.yaml
@@ -11,6 +11,85 @@ properties:
   class: secondary
   version: 2
   update_time: "2024-03-16T16:23:28-08:00"
+  prohibited_transitions:
+    - sequence:
+        - connector_id: connector1
+          segment_id: segment1
+      final_heading: forward
+      between: [ 0, 0.5 ]
+    - sequence:
+        - connector_id: connector1
+          segment_id: segment1
+      final_heading: forward
+      when:
+        during: PH
+    - sequence:
+        - connector_id: connector1
+          segment_id: segment1
+      final_heading: forward
+      when: {heading: forward}
+    - sequence:
+        - connector_id: connector1
+          segment_id: segment1
+      final_heading: forward
+      when:
+        heading: forward
+        mode: [car, hgv]
+    - sequence:
+        - connector_id: connector1
+          segment_id: segment1
+      final_heading: forward
+      when:
+        heading: forward
+        using: [at_destination]
+    - sequence:
+        - connector_id: connector1
+          segment_id: segment1
+      final_heading: forward
+      when:
+        heading: forward
+        recognized: [as_employee]
+    - sequence:
+        - connector_id: connector1
+          segment_id: segment1
+      final_heading: forward
+      when:
+        heading: forward
+        vehicle:
+          - dimension: axle_count
+            comparison: less_than
+            value: 3
+          - dimension: weight
+            comparison: less_than_equal
+            value: 600
+            unit: 'kg'
+          - dimension: height
+            comparison: less_than
+            value: 12
+            unit: 'ft'
+    - sequence:
+        - connector_id: connector1
+          segment_id: segment1
+      final_heading: forward
+      between: [0.25, 0.5]
+      when:
+        heading: forward
+        during: PH
+        mode: [car, hgv]
+        using: [at_destination]
+        recognized: [as_employee]
+        vehicle:
+          - dimension: axle_count
+            comparison: less_than
+            value: 3
+          - dimension: weight
+            comparison: less_than_equal
+            value: 600
+            unit: 'kg'
+          - dimension: height
+            comparison: less_than
+            value: 12
+            unit: 'ft'
   road:
     restrictions:
       prohibited_transitions:
@@ -58,9 +137,17 @@ properties:
           when:
             heading: forward
             vehicle:
-              axle_count: {is_less_than: 3}
-              weight: {is_at_most: {value: 600, unit: 'kg'}}
-              height: {is_less_than: {value: 12, unit: 'ft'}}
+              - dimension: axle_count
+                comparison: less_than
+                value: 3
+              - dimension: weight
+                comparison: less_than_equal
+                value: 600
+                unit: 'kg'
+              - dimension: height
+                comparison: less_than
+                value: 12
+                unit: 'ft'
         - sequence:
             - connector_id: connector1
               segment_id: segment1
@@ -73,6 +160,14 @@ properties:
             using: [at_destination]
             recognized: [as_employee]
             vehicle:
-              axle_count: { is_less_than: 3 }
-              weight: { is_at_most: { value: 600, unit: 'kg' } }
-              height: { is_less_than: { value: 12, unit: 'ft' } }
+              - dimension: axle_count
+                comparison: less_than
+                value: 3
+              - dimension: weight
+                comparison: less_than_equal
+                value: 600
+                unit: 'kg'
+              - dimension: height
+                comparison: less_than
+                value: 12
+                unit: 'ft'

--- a/examples/transportation/segment/road/restrictions/road-restrictions-speed-limits.yaml
+++ b/examples/transportation/segment/road/restrictions/road-restrictions-speed-limits.yaml
@@ -70,7 +70,7 @@ properties:
             comparison: less_than
             value: 12
             unit: 'ft'
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       speed_limits:
         - max_speed: {value: 20, unit: 'km/h'}

--- a/examples/transportation/segment/road/restrictions/road-restrictions-speed-limits.yaml
+++ b/examples/transportation/segment/road/restrictions/road-restrictions-speed-limits.yaml
@@ -11,6 +11,65 @@ properties:
   class: tertiary
   version: 3
   update_time: "2024-03-16T16:23:31-08:00"
+  speed_limits:
+    - max_speed: {value: 20, unit: 'km/h'}
+      between: [ 0, 0.5 ]
+    - min_speed: {value: 25, unit: 'mph'}
+      when:
+        during: PH
+    - max_speed: {value: 100, unit: 'km/h'}
+      min_speed: {value: 75, unit: 'km/h'}
+      when: {heading: forward}
+    - min_speed: {value: 25, unit: 'mph'}
+      when:
+        heading: forward
+        mode: [car, hgv]
+    - max_speed: {value: 60, unit: 'mph'}
+      is_max_speed_variable: true
+      when:
+        heading: forward
+        using: [at_destination]
+    - min_speed: {value: 25, unit: 'mph'}
+      when:
+        heading: forward
+        recognized: [as_employee]
+    - min_speed: {value: 40, unit: 'mph'}
+      when:
+        heading: forward
+        vehicle:
+          - dimension: axle_count
+            comparison: less_than
+            value: 3
+          - dimension: weight
+            comparison: less_than_equal
+            value: 600
+            unit: 'kg'
+          - dimension: height
+            comparison: less_than
+            value: 12
+            unit: 'ft'
+    - max_speed: {value: 30, unit: 'km/h'}
+      min_speed: {value: 20, unit: 'mph'}
+      is_max_speed_variable: true
+      between: [0.25, 0.5]
+      when:
+        heading: forward
+        during: PH
+        mode: [car, hgv]
+        using: [at_destination]
+        recognized: [as_employee]
+        vehicle:
+          - dimension: axle_count
+            comparison: less_than
+            value: 3
+          - dimension: weight
+            comparison: less_than_equal
+            value: 600
+            unit: 'kg'
+          - dimension: height
+            comparison: less_than
+            value: 12
+            unit: 'ft'
   road:
     restrictions:
       speed_limits:
@@ -39,9 +98,17 @@ properties:
           when:
             heading: forward
             vehicle:
-              axle_count: {is_less_than: 3}
-              weight: {is_at_most: {value: 600, unit: 'kg'}}
-              height: {is_less_than: {value: 12, unit: 'ft'}}
+              - dimension: axle_count
+                comparison: less_than
+                value: 3
+              - dimension: weight
+                comparison: less_than_equal
+                value: 600
+                unit: 'kg'
+              - dimension: height
+                comparison: less_than
+                value: 12
+                unit: 'ft'
         - max_speed: {value: 30, unit: 'km/h'}
           min_speed: {value: 20, unit: 'mph'}
           is_max_speed_variable: true
@@ -53,6 +120,14 @@ properties:
             using: [at_destination]
             recognized: [as_employee]
             vehicle:
-              axle_count: { is_less_than: 3 }
-              weight: { is_at_most: { value: 600, unit: 'kg' } }
-              height: { is_less_than: { value: 12, unit: 'ft' } }
+              - dimension: axle_count
+                comparison: less_than
+                value: 3
+              - dimension: weight
+                comparison: less_than_equal
+                value: 600
+                unit: 'kg'
+              - dimension: height
+                comparison: less_than
+                value: 12
+                unit: 'ft'

--- a/examples/transportation/segment/road/road-abandoned.yaml
+++ b/examples/transportation/segment/road/road-abandoned.yaml
@@ -16,7 +16,7 @@ properties:
     - value: gravel
   road_flags:
     - values: [is_abandoned]
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     surface:
       - value: gravel
     flags:

--- a/examples/transportation/segment/road/road-abandoned.yaml
+++ b/examples/transportation/segment/road/road-abandoned.yaml
@@ -12,6 +12,10 @@ properties:
   version: 3
   subtype: road
   class: tertiary
+  road_surface:
+    - value: gravel
+  road_flags:
+    - values: [is_abandoned]
   road:
     surface:
       - value: gravel

--- a/examples/transportation/segment/road/road-acesss-restriction.yaml
+++ b/examples/transportation/segment/road/road-acesss-restriction.yaml
@@ -35,7 +35,7 @@ properties:
             comparison: greater_than
             value: 5
       between: [0.50, 0.70]
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/segment/road/road-acesss-restriction.yaml
+++ b/examples/transportation/segment/road/road-acesss-restriction.yaml
@@ -18,6 +18,23 @@ properties:
   version: 5
   subtype: road
   class: primary
+  access_restrictions:
+    - access_type: denied
+    - access_type: designated
+      when: {mode: [truck]}
+      between: [0.1, 0.25]
+    - access_type: allowed
+      when:
+        using: [as_customer, to_farm]
+        recognized: [as_permitted, as_employee]
+      between: [0.25, 0.50]
+    - access_type: allowed
+      when:
+        vehicle:
+          - dimension: axle_count
+            comparison: greater_than
+            value: 5
+      between: [0.50, 0.70]
   road:
     restrictions:
       access:
@@ -31,5 +48,9 @@ properties:
             recognized: [as_permitted, as_employee]
           between: [0.25, 0.50]
         - access_type: allowed
-          when: {vehicle: {axle_count: {is_more_than: 5}}}
+          when:
+            vehicle:
+              - dimension: axle_count
+                comparison: greater_than
+                value: 5
           between: [0.50, 0.70]

--- a/examples/transportation/segment/road/road-alley.yaml
+++ b/examples/transportation/segment/road/road-alley.yaml
@@ -15,7 +15,7 @@ properties:
     - access_type: allowed
       when:
         using: [at_destination]
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: allowed

--- a/examples/transportation/segment/road/road-alley.yaml
+++ b/examples/transportation/segment/road/road-alley.yaml
@@ -11,6 +11,10 @@ properties:
   version: 5
   subtype: road
   class: alley
+  access_restrictions:
+    - access_type: allowed
+      when:
+        using: [at_destination]
   road:
     restrictions:
       access:

--- a/examples/transportation/segment/road/road-covered.yaml
+++ b/examples/transportation/segment/road/road-covered.yaml
@@ -16,7 +16,7 @@ properties:
     - value: paved
   road_flags:
     - values: [is_covered]
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     surface:
       - value: paved
     flags:

--- a/examples/transportation/segment/road/road-covered.yaml
+++ b/examples/transportation/segment/road/road-covered.yaml
@@ -12,6 +12,10 @@ properties:
   version: 3
   subtype: road
   class: tertiary
+  road_surface:
+    - value: paved
+  road_flags:
+    - values: [is_covered]
   road:
     surface:
       - value: paved

--- a/examples/transportation/segment/road/road-level.yaml
+++ b/examples/transportation/segment/road/road-level.yaml
@@ -16,7 +16,7 @@ properties:
       between: [0, 0.5]
     - value: 1
       between: [0.75, 1]
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     level:
       - value: -1
         between: [0, 0.5]

--- a/examples/transportation/segment/road/road-level.yaml
+++ b/examples/transportation/segment/road/road-level.yaml
@@ -11,6 +11,11 @@ properties:
   version: 2
   update_time: "2024-03-15T09:24:29-08:00"
   class: residential
+  level_rules:
+    - value: -1
+      between: [0, 0.5]
+    - value: 1
+      between: [0.75, 1]
   road:
     level:
       - value: -1

--- a/examples/transportation/segment/road/road-oneway-no-lanes.yaml
+++ b/examples/transportation/segment/road/road-oneway-no-lanes.yaml
@@ -12,8 +12,11 @@ properties:
   subtype: road
   class: secondary
   connector_ids: [fooConnector, barConnector]
+  # one way road in backward direction (forward access is denied)
+  access_restrictions:
+    - access_type: denied
+      when: {heading: forward}
   road:
-    # one way road in backward direction (forward access is denied)
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/segment/road/road-oneway-no-lanes.yaml
+++ b/examples/transportation/segment/road/road-oneway-no-lanes.yaml
@@ -16,7 +16,7 @@ properties:
   access_restrictions:
     - access_type: denied
       when: {heading: forward}
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     restrictions:
       access:
         - access_type: denied

--- a/examples/transportation/segment/road/road-oneway-with-lanes.yaml
+++ b/examples/transportation/segment/road/road-oneway-with-lanes.yaml
@@ -12,9 +12,13 @@ properties:
   subtype: road
   class: secondary
   connector_ids: [fooConnector, barConnector]
+  # one way road in forward direction (lanes only in forward direction)
+  lanes:
+    - value:
+      - direction: forward
+      - direction: forward
   road:
     lanes:
-      # one way road in forward direction (lanes only in forward direction)
       - value:
         - direction: forward
         - direction: forward

--- a/examples/transportation/segment/road/road-oneway-with-lanes.yaml
+++ b/examples/transportation/segment/road/road-oneway-with-lanes.yaml
@@ -17,7 +17,7 @@ properties:
     - value:
       - direction: forward
       - direction: forward
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     lanes:
       - value:
         - direction: forward

--- a/examples/transportation/segment/road/road-with-lr-width.yaml
+++ b/examples/transportation/segment/road/road-with-lr-width.yaml
@@ -15,6 +15,11 @@ properties:
   subtype: road
   class: secondary
   connector_ids: [fooConnector, barConnector]
+  width_rules:
+    - between: [0, 0.5]
+      value: 1.5
+    - between: [0.5, 1]
+      value: 2.0
   road:
     width:
     - between: [0, 0.5]

--- a/examples/transportation/segment/road/road-with-lr-width.yaml
+++ b/examples/transportation/segment/road/road-with-lr-width.yaml
@@ -20,7 +20,7 @@ properties:
       value: 1.5
     - between: [0.5, 1]
       value: 2.0
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     width:
     - between: [0, 0.5]
       value: 1.5

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -58,7 +58,7 @@ properties:
           connector_id: overture:transportation:connector:456
       final_heading: backward
       when: {heading: backward}
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     surface:
       - value: gravel
     flags:

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -17,11 +17,51 @@ properties:
   connector_ids: [fooConnector, barConnector] # Topology: To discuss further.
   names:
     primary: Common Road Name
+  # no access nor lanes information -> means by default road is accessible in both directions with at least one lane in each direction
+  road_surface:
+    - value: gravel
+  road_flags:
+    - values: [is_link, is_tunnel]
+  level: -1
+  level_rules:
+    - value: -1
+  width_rules:
+    - value: 10
+  speed_limits:
+    - min_speed:
+        value: 90
+        unit: km/h
+      max_speed:
+        value: 110
+        unit: mph
+      is_max_speed_variable: true
+    - max_speed:
+        value: 55
+        unit: mph
+      when: {mode: [ "truck" ]}
+    - max_speed:
+        value: 30
+        unit: km/h
+      between: [0.25, 0.50]
+      when:
+        during: Mo-Sa 09:00-12:00, We 15:00-18:00
+  prohibited_transitions:
+    - sequence:
+      - segment_id: overture:transportation:segment:234
+        connector_id: overture:transportation:connector:123
+      final_heading: forward
+      when: {heading: forward}
+    - sequence:
+        - segment_id: overture:transportation:segment:456
+          connector_id: overture:transportation:connector:345
+        - segment_id: overture:transportation:segment:567
+          connector_id: overture:transportation:connector:456
+      final_heading: backward
+      when: {heading: backward}
   road:
-    # no access nor lanes information -> means by default road is accessible in both directions with at least one lane in each direction
     surface:
       - value: gravel
-    flags: 
+    flags:
       - values: [is_link, is_tunnel]
     level:
       - value: -1

--- a/examples/transportation/segment/road/sidewalk.yaml
+++ b/examples/transportation/segment/road/sidewalk.yaml
@@ -14,6 +14,6 @@ properties:
   connector_ids: [fooConnector, barConnector]
   road_surface:
     - value: paved
-  road:
+  road:  # The `road` property is deprecated and will be removed in the 2024-07 release
     surface:
       - value: paved

--- a/examples/transportation/segment/road/sidewalk.yaml
+++ b/examples/transportation/segment/road/sidewalk.yaml
@@ -12,6 +12,8 @@ properties:
   subtype: road
   class: sidewalk
   connector_ids: [fooConnector, barConnector]
+  road_surface:
+    - value: paved
   road:
     surface:
       - value: paved

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -25,7 +25,6 @@ properties:
           required: [class]
           properties:
             class: { "$ref": "#/$defs/propertyDefinitions/roadClass" }
-            road: { "$ref": "#/$defs/propertyDefinitions/road" }
             speed_limits: { "$ref": "#/$defs/propertyContainers/speedLimitsContainer" }
             access_restrictions: { "$ref": "#/$defs/propertyContainers/accessContainer" }
             prohibited_transitions: { "$ref": "#/$defs/propertyContainers/prohibitedTransitionsContainer" }
@@ -35,6 +34,8 @@ properties:
             lanes: { "$ref": "#/$defs/propertyContainers/lanesContainer" }
             level_rules: { "$ref": "#/$defs/propertyContainers/levelRulesContainer" }
             level: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/level" }
+            # The `road` property is deprecated and will be removed in the 2024-07 release
+            road: { "$ref": "#/$defs/propertyDefinitions/road" }
       - "$ref": ../defs.yaml#/$defs/propertyContainers/overtureFeaturePropertiesContainer
       - "$ref": ../defs.yaml#/$defs/propertyContainers/namesContainer
     properties:
@@ -137,6 +138,8 @@ properties:
         motor_vehicle includes car, truck and motorcycle
     road:
       description: >-
+        ** Note: this field is deprecated in favor of promoting its sub-properties into top-level properties and will be removed in the 2024-07 release **
+
         Properties for segments whose segment subtype is road. The road
         subtype includes any variety of road, street, or path, including
         dedicated paths for walking and cycling.

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -241,7 +241,7 @@ properties:
         - required: [is_less_than]
           properties: { is_less_than: { type: integer } }
     vehicleScopeDimension:
-      description: TODO
+      description: Enumerates possible vehicle dimensions for use in restrictions
       type: string
       enum:
         - axle_count
@@ -250,7 +250,7 @@ properties:
         - weight
         - width
     vehicleScopeComparison:
-      description: TODO
+      description: Enumerates possible comparison operators for use in scoping
       type: string
       enum:
         - greater_than
@@ -259,7 +259,7 @@ properties:
         - less_than
         - less_than_equal
     vehicleScopeUnit:
-      description: TODO
+      description: Parent enum of both length and width for use in vehicle scoping
       anyOf:
         - {"$ref": "#/$defs/propertyDefinitions/lengthUnit"}
         - {"$ref": "#/$defs/propertyDefinitions/weightUnit"}

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -26,6 +26,16 @@ properties:
           properties:
             class: { "$ref": "#/$defs/propertyDefinitions/roadClass" }
             road: { "$ref": "#/$defs/propertyDefinitions/road" }
+            speed_limits: { "$ref": "#/$defs/propertyContainers/speedLimitsContainer" }
+            access_restrictions: { "$ref": "#/$defs/propertyContainers/accessContainer" }
+            prohibited_transitions: { "$ref": "#/$defs/propertyContainers/prohibitedTransitionsContainer" }
+            road_surface: { "$ref": "#/$defs/propertyContainers/surfaceContainer"}
+            road_flags: { "$ref": "#/$defs/propertyContainers/flagsContainer" }
+            width_rules: { "$ref": "#/$defs/propertyContainers/widthRulesContainer" }
+            width: { "$ref": "#/$defs/propertyDefinitions/width" }
+            lanes: { "$ref": "#/$defs/propertyContainers/lanesContainer" }
+            level_rules: { "$ref": "#/$defs/propertyContainers/levelRulesContainer" }
+            level: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/level" }
       - "$ref": ../defs.yaml#/$defs/propertyContainers/overtureFeaturePropertiesContainer
       - "$ref": ../defs.yaml#/$defs/propertyContainers/namesContainer
     properties:
@@ -135,115 +145,11 @@ properties:
       unevaluatedProperties: false
       default: {}
       properties:
-        surface:
-          description: Physical surface of the road. May either be
-            specified as a single global value for the segment, or as
-            an array of surface rules.
-          type: array
-          items:
-            type: object
-            allOf:
-              - { "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer" }
-            unevaluatedProperties: false
-            properties:
-              value: { "$ref": "#/$defs/propertyDefinitions/roadSurface" }
-          minItems: 1
-          uniqueItems: true
-          "$comment":
-            We should likely restrict the available surface types to
-            the subset of the common OSM surface=* tag values that are
-            useful both for routing and for map tile rendering.
-        flags:
-          description:
-            Set of boolean attributes applicable to roads. May be
-            specified either as a single flag array of flag values, or
-            as an array of flag rules.
-          type: array
-          items:
-            type: object
-            allOf:
-              - { "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer" }
-            unevaluatedProperties: false
-            properties:
-              values:
-                type: array
-                items: { "$ref": "#/$defs/propertyDefinitions/roadFlag" }
-                uniqueItems: true
-                minLength: 1
-          uniqueItems: true
-          minLength: 1
-        level:
-          description:
-            Defines the Z-order, i.e. stacking order, of the road
-            segment.
-          type: array
-          items:
-            description:
-              A single level rule defining the Z-order, i.e. stacking
-              order, applicable within a given scope on the road
-              segment.
-            type: object
-            allOf:
-              - { "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer" }
-            unevaluatedProperties: false
-            required: [value]
-            properties:
-              value: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/level" }
-        width:
-          description: >-
-            Edge-to-edge width of the road modeled by this segment, in
-            meters.
-
-            Examples: (1) If this segment models a carriageway without
-            sidewalk, this value represents the edge-to-edge width of the
-            carriageway, inclusive of any shoulder. (2) If this segment
-            models a sidewalk by itself, this value represents the
-            edge-to-edge width of the sidewalk. (3) If this segment models a
-            combined sidewalk and carriageway, this value represents the
-            edge-to-edge width inclusive of sidewalk.
-          type: array
-          items:
-            type: object
-            allOf:
-              - { "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer" }
-            required: [value]
-            properties:
-              value:
-                type: number
-                exclusiveMinimum: 0
-            unevaluatedProperties: false
-          minItems: 1
-          uniqueItems: true
-        lanes:
-          description: >-
-            List of lane block rules describing the layout of lanes on
-            the road plus lane-related information. The standard rule
-            evaluation algorithm is used to determine which lane block
-            applies at a given place and time along the segment.
-
-            Each lane block contains the list of lanes that make up the
-            block. Lanes in the block are listed from left to right as
-            they would be seen by a person standing on the road segment
-            facing in the direction of the segment's orientation (toward
-            the end).
-          type: array
-          items:
-            type: object
-            unevaluatedProperties: false
-            allOf:
-              - "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer"
-            properties:
-              value:
-                type: array
-                items:  { "$ref": "#/$defs/propertyDefinitions/lane" }
-                minItems: 1
-              when:
-                allOf:
-                  - "$ref": "#/$defs/propertyContainers/temporalScopeContainer"
-                minProperties: 1
-                unevaluatedProperties: false
-          minItems: 1
-          uniqueItems: true
+        # surface: { "$ref": "#/defs/propertyContainers/surfaceContainer" }
+        flags: { "$ref": "#/$defs/propertyContainers/flagsContainer" }
+        level: { "$ref": "#/$defs/propertyContainers/levelRulesContainer" }
+        width: { "$ref": "#/$defs/propertyContainers/widthRulesContainer" }
+        lanes: { "$ref": "#/$defs/propertyContainers/lanesContainer" }
         restrictions:
           description: Restrictions on how the road may be used
           type: object
@@ -251,43 +157,7 @@ properties:
           properties:
             speed_limits: { "$ref": "#/$defs/propertyContainers/speedLimitsContainer" }
             access: { "$ref": "#/$defs/propertyContainers/accessContainer" }
-            prohibited_transitions:
-              description: >-
-                Rules preventing transitions from this segment to
-                another segment.
-              type: array
-              items:
-                type: object
-                unevaluatedProperties: false
-                allOf:
-                  - "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer"
-                required: [sequence, final_heading]
-                properties:
-                  sequence:
-                    description: >-
-                      Ordered sequence of connector/segment pairs that it is
-                      prohibited to follow from this segment.
-                    type: array
-                    items:
-                      description: Pair of segment and connector IDs along the sequence
-                      "$ref": "#/$defs/propertyDefinitions/sequenceEntry"
-                    minItems: 1
-                    uniqueItems: true
-                  final_heading:
-                    description: >-
-                      Direction of travel that is prohibited on the destination
-                      segment of the sequence.
-                    "$ref": "#/$defs/propertyDefinitions/heading"
-                  when:
-                    allOf:
-                      - "$ref": "#/$defs/propertyContainers/headingScopeContainer"
-                      - "$ref": "#/$defs/propertyContainers/temporalScopeContainer"
-                      - "$ref": "#/$defs/propertyContainers/purposeOfUseScopeContainer"
-                      - "$ref": "#/$defs/propertyContainers/recognizedStatusScopeContainer"
-                      - "$ref": "#/$defs/propertyContainers/travelModeScopeContainer"
-                      - "$ref": "#/$defs/propertyContainers/vehicleScopeContainer"
-                    minProperties: 1
-                    unevaluatedProperties: false
+            prohibited_transitions: { "$ref": "#/$defs/propertyContainers/prohibitedTransitionsContainer"}
     roadFlag:
       description: Simple flags that can be on or off for a road segment
       type: string
@@ -371,6 +241,29 @@ properties:
           properties: { is_at_most: { type: integer } }
         - required: [is_less_than]
           properties: { is_less_than: { type: integer } }
+    vehicleScopeDimension:
+      description: TODO
+      type: string
+      enum:
+        - axle_count
+        - height
+        - length
+        - weight
+        - width
+    vehicleScopeComparison:
+      description: TODO
+      type: string
+      enum:
+        - greater_than
+        - greater_than_equal
+        - equal
+        - less_than
+        - less_than_equal
+    vehicleScopeUnit:
+      description: TODO
+      anyOf:
+        - {"$ref": "#/$defs/propertyDefinitions/lengthUnit"}
+        - {"$ref": "#/$defs/propertyDefinitions/weightUnit"}
     lengthUnit:
       description: Enumerates length units supported by the Overture schema.
       "$comment": Keep in sync with `combobulib/measure.py`.
@@ -457,6 +350,9 @@ properties:
           properties: { is_at_most: { allOf: [ { "$ref": "#/$defs/propertyDefinitions/weightValueWithUnit" } ] } }
         - required: [is_less_than]
           properties: { is_less_than: { allOf: [ { "$ref": "#/$defs/propertyDefinitions/weightValueWithUnit" } ] } }
+    width:
+      type: number
+      exclusiveMinimum: 0
     sequenceEntry:
       description: >-
         A segment/connector pair in a prohibited transition sequence.
@@ -521,20 +417,31 @@ properties:
       description: >-
         Properties defining vehicle attributes for which a rule is
         active.
-      type: object
+      type: array
+      uniqueItems: true
+      minLength: 1
       properties:
         vehicle:
           description: Vehicle attributes for which the rule applies
-          type: object
-          unevaluatedProperties: false
-          minProperties: 1
-          properties:
-            axle_count: { "$ref": "#/$defs/propertyDefinitions/integerRelation" }
-            height: { "$ref": "#/$defs/propertyDefinitions/lengthRelation" }
-            length: { "$ref": "#/$defs/propertyDefinitions/lengthRelation" }
-            weight: { "$ref": "#/$defs/propertyDefinitions/weightRelation" }
-            width: { "$ref": "#/$defs/propertyDefinitions/lengthRelation" }
-    speedLimitsContainer:  # FIXME: Not a 'container', move up.
+          type: array
+          uniqueItems: true
+          minLength: 1
+          items:
+            description: An individual vehicle scope rule
+            type: object
+            unevaluatedProperties: false
+            required: [dimension, comparison, value]
+            properties:
+              dimension:
+                "$ref": "#/$defs/propertyDefinitions/vehicleScopeDimension"
+              comparison:
+                "$ref": "#/$defs/propertyDefinitions/vehicleScopeComparison"
+              value:
+                type: number
+                minimum: 0
+              unit:
+                "$ref": "#/$defs/propertyDefinitions/vehicleScopeUnit"
+    speedLimitsContainer:
       description: Rules governing speed on this road segment or lane
       type: array
       items:
@@ -570,7 +477,7 @@ properties:
             unevaluatedProperties: false
       minLength: 1
       uniqueItems: true
-    accessContainer: # FIXME: Not a 'container', move up.
+    accessContainer:
       description: Rules governing access to this road segment or lane
       type: array
       items:
@@ -595,3 +502,147 @@ properties:
             unevaluatedProperties: false
         minLength: 1
         uniqueItems: true
+    lanesContainer:
+      description: >-
+        List of lane block rules describing the layout of lanes on
+        the road plus lane-related information. The standard rule
+        evaluation algorithm is used to determine which lane block
+        applies at a given place and time along the segment.
+
+        Each lane block contains the list of lanes that make up the
+        block. Lanes in the block are listed from left to right as
+        they would be seen by a person standing on the road segment
+        facing in the direction of the segment's orientation (toward
+        the end).
+      type: array
+      items:
+        type: object
+        unevaluatedProperties: false
+        allOf:
+          - "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer"
+        properties:
+          value:
+            type: array
+            items:  { "$ref": "#/$defs/propertyDefinitions/lane" }
+            minItems: 1
+          when:
+            allOf:
+              - "$ref": "#/$defs/propertyContainers/temporalScopeContainer"
+            minProperties: 1
+            unevaluatedProperties: false
+      minItems: 1
+      uniqueItems: true
+    prohibitedTransitionsContainer:
+      description: >-
+        Rules preventing transitions from this segment to
+        another segment.
+      type: array
+      items:
+        type: object
+        unevaluatedProperties: false
+        allOf:
+          - "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer"
+        required: [sequence, final_heading]
+        properties:
+          sequence:
+            description: >-
+              Ordered sequence of connector/segment pairs that it is
+              prohibited to follow from this segment.
+            type: array
+            items:
+              description: Pair of segment and connector IDs along the sequence
+              "$ref": "#/$defs/propertyDefinitions/sequenceEntry"
+            minItems: 1
+            uniqueItems: true
+          final_heading:
+            description: >-
+              Direction of travel that is prohibited on the destination
+              segment of the sequence.
+            "$ref": "#/$defs/propertyDefinitions/heading"
+          when:
+            allOf:
+              - "$ref": "#/$defs/propertyContainers/headingScopeContainer"
+              - "$ref": "#/$defs/propertyContainers/temporalScopeContainer"
+              - "$ref": "#/$defs/propertyContainers/purposeOfUseScopeContainer"
+              - "$ref": "#/$defs/propertyContainers/recognizedStatusScopeContainer"
+              - "$ref": "#/$defs/propertyContainers/travelModeScopeContainer"
+              - "$ref": "#/$defs/propertyContainers/vehicleScopeContainer"
+            minProperties: 1
+            unevaluatedProperties: false
+    flagsContainer:
+      description:
+        Set of boolean attributes applicable to roads. May be
+        specified either as a single flag array of flag values, or
+        as an array of flag rules.
+      type: array
+      items:
+        type: object
+        allOf:
+          - { "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer" }
+        unevaluatedProperties: false
+        properties:
+          values:
+            type: array
+            items: { "$ref": "#/$defs/propertyDefinitions/roadFlag" }
+            uniqueItems: true
+            minLength: 1
+      uniqueItems: true
+      minLength: 1
+    levelRulesContainer:
+      description:
+        Defines the Z-order, i.e. stacking order, of the road
+        segment.
+      type: array
+      items:
+        description:
+          A single level rule defining the Z-order, i.e. stacking
+          order, applicable within a given scope on the road
+          segment.
+        type: object
+        allOf:
+          - { "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer" }
+        unevaluatedProperties: false
+        required: [value]
+        properties:
+          value: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/level" }
+    surfaceContainer:
+      description: Physical surface of the road. May either be
+        specified as a single global value for the segment, or as
+        an array of surface rules.
+      type: array
+      items:
+        type: object
+        allOf:
+          - { "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer" }
+        unevaluatedProperties: false
+        properties:
+          value: { "$ref": "#/$defs/propertyDefinitions/roadSurface" }
+      minItems: 1
+      uniqueItems: true
+      "$comment":
+        We should likely restrict the available surface types to
+        the subset of the common OSM surface=* tag values that are
+        useful both for routing and for map tile rendering.
+    widthRulesContainer:
+      description: >-
+        Edge-to-edge width of the road modeled by this segment, in
+        meters.
+
+        Examples: (1) If this segment models a carriageway without
+        sidewalk, this value represents the edge-to-edge width of the
+        carriageway, inclusive of any shoulder. (2) If this segment
+        models a sidewalk by itself, this value represents the
+        edge-to-edge width of the sidewalk. (3) If this segment models a
+        combined sidewalk and carriageway, this value represents the
+        edge-to-edge width inclusive of sidewalk.
+      type: array
+      items:
+        type: object
+        allOf:
+          - { "$ref": "../defs.yaml#/$defs/propertyContainers/geometricRangeScopeContainer" }
+        required: [value]
+        properties:
+          value: { "$ref": "#/$defs/propertyDefinitions/width" }
+        unevaluatedProperties: false
+      minItems: 1
+      uniqueItems: true

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -32,7 +32,6 @@ properties:
             road_surface: { "$ref": "#/$defs/propertyContainers/surfaceContainer"}
             road_flags: { "$ref": "#/$defs/propertyContainers/flagsContainer" }
             width_rules: { "$ref": "#/$defs/propertyContainers/widthRulesContainer" }
-            width: { "$ref": "#/$defs/propertyDefinitions/width" }
             lanes: { "$ref": "#/$defs/propertyContainers/lanesContainer" }
             level_rules: { "$ref": "#/$defs/propertyContainers/levelRulesContainer" }
             level: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/level" }
@@ -145,7 +144,7 @@ properties:
       unevaluatedProperties: false
       default: {}
       properties:
-        # surface: { "$ref": "#/defs/propertyContainers/surfaceContainer" }
+        surface: { "$ref": "#/$defs/propertyContainers/surfaceContainer" }
         flags: { "$ref": "#/$defs/propertyContainers/flagsContainer" }
         level: { "$ref": "#/$defs/propertyContainers/levelRulesContainer" }
         width: { "$ref": "#/$defs/propertyContainers/widthRulesContainer" }
@@ -417,9 +416,7 @@ properties:
       description: >-
         Properties defining vehicle attributes for which a rule is
         active.
-      type: array
-      uniqueItems: true
-      minLength: 1
+      type: object
       properties:
         vehicle:
           description: Vehicle attributes for which the rule applies
@@ -432,15 +429,12 @@ properties:
             unevaluatedProperties: false
             required: [dimension, comparison, value]
             properties:
-              dimension:
-                "$ref": "#/$defs/propertyDefinitions/vehicleScopeDimension"
-              comparison:
-                "$ref": "#/$defs/propertyDefinitions/vehicleScopeComparison"
+              dimension: { "$ref": "#/$defs/propertyDefinitions/vehicleScopeDimension" }
+              comparison: { "$ref": "#/$defs/propertyDefinitions/vehicleScopeComparison" }
               value:
                 type: number
                 minimum: 0
-              unit:
-                "$ref": "#/$defs/propertyDefinitions/vehicleScopeUnit"
+              unit: { "$ref": "#/$defs/propertyDefinitions/vehicleScopeUnit" }
     speedLimitsContainer:
       description: Rules governing speed on this road segment or lane
       type: array

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -19,21 +19,23 @@ properties:
     unevaluatedProperties: false
     required: [subtype]
     allOf:
+      - title: "Segment Properties"
+        required: [class]
+        properties:
+          class: { "$ref": "#/$defs/propertyDefinitions/roadClass" }
+          access_restrictions: { "$ref": "#/$defs/propertyContainers/accessContainer" }
+          level: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/level" }
+          level_rules: { "$ref": "#/$defs/propertyContainers/levelRulesContainer" }
       - title: "Conditional Properties"
         if: { properties: { subtype: { enum: [road] } } }
         then:
-          required: [class]
           properties:
-            class: { "$ref": "#/$defs/propertyDefinitions/roadClass" }
-            speed_limits: { "$ref": "#/$defs/propertyContainers/speedLimitsContainer" }
-            access_restrictions: { "$ref": "#/$defs/propertyContainers/accessContainer" }
+            lanes: { "$ref": "#/$defs/propertyContainers/lanesContainer" }
             prohibited_transitions: { "$ref": "#/$defs/propertyContainers/prohibitedTransitionsContainer" }
             road_surface: { "$ref": "#/$defs/propertyContainers/surfaceContainer"}
             road_flags: { "$ref": "#/$defs/propertyContainers/flagsContainer" }
+            speed_limits: { "$ref": "#/$defs/propertyContainers/speedLimitsContainer" }
             width_rules: { "$ref": "#/$defs/propertyContainers/widthRulesContainer" }
-            lanes: { "$ref": "#/$defs/propertyContainers/lanesContainer" }
-            level_rules: { "$ref": "#/$defs/propertyContainers/levelRulesContainer" }
-            level: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/level" }
             # The `road` property is deprecated and will be removed in the 2024-07 release
             road: { "$ref": "#/$defs/propertyDefinitions/road" }
       - "$ref": ../defs.yaml#/$defs/propertyContainers/overtureFeaturePropertiesContainer


### PR DESCRIPTION
# Description

Storing road data as JSON carries a number of issues and was always considered a "stop gap" during rapid feature iteration for transportation. As we approach GA, we need to properly schematize this data. It is proposed that this also includes some structure simplification ("flattening") for ease of querying, whereas before a priority was making the JSON nicely human-readable. I've left in `road` as-is to allow us to ship both deliveries for one release to ease migration.

Here is the high level schema change:
Old JSON path | New column
-- | --
road.restrictions.speed_limits | speed_limits
road.restrictions.access | access_restrictions
road.restrictions.prohibited_transitions | prohibited_transitions
road.surface | road_surface
road.flags | road_flags
road.width | width_rules
road.lanes | lanes
road.level | level_rules

Additionally, for the non-geometry vehicle scoping block (`when: vehicle:`), we will simplify that frequently used structure as follows (note that this is a **breaking change** for consumers of this data):
```
speed_limits:
  when:
    ...
    vehicle:
      - dimension: <axle_count, height, length, weight, width>
        comparison: <greater_than, greater_than_equal, equal, less_than, less_than_equal>
        value: str
        unit: str
```
vs previously:
```
speed_limits:
  when:
    ...
    vehicle:
      axle_count:
        is_more_than:
          value:
          unit:
        is_less_than:
          ...
        ...
        ...
      height:
        ...
      length:
        ...
      weight:
        ...
      width:
        ...
```

See additional context in [this discussion](https://github.com/OvertureMaps/schema/discussions/184)

# Reference

1. https://github.com/OvertureMaps/schema/discussions/184
2. https://github.com/OvertureMaps/tf-transportation/issues/229

# Testing 

Updated all examples and counterexamples to reflect changes, including copying subproperties out of `road` to separate properties.

# Checklist

1. [X] Add relevant examples.
3. [X] Add relevant counterexamples.
4. [X] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
5. [X] Update in-schema documentation using plain English written in complete sentences, if an update is required.
6. [X] Update Docusaurus documentation, if an update is required.
7. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/203)
