### PR TITLE
Building is underground

### DIFF
--- a/examples/buildings/building-polygon.yaml
+++ b/examples/buildings/building-polygon.yaml
@@ -24,6 +24,7 @@ properties:
   num_floors: 4
   subtype: transportation
   class: parking
+  is_underground: false
   sources:
   - property: ""
     dataset: microsoftMLBuildings,

--- a/schema/buildings/defs.yaml
+++ b/schema/buildings/defs.yaml
@@ -13,8 +13,9 @@ shapeContainer:
       exclusiveMinimum: 0
     is_underground:
       description: >-
-        Whether the entire building or part is below ground-level. This is different than the level column which is used
-        to indicate z-ordering of elements and negative values may be above ground.
+        Whether the entire building or part is completely below ground. This is useful for rendering which typically omits these
+        buildings or styles them differently because they are not visible above ground. This is different than the level column
+        which is used to indicate z-ordering of elements and negative values may be above ground.
       type: boolean
     num_floors:
       description: >-

--- a/schema/buildings/defs.yaml
+++ b/schema/buildings/defs.yaml
@@ -13,7 +13,7 @@ shapeContainer:
       exclusiveMinimum: 0
     is_underground:
       description: >-
-        Whether the entire building or part below ground-level. This is different than the level column which is used
+        Whether the entire building or part is below ground-level. This is different than the level column which is used
         to indicate z-ordering of elements and negative values may be above ground.
       type: boolean
     num_floors:

--- a/schema/buildings/defs.yaml
+++ b/schema/buildings/defs.yaml
@@ -11,6 +11,11 @@ shapeContainer:
         Height of the building or part in meters. The height is the distance from the lowest point to the highest point.
       type: number
       exclusiveMinimum: 0
+    is_underground:
+      description: >-
+        Whether the entire building or part below ground-level. This is different than the level column which is used
+        to indicate z-ordering of elements and negative values may be above ground.
+      type: boolean
     num_floors:
       description: >-
         Number of above-ground floors of the building or part.


### PR DESCRIPTION
# Description

Adds an `is_underground` flag to allow buildings or parts to be tagged as completely underground. While Overture has the level column, it is currently insufficient for entirely determining whether a feature is below ground. As it's mostly taken from OSM's "layer" tag, that value can be negative for above ground features.

Note - Transportation has the notion of segments being below ground, but that is captured as tunnel and covered flags which do not really apply well to buildings.

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

1. TODO - Add documentation once we know there's alignment


1. [x ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/<PUT THE PR # HERE>)
