### PR TITLE
Align place categories schema with names, and add category name validation

### DIFF
--- a/counterexamples/places/bad-address-invalid-property.yaml
+++ b/counterexamples/places/bad-address-invalid-property.yaml
@@ -13,7 +13,7 @@ properties:
   names:
     primary: Fancy POI with invalid address property (region2)
   categories:
-    main: some_category
+    primary: some_category
   addresses:
     - freeform: "770 Broadway, Floor 8"
       locality: "New York"

--- a/counterexamples/places/bad-categories-missing-primary.yaml
+++ b/counterexamples/places/bad-categories-missing-primary.yaml
@@ -5,13 +5,13 @@ geometry:
   type: Point
   coordinates: [0, 0]
 properties:
-  ext_expected_errors: ["missing properties: 'main'"]
+  ext_expected_errors: ["missing properties: 'primary'"]
   theme: places
   type: place
-  version: 0
-  update_time: "2023-02-22T23:55:01-08:00"
+  version: 1
+  update_time: "2024-06-12T12:41:30-06:00"
   names:
-    primary: Fancy POI missing main category property
+    primary: Fancy POI missing primary category property
   categories:
     alternate:
       - some_category

--- a/counterexamples/places/bad-categories-value.yaml
+++ b/counterexamples/places/bad-categories-value.yaml
@@ -1,0 +1,23 @@
+---
+id: counterexample:place:bad-categories-values
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  ext_expected_errors:
+    - "'foo_' does not match pattern"
+    - "' bar ' does not match pattern"
+    - "'BAZ' does not match pattern"
+  theme: places
+  type: place
+  version: 1
+  update_time: "2024-06-12T12:19:52-06:00"
+  categories:
+    primary: foo_
+    alternate:
+      - " bar "
+      - BAZ
+  confidence: 0.9
+  names:
+    primary: Problematic POI with problematic categories

