### PR TITLE
Fix new issues with boundary relationship modeling

### DIFF
--- a/counterexamples/divisions/boundary/bad-division_ids-1.yaml
+++ b/counterexamples/divisions/boundary/bad-division_ids-1.yaml
@@ -7,11 +7,11 @@ geometry:
 properties:
   theme: divisions
   type: boundary
-  update_time: "2024-02-23T22:47:06Z"
-  version: 0
+  update_time: "2024-06-12T17:52:42Z"
+  version: 1
   subtype: region
   class: land
-  divisions: ["example:division:country:left", "example:division:country:right", "example:division:country:right", 123]
+  division_ids: ["example:division:country:left", "example:division:country:right", "example:division:country:right", 123]
   is_disputed: "true"
   ext_expected_errors:
     - maximum 2 items required, but found 4 items

--- a/counterexamples/divisions/boundary/bad-division_ids-2.yaml
+++ b/counterexamples/divisions/boundary/bad-division_ids-2.yaml
@@ -7,10 +7,10 @@ geometry:
 properties:
   theme: divisions
   type: boundary
-  update_time: "2024-02-23T22:58:18Z"
-  version: 0
+  update_time: "2024-06-12T17:52:55Z"
+  version: 1
   subtype: county
   class: land
-  divisions: ["example:division:country:lonelylhsdivision"]
+  division_ids: ["example:division:country:lonelylhsdivision"]
   ext_expected_errors:
     - minimum 2 items required, but found 1 items

--- a/examples/divisions/boundary/disputed.yaml
+++ b/examples/divisions/boundary/disputed.yaml
@@ -7,11 +7,11 @@ geometry:
 properties:
   theme: divisions
   type: boundary
-  update_time: "2024-02-23T21:51:29Z"
-  version: 0
+  update_time: "2024-06-12T17:53:33Z"
+  version: 1
   subtype: country
   class: land
-  divisions: ["example:division:country:left", "example:division:country:right"]
+  division_ids: ["example:division:country:left", "example:division:country:right"]
   is_disputed: true
   perspectives:
     mode: disputed_by

--- a/examples/divisions/boundary/disputed_both.yaml
+++ b/examples/divisions/boundary/disputed_both.yaml
@@ -7,11 +7,11 @@ geometry:
 properties:
   theme: divisions
   type: boundary
-  update_time: "2024-02-23T21:51:29Z"
-  version: 0
+  update_time: "2024-06-12T11:53:53Z"
+  version: 1
   subtype: country
   class: land
-  divisions: ["example:division:country:left", "example:division:country:right"]
+  division_ids: ["example:division:country:left", "example:division:country:right"]
   is_disputed: true
   perspectives:
     mode: disputed_by

--- a/examples/divisions/boundary/land_region.yaml
+++ b/examples/divisions/boundary/land_region.yaml
@@ -7,8 +7,8 @@ geometry:
 properties:
   theme: divisions
   type: boundary
-  update_time: "2024-02-23T22:00:28Z"
-  version: 0
+  update_time: "2024-06-12T17:54:03Z"
+  version: 1
   subtype: region
   class: land
-  divisions: ["example:division:region:left",  "example:division:region:right"]
+  division_ids: ["example:division:region:left",  "example:division:region:right"]

--- a/examples/divisions/boundary/maritime_country.yaml
+++ b/examples/divisions/boundary/maritime_country.yaml
@@ -7,8 +7,8 @@ geometry:
 properties:
   theme: divisions
   type: boundary
-  update_time: "2024-02-23T21:59:56Z"
-  version: 0
+  update_time: "2024-06-12T17:54:30Z"
+  version: 1
   subtype: country
   class: maritime
-  divisions: ["example:division:region:left",  "example:division:region:right"]
+  division_ids: ["example:division:region:left",  "example:division:region:right"]

--- a/schema/divisions/boundary.yaml
+++ b/schema/divisions/boundary.yaml
@@ -17,7 +17,7 @@ properties:     # JSON Schema: Top-level object properties.
       - "$ref": https://geojson.org/schema/MultiLineString.json
   properties:   # GeoJSON: top-level object 'properties' property.
     unevaluatedProperties: false
-    required: [subtype, class, divisions]
+    required: [subtype, class, division_ids]
     allOf:
       - "$ref": ../defs.yaml#/$defs/propertyContainers/overtureFeaturePropertiesContainer
     properties: # JSON Schema: properties within GeoJSON top-level object 'properties' property
@@ -30,16 +30,16 @@ properties:     # JSON Schema: Top-level object properties.
 
           - maritime    # All the boundary geometry extends beyond the
                         # coastline of both associated divisions.
-      divisions:
+      division_ids:
         description:
-          The two divisions to the left and right, respectively, of the
-          boundary line. The left- and right-hand sides of the boundary are
-          considered from the perspective of a person standing on the
-          line facing in the direction in which the geometry is oriented,
-          i.e. facing toward the end of the line.
+          Identifies the two divisions to the left and right, respectively, of
+          the boundary line. The left- and right-hand sides of the boundary are
+          considered from the perspective of a person standing on the line
+          facing in the direction in which the geometry is oriented, i.e. facing
+          toward the end of the line.
           
-          The first array element represents the left division. The second
-          element represents the right division.
+          The first array element is the Overture ID of the left division. The
+          second element is the Overture ID of the right division.
         type: array
         items: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/id" }
         minItems: 2

--- a/schema/divisions/boundary.yaml
+++ b/schema/divisions/boundary.yaml
@@ -9,8 +9,8 @@ properties:     # JSON Schema: Top-level object properties.
   id: { "$ref": ../defs.yaml#/$defs/propertyDefinitions/id }
   geometry:
     description:
-      Boundary's geometry which MUST be a LineString as defined by the
-      GeoJSON schema.
+      Boundary's geometry which MUST be a LineString or MultiLineString
+      as defined by the GeoJSON schema.
     unevaluatedProperties: false
     oneOf:
       - "$ref": https://geojson.org/schema/LineString.json


### PR DESCRIPTION
# Description

## Primary change

The primary change in this PR is to align the foreign key references to division features within boundary features with the schema relationships guidance.

In a recent change, PR #200, the schema for the divisions theme's boundary feature fell out of alignment with the *Relationships in the Schema* guidance.
    
The guidance is that a property or nested sub-property that contains a foreign key reference to another feature by Overture ID must end in the suffix `_id`.
    
Before PR #200, things were fine because the Overture ID was contained in a nested sub-property, `divisions[*].division_id`. But since PR #200 removed the nested structures from the `divisions` property, it should have renamed it `division_ids`. This change fixes that.

## Secondary change

In another recent change, PR #188, the boundary feature's geometry property description got decoupled from the actual allowed content of the geometry property. This change fixes the description.

# Reference

- Foreign key relationships:
    - https://github.com/OvertureMaps/schema/pull/200
    - https://github.com/OvertureMaps/schema-wg/blob/admin/decisions/adr-relationship-modeling.md
    - https://wiki.overturemaps.org/x/oAEjAQ
- Description change: https://github.com/OvertureMaps/schema/pull/188

# Testing

Updated examples and counterexamples and ran the test script.

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [X] ~~Add~~ Update relevant examples.
2. [ ] Add relevant counterexamples.
3. [X] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [X] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/215)
