### PR TITLE
github action housekeeping

### DIFF
--- a/.github/workflows/github-actions-copy-latest-docs-to-staging.yaml
+++ b/.github/workflows/github-actions-copy-latest-docs-to-staging.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "19"
 
@@ -34,7 +34,7 @@ jobs:
         run: cd docusaurus && npm run build
 
       - name: Fetch AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::207370808101:role/Overture_GitHub_schema_Publish_Docs_Staging
           aws-region: us-east-2

--- a/.github/workflows/github-actions-copy-latest-docs-to-staging.yaml
+++ b/.github/workflows/github-actions-copy-latest-docs-to-staging.yaml
@@ -46,3 +46,6 @@ jobs:
       - name: Purge CDN cache
         run: |
           aws cloudfront create-invalidation --distribution-id E3L106P8HVBE9L --paths "/latest/*"
+
+      - name: Publish URL
+        run: echo "### [https://dfhx9f55j8eg5.cloudfront.net/latest/](https://dfhx9f55j8eg5.cloudfront.net/latest/)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/github-actions-copy-pr-docs-to-staging.yaml
+++ b/.github/workflows/github-actions-copy-pr-docs-to-staging.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   publish:
     environment:
-      name: Schema Docs Staging
+      name: staging
       url: https://dfhx9f55j8eg5.cloudfront.net/pr/${{github.event.number}}/schema
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/github-actions-copy-pr-docs-to-staging.yaml
+++ b/.github/workflows/github-actions-copy-pr-docs-to-staging.yaml
@@ -1,5 +1,6 @@
 ---
 name: Publish docs to staging website (for PR)
+run-name: Publish schema documentation to staging website
 
 on: [pull_request]
 
@@ -9,6 +10,9 @@ permissions:
 
 jobs:
   publish:
+    environment:
+      name: Schema Docs Staging
+      url: https://dfhx9f55j8eg5.cloudfront.net/pr/${{github.event.number}}/schema
     runs-on: ubuntu-latest
     steps:
       - name: Check out the schema repository
@@ -17,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "19"
+          node-version: "20"
 
       - name: Install NPM dependencies
         run: cd docusaurus && npm install --prefer-dedupe
@@ -29,7 +33,7 @@ jobs:
         run: cd docusaurus && npm run build
 
       - name: Fetch AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::207370808101:role/Overture_GitHub_schema_Publish_Docs_Staging
           aws-region: us-east-2
@@ -41,3 +45,6 @@ jobs:
       - name: Purge CDN cache
         run: |
           aws cloudfront create-invalidation --distribution-id E3L106P8HVBE9L --paths "/pr/${{github.event.number}}/*"
+
+      - name: Publish URL
+        run: echo "View preview page at [https://dfhx9f55j8eg5.cloudfront.net/pr/${{github.event.number}}/](https://dfhx9f55j8eg5.cloudfront.net/pr/${{github.event.number}}/schema)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/github-actions-copy-pr-docs-to-staging.yaml
+++ b/.github/workflows/github-actions-copy-pr-docs-to-staging.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
 


### PR DESCRIPTION
# Description

- Updates setup action versions and sets environment to `staging` with the proper URL
- Note: Cleaned up the Trust Relationship on the AWS side for clarity

Now we get a nice status with a URL: 

When running: 
![image](https://github.com/OvertureMaps/schema/assets/1637425/089cb685-4c46-4753-8d34-bd58db1e38b5)

When finished: 
![image](https://github.com/OvertureMaps/schema/assets/1637425/2d54c366-4aad-40d5-8d2d-49298ecc3f83)

These URLs link directly out to the staging website. Notice there are no more deprecation warnings, either. 
