### PR TITLE
Fix issues with `test.sh`

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -162,8 +162,9 @@ function schema() {
 function examples() {
   echo "---- VERIFYING examples ----"
   find examples -type f | sort | while read -r instance_file; do
-    if ! [[ "$instance_file" == *.yaml ]]; then
-      printf "%s...FAILED\nexample instance '%s' is EXPECTED to be a .yaml file but ACTUALLY it is not.\n" "$instance_file" "$instance_file"
+    if ! [[ "$instance_file" == *.yaml ]] && ! [[ "$instance_file" == *.json ]]; then
+      printf "%s...FAILED\nexample instance '%s' is EXPECTED to be a .yaml or .json file but ACTUALLY it is not.\n" "$instance_file" "$instance_file"
+      return 1
     elif ! match "$instance_file"; then
       continue
     fi

--- a/test.sh
+++ b/test.sh
@@ -120,7 +120,7 @@ function verify() {
 
   case "$mode" in
   quiet)
-    jv "${jv_args[@]}" 2>/dev/null
+    jv "${jv_args[@]}" >/dev/null 2>/dev/null
     ;;
   simple)
     jv "${jv_args[@]}"

--- a/test.sh
+++ b/test.sh
@@ -126,7 +126,7 @@ function verify() {
     jv "${jv_args[@]}"
     ;;
   *)
-    jv -output "$mode" "${jv_args[@]}"
+    jv --output "$mode" "${jv_args[@]}"
     ;;
   esac
 }


### PR DESCRIPTION
# Description

This change makes three improvements to the `test.sh` script:

1. Mutes output produced by the latest version of the `jv` validator on the standard output when validating in `quiet` mode.
2. Completes work Jake started in https://github.com/OvertureMaps/schema/pull/211 to update the command line arguments send to the `jv` validator tool to the ones used in the latest version of `jv`.
3. Ensures the example tests fail if a non-YAML test file is found. Previously the script would print `FAILED` but then go on its merry way without actually stopping.

# Reference

1. https://github.com/OvertureMaps/schema/pull/211
2. https://github.com/santhosh-tekuri/jsonschema/releases/tag/v6.0.1

# Testing

*Brief description of the testing done for this change showing why you are confident it works as expected and does not introduce regressions. Provide sample output data where appropriate.* 

Ran the tests.

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [X] ~~Add~~ Update relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/214)
