### PR TITLE
Adding capital_of_divisions to Divisions

### DIFF
--- a/examples/divisions/division/capital_of.yaml
+++ b/examples/divisions/division/capital_of.yaml
@@ -1,0 +1,30 @@
+---
+id: example:division:locality:lj
+type: Feature
+geometry:
+  type: Point
+  coordinates: [14.5845, 46.0570]
+properties:
+  theme: divisions
+  type: division
+  update_time: "2024-06-27T15:55:28Z"
+  version: 0
+  subtype: locality
+  local_type:
+    en: city
+  names:
+    primary: Ljubljana
+  sources:
+    - property: ""
+      dataset: OpenStreetMap
+      record_id: N6968827.V76
+  country: SI
+  hierarchies:
+    - - division_id: example:division:country:si
+        subtype: country
+        name: Slovenia
+  capital_of_divisions:
+    - division_id: example:division:country:si
+      subtype: country
+  parent_division_id: example:division:country:si
+  population: 335509

--- a/schema/divisions/defs.yaml
+++ b/schema/divisions/defs.yaml
@@ -105,3 +105,14 @@ description: Common schema definitions for divisions theme
           items: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/iso3166_1Alpha2CountryCode" }
           minItems: 1
           uniqueItems: true
+    capitalOfDivisionItem:
+      description: One division that has capital
+      type: object
+      unevaluatedProperties: false
+      required: [division_id, subtype]
+      properties:
+        division_id:
+          description: ID of the division
+          allOf:
+            - "$ref": "../defs.yaml#/$defs/propertyDefinitions/id"
+        subtype: { "$ref": "#/$defs/typeDefinitions/placetype" }

--- a/schema/divisions/division.yaml
+++ b/schema/divisions/division.yaml
@@ -197,8 +197,8 @@ properties:     # JSON Schema: Top-level object properties.
         items: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/id" }
       capital_of_divisions:
         description:
-          Division IDs and subtypes of division's this division is capital of. If present,
-          this property will refer to the division IDs of the countries, regions, counties, etc.
+          Division IDs and subtypes of divisions this division is a
+          capital of.
         type: array
         minItems: 1
         uniqueItems: true

--- a/schema/divisions/division.yaml
+++ b/schema/divisions/division.yaml
@@ -195,4 +195,12 @@ properties:     # JSON Schema: Top-level object properties.
         minItems: 1
         uniqueItems: true
         items: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/id" }
+      capital_of_divisions:
+        description:
+          Division IDs and subtypes of division's this division is capital of. If present,
+          this property will refer to the division IDs of the countries, regions, counties, etc.
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items: { "$ref": "defs.yaml#/$defs/typeDefinitions/capitalOfDivisionItem" }
       wikidata: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/wikidata" }


### PR DESCRIPTION
# Description

This will allow easier rendering of Division data since reverse lookup via capital_division_ids is not needed anymore.

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

1. This was discussed briefly in https://github.com/OvertureMaps/tf-admin/issues/98

# Testing


# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [x] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/225)