--- a/counterexamples/places/bad-geometry.yaml
+++ b/counterexamples/places/bad-geometry.yaml
@@ -6,4 +6,4 @@ geometry:
   coordinates: [[[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]]
 properties:
   categories:
-    main: a_category
+    primary: a_category

--- a/examples/common/timestamp/timestamp-utc.yaml
+++ b/examples/common/timestamp/timestamp-utc.yaml
@@ -6,8 +6,8 @@ geometry:
   coordinates: [0, 0]
 properties:
   categories:
-    main: some_category
+    primary: some_category
   theme: places
   type: place
-  version: 0
-  update_time: "2024-01-22T12:00:00Z"
+  version: 1
+  update_time: "2024-06-12T18:21:50Z"

--- a/examples/places/place-alternate-categories.yaml
+++ b/examples/places/place-alternate-categories.yaml
@@ -6,7 +6,7 @@ geometry:
   coordinates: [0, 0]
 properties:
   categories:
-    primary: some_category
+    primary: the1_category_you_want_first
     alternate:
       - another_category
   confidence: 0.9
@@ -25,7 +25,7 @@ properties:
   addresses:
     - freeform: "770 Broadway, Floor 8"
       locality: "New York"
-    - freeform: "770 Brodway, #802"
+    - freeform: "770 Broadway, #802"
       locality: "New York"
       region: "US-NY"
       country: "US"

--- a/examples/places/place-alternate-categories.yaml
+++ b/examples/places/place-alternate-categories.yaml
@@ -6,7 +6,7 @@ geometry:
   coordinates: [0, 0]
 properties:
   categories:
-    main: some_category
+    primary: some_category
     alternate:
       - another_category
   confidence: 0.9
@@ -32,8 +32,8 @@ properties:
   # Overture properties
   theme: places
   type: place
-  version: 0
-  update_time: "2023-02-22T23:55:01-08:00"
+  version: 1
+  update_time: "2024-06-12T12:20:26-06:00"
   names:
     primary: My Sweet POI
     common:

--- a/examples/places/place.yaml
+++ b/examples/places/place.yaml
@@ -6,7 +6,7 @@ geometry:
   coordinates: [0, 0]
 properties:
   categories:
-    main: some_category
+    primary: some_category
   confidence: 0.9
   websites:
     - https://www.example.com
@@ -30,8 +30,8 @@ properties:
   # Overture properties
   theme: places
   type: place
-  version: 0
-  update_time: "2023-02-22T23:55:01-08:00"
+  version: 1
+  update_time: "2024-06-12T12:19:52-06:00"
   sources:
     - property: ""
       dataset: metaPlaces

--- a/examples/places/place2.yaml
+++ b/examples/places/place2.yaml
@@ -16,7 +16,7 @@ properties:
     name: Example
     wikidata: Q1000
   categories:
-    main: some_category
+    primary: some_category
   emails:
   - info@example.com
   phones:
@@ -25,8 +25,8 @@ properties:
   - https://www.twitter.com/example
   theme: places
   type: place
-  update_time: '2023-02-22T23:55:01-08:00'
-  version: 0
+  update_time: '2024-06-12T12:20:08-06:00'
+  version: 1
   websites:
   - https://www.example.com
 type: Feature

--- a/schema/places/defs.yaml
+++ b/schema/places/defs.yaml
@@ -1,0 +1,10 @@
+---
+"$schema": https://json-schema.org/draft/2020-12/schema
+description: Common schema definitions for places theme
+"$defs":
+  typeDefinitions:
+    category:
+      description: Category of a place.
+      type: string
+      minLength: 1
+      pattern: ^[a-z0-9]+(_[a-z0-9]+)*$

--- a/schema/places/place.yaml
+++ b/schema/places/place.yaml
@@ -31,7 +31,7 @@ properties:
         properties:
           primary:
             description: The primary or main category of the place.
-            type: string
+            "$ref": "./defs.yaml#/$defs/typeDefinitions/category"
           alternate:
             description:
               Alternate categories of the place. Some places might fit into two
@@ -40,7 +40,7 @@ properties:
               categories.
             type: array
             items:
-              type: string
+              "$ref": "./defs.yaml#/$defs/typeDefinitions/category"
             uniqueItems: true
       confidence:
         description: The confidence of the existence of the place. It's a number between 0 and 1. 0 means that we're sure that the place doesn't exist (anymore). 1 means that we're sure that the place exists. If there's no value for the confidence, it means that we don't have any confidence information.

--- a/schema/places/place.yaml
+++ b/schema/places/place.yaml
@@ -24,15 +24,20 @@ properties:
     properties:
       categories:
         description: |
-          The categories of the place. Complete list is available on GitHub: https://github.com/OvertureMaps/schema/blob/main/task-force-docs/places/overture_categories.csv
+          The categories of the place. Complete list is available on
+          GitHub: https://github.com/OvertureMaps/schema/blob/main/task-force-docs/places/overture_categories.csv
         type: object
-        required: [main]
+        required: [primary]
         properties:
-          main:
-            description: The main category of the place.
+          primary:
+            description: The primary or main category of the place.
             type: string
           alternate:
-            description: Alternate categories of the place. Some places might fit into two categories, e.g. a book store and a coffee shop. In such a case, the main category can be augmented with additional applicable categories.
+            description:
+              Alternate categories of the place. Some places might fit into two
+              categories, e.g. a book store and a coffee shop. In such a case,
+              the primary category can be augmented with additional applicable
+              categories.
             type: array
             items:
               type: string


### PR DESCRIPTION
# Description

*Brief description of the business purpose and effect of the pull request.*

This PR contains two changes.

1. It renames the `place` feature's `categories.main` property to `categories.primary` to align it with the names schema, which uses `names.primary`.
    - Either `main` or `primary` would be fine; `primary` was chosen because it causes fewer touchpoints, since changing the names schema requires touching five themes' data generation pipelines.
    - An issue has been filed with the Places theme to fix the data generation pipeline to align with the schema before the July release.
3. It adds JSON Schema validation to the `place` feature's category names. Note that this change reveals some invalid category names in the places category CSV file and dataset and required me to file a bug issue to places to fix it.

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

1. Bug issue for Places TF to fix category names: https://github.com/OvertureMaps/tf-place-data/issues/135
4. Issue for Places TF to ensure `categories.main` is renamed to `categories.primary` in the data.

# Testing

*Brief description of the testing done for this change showing why you are confident it works as expected and does not introduce regressions. Provide sample output data where appropriate.* 

- Updated examples and counterexamples.
- Added a new counterexample for the category name validation.
- Ran the tests.

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [X] ~~Add~~ Update relevant examples.
2. [X] Add relevant counterexamples.
3. [X] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/216)
