### PR TITLE
Add num_floors_underground

### DIFF
--- a/counterexamples/buildings/bad-floors-underground.yaml
+++ b/counterexamples/buildings/bad-floors-underground.yaml
@@ -12,4 +12,4 @@ properties:
   num_floors_underground: -1
   # Expected errors:
   ext_expected_errors:
-    - "[I#/properties/num_floors_underground] exclusiveMinimum: got -1, want 0"
+    - "exclusiveMinimum: got -1, want 0"

--- a/counterexamples/buildings/bad-floors-underground.yaml
+++ b/counterexamples/buildings/bad-floors-underground.yaml
@@ -1,0 +1,13 @@
+---
+id: overture:buildings:footprint:1234
+type: Feature
+geometry:
+  type: Polygon
+  coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]
+properties:
+  theme: buildings
+  type: building
+  version: 1
+  num_floors_underground: -1
+  ext_expected_errors:
+    - "[I#/properties/num_floors_underground] [S#/$defs/propertyDefinitions/featureUpdateTime/format] 'abc2023-02-22T23:55:01-08:00' is not valid 'date-time'"

--- a/counterexamples/buildings/bad-floors-underground.yaml
+++ b/counterexamples/buildings/bad-floors-underground.yaml
@@ -7,5 +7,9 @@ geometry:
 properties:
   theme: buildings
   type: building
+  update_time: "2023-02-22T23:55:01-08:00"
   version: 1
   num_floors_underground: -1
+  # Expected errors:
+  ext_expected_errors:
+    - "[I#/properties/num_floors_underground] exclusiveMinimum: got -1, want 0"

--- a/counterexamples/buildings/bad-floors-underground.yaml
+++ b/counterexamples/buildings/bad-floors-underground.yaml
@@ -9,5 +9,3 @@ properties:
   type: building
   version: 1
   num_floors_underground: -1
-  ext_expected_errors:
-    - "[I#/properties/num_floors_underground] [S#/$defs/propertyDefinitions/featureUpdateTime/format] 'abc2023-02-22T23:55:01-08:00' is not valid 'date-time'"

--- a/examples/buildings/building-polygon.yaml
+++ b/examples/buildings/building-polygon.yaml
@@ -22,6 +22,7 @@ properties:
   update_time: "2023-06-06T10:30:00-08:00"
   height: 21.34
   num_floors: 4
+  num_floors_underground: 1
   subtype: transportation
   class: parking
   is_underground: false

--- a/schema/buildings/defs.yaml
+++ b/schema/buildings/defs.yaml
@@ -22,6 +22,11 @@ shapeContainer:
         Number of above-ground floors of the building or part.
       type: integer
       exclusiveMinimum: 0
+    num_floors_underground:
+      description: >-
+        Number of below-ground floors of the building or part.
+      type: integer
+      exclusiveMinimum: 0
     min_height:
       description: >-
         The height of the bottom part of building in meters. Used if a building or part of building starts above the ground level.


### PR DESCRIPTION
# Description

Adds a `num_floors_underground` flag for buildings that have one or more floors below ground level. This will allow for more accurate 3d representations of buildings that are partially or fully below ground. This should map to the `building:levels:underground` tag from OSM.

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

1. TODO.

1. [x] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/<PUT THE PR # HERE>)
