### PR TITLE
Connectors LR

### DIFF
--- a/counterexamples/transportation/segment/bad-connector-duplicate.json
+++ b/counterexamples/transportation/segment/bad-connector-duplicate.json
@@ -13,6 +13,20 @@
     "type": "segment",
     "version": 4,
     "subtype": "rail",
-    "connector_ids": ["fooConnector", "bazConnector", "fooConnector"]
+    "connector_ids": ["fooConnector", "bazConnector", "fooConnector"],
+    "connectors": [
+      {
+        "connector_id": "fooConnector",
+        "at": 0.0
+      },
+      {
+        "connector_id": "bazConnector",
+        "at": 1.0
+      },
+      {
+        "connector_id": "fooConnector",
+        "at": 0.0
+      }
+    ]
   }
 }

--- a/counterexamples/transportation/segment/bad-connector-duplicate.json
+++ b/counterexamples/transportation/segment/bad-connector-duplicate.json
@@ -1,5 +1,5 @@
 {
-  "id": "segment with an invalid entry in the connector_ids array",
+  "id": "segment with an invalid entry in the connectors array",
   "type": "Feature",
   "geometry": {
     "type": "LineString",

--- a/counterexamples/transportation/segment/bad-connector-duplicate.json
+++ b/counterexamples/transportation/segment/bad-connector-duplicate.json
@@ -17,15 +17,15 @@
     "connectors": [
       {
         "connector_id": "fooConnector",
-        "at": 0.0
+        "at": 0
       },
       {
         "connector_id": "bazConnector",
-        "at": 1.0
+        "at": 1
       },
       {
         "connector_id": "fooConnector",
-        "at": 0.0
+        "at": 0
       }
     ]
   }

--- a/counterexamples/transportation/segment/bad-connector.json
+++ b/counterexamples/transportation/segment/bad-connector.json
@@ -1,5 +1,5 @@
 {
-  "id": "segment with an invalid entry in the connector_ids array",
+  "id": "segment with an invalid entry in the connectors array",
   "type": "Feature",
   "geometry": {
     "type": "LineString",
@@ -8,12 +8,16 @@
   "properties": {
     "ext_expected_errors": [
       "expected string, but got number",
-      "expected string, but got boolean"
+      "expected string, but got boolean",
+      "expected object, but got string",
+      "expected object, but got number",
+      "expected object, but got boolean"
     ],
     "theme": "transportation",
     "type": "segment",
     "version": 3,
     "subtype": "rail",
-    "connector_ids": ["bazConnector", "qux", 1, false]
+    "connector_ids": ["bazConnector", "qux", 1, false],
+    "connectors": [{"connector_id": "foo", "at": 0.0}, {"connector_id": "bar", "at": 1.0}, "bazConnector", "qux", 1, false]
   }
 }

--- a/counterexamples/transportation/segment/bad-route.yaml
+++ b/counterexamples/transportation/segment/bad-route.yaml
@@ -13,7 +13,13 @@ properties:
   version: 1
   subtype: road
   class: secondary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   routes:
     - name: ""
       ref: 1234

--- a/counterexamples/transportation/segment/road/bad-road-level-invalid-value.yaml
+++ b/counterexamples/transportation/segment/road/bad-road-level-invalid-value.yaml
@@ -10,7 +10,13 @@ properties:
   version: 1
   subtype: road
   class: secondary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   level_rules:
     - value: 1.5
   ext_expected_errors:

--- a/counterexamples/transportation/segment/road/bad-road-level-unsupported-properties.yaml
+++ b/counterexamples/transportation/segment/road/bad-road-level-unsupported-properties.yaml
@@ -10,7 +10,13 @@ properties:
   version: 1
   subtype: road
   class: secondary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   level_rules:
     - value: 1
       foo: bar

--- a/counterexamples/transportation/segment/road/restrictions/access/bad-access-mode.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/access/bad-access-mode.yaml
@@ -18,7 +18,13 @@ properties:
   subclass: link
   subclass_rules:
     - value: link
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   road_surface: gravel
   road_flags:
     - [is_link, is_tunnel] # Note: `is_link` is deprecated and will be removed in a future release in favor of the link subclass

--- a/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/bad-sequence-duplicate-entry.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/bad-sequence-duplicate-entry.yaml
@@ -10,8 +10,13 @@ properties:
   version: 2
   subtype: road
   class: primary
-  connector_ids:
-    - overture:transportation:example:connector:1
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
+  connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   prohibited_transitions:
     - sequence:
         - segment_id: foo

--- a/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/bad-sequence-empty.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/bad-sequence-empty.yaml
@@ -10,8 +10,13 @@ properties:
   version: 2
   subtype: road
   class: primary
-  connector_ids:
-    - overture:transportation:example:connector:1
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
+  connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   prohibited_transitions:
     - sequence: []
       final_heading: forward

--- a/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/missing-final-heading.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/missing-final-heading.yaml
@@ -10,8 +10,13 @@ properties:
   version: 2
   subtype: road
   class: primary
-  connector_ids:
-    - overture:transportation:example:connector:1
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
+  connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   prohibited_transitions:
     - sequence:
         - segment_id: foo

--- a/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-mode.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-mode.yaml
@@ -15,7 +15,13 @@ properties:
   version: 2
   subtype: road
   class: secondary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   speed_limits:
     - max_speed:
         value: 110

--- a/examples/transportation/docusaurus/access-restriction.yaml
+++ b/examples/transportation/docusaurus/access-restriction.yaml
@@ -16,9 +16,13 @@ properties:
   version: 4
   subtype: road
   class: motorway
-  connector_ids:
-    - overture:transportation:example:simple-road-connector-1
-    - overture:transportation:example:simple-road-connector-2
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
+  connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: SR 520
   access_restrictions:

--- a/examples/transportation/docusaurus/lanes-resolution-segment-01.yaml
+++ b/examples/transportation/docusaurus/lanes-resolution-segment-01.yaml
@@ -10,7 +10,13 @@ properties:
   theme: transportation
   type: segment
   version: 1
-  connector_ids: [lanes-resolution-example-connector]
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
+  connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   subtype: road
   class: motorway
   lanes: # A list of two geometrically-scoped rules for resolving the lane block.

--- a/examples/transportation/docusaurus/lanes-resolution-segment-02.yaml
+++ b/examples/transportation/docusaurus/lanes-resolution-segment-02.yaml
@@ -10,7 +10,13 @@ properties:
   theme: transportation
   type: segment
   version: 2
-  connector_ids: [lanes-resolution-example-connector]
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
+  connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   subtype: road
   class: motorway
   lanes:

--- a/examples/transportation/docusaurus/simple-road.yaml
+++ b/examples/transportation/docusaurus/simple-road.yaml
@@ -13,9 +13,15 @@ properties:
   version: 5
   subtype: road
   class: residential
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids:
-    - overture:transportation:example:simple-road-connector-1
-    - overture:transportation:example:simple-road-connector-2
+    - overture:transportation:example:via-turn-restriction-connector1
+    - overture:transportation:example:via-turn-restriction-connector2
+  connectors:
+    - connector_id: overture:transportation:example:via-turn-restriction-connector1
+      at: 0
+    - connector_id: overture:transportation:example:via-turn-restriction-connector2
+      at: 1
   names:
     primary: Nicola Street
   lanes:

--- a/examples/transportation/docusaurus/turn-restriction-01-exit.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-01-exit.yaml
@@ -15,6 +15,12 @@ properties:
   version: 1
   subtype: road
   class: secondary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids:
-    - overture:transportation:example:simple-turn-restriction-connector1
-    - overture:transportation:example:simple-turn-restriction-connector3
+    - overture:transportation:example:via-turn-restriction-connector1
+    - overture:transportation:example:via-turn-restriction-connector2
+  connectors:
+    - connector_id: overture:transportation:example:via-turn-restriction-connector1
+      at: 0
+    - connector_id: overture:transportation:example:via-turn-restriction-connector2
+      at: 1

--- a/examples/transportation/docusaurus/turn-restriction-01-source.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-01-source.yaml
@@ -13,9 +13,15 @@ properties:
   version: 5
   subtype: road
   class: secondary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids:
-    - overture:transportation:example:simple-turn-restriction-connector1
-    - overture:transportation:example:simple-turn-restriction-connector2
+    - overture:transportation:example:via-turn-restriction-connector1
+    - overture:transportation:example:via-turn-restriction-connector2
+  connectors:
+    - connector_id: overture:transportation:example:via-turn-restriction-connector1
+      at: 0
+    - connector_id: overture:transportation:example:via-turn-restriction-connector2
+      at: 1
   prohibited_transitions:
       - sequence:
         - segment_id: overture:transportation:example:simple-turn-restriction-target

--- a/examples/transportation/docusaurus/turn-restriction-01-target.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-01-target.yaml
@@ -15,6 +15,12 @@ properties:
   version: 1
   subtype: road
   class: secondary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids:
-    - overture:transportation:example:simple-turn-restriction-connector2
-    - overture:transportation:example:simple-turn-restriction-connector3
+    - overture:transportation:example:via-turn-restriction-connector1
+    - overture:transportation:example:via-turn-restriction-connector2
+  connectors:
+    - connector_id: overture:transportation:example:via-turn-restriction-connector1
+      at: 0
+    - connector_id: overture:transportation:example:via-turn-restriction-connector2
+      at: 1

--- a/examples/transportation/docusaurus/turn-restriction-02-source.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-source.yaml
@@ -19,8 +19,15 @@ properties:
   version: 5
   subtype: road
   class: primary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids:
     - overture:transportation:example:via-turn-restriction-connector1
+    - overture:transportation:example:via-turn-restriction-connector2
+  connectors:
+    - connector_id: overture:transportation:example:via-turn-restriction-connector1
+      at: 0
+    - connector_id: overture:transportation:example:via-turn-restriction-connector2
+      at: 1
   names:
     primary: Arborway
   prohibited_transitions:

--- a/examples/transportation/docusaurus/turn-restriction-02-target.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-target.yaml
@@ -17,8 +17,15 @@ properties:
   version: 5
   subtype: road
   class: primary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids:
+    - overture:transportation:example:via-turn-restriction-connector1
     - overture:transportation:example:via-turn-restriction-connector2
+  connectors:
+    - connector_id: overture:transportation:example:via-turn-restriction-connector1
+      at: 0
+    - connector_id: overture:transportation:example:via-turn-restriction-connector2
+      at: 1
   names:
     primary: Arborway
   road_surface:

--- a/examples/transportation/docusaurus/turn-restriction-02-via.yaml
+++ b/examples/transportation/docusaurus/turn-restriction-02-via.yaml
@@ -14,9 +14,15 @@ properties:
   version: 5
   subtype: road
   class: secondary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids:
     - overture:transportation:example:via-turn-restriction-connector1
     - overture:transportation:example:via-turn-restriction-connector2
+  connectors:
+    - connector_id: overture:transportation:example:via-turn-restriction-connector1
+      at: 0
+    - connector_id: overture:transportation:example:via-turn-restriction-connector2
+      at: 1
   names:
     primary: Washington Street
   road_surface:

--- a/examples/transportation/segment/road/lanes/lanes-flow-alternating.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-flow-alternating.yaml
@@ -11,6 +11,11 @@ properties:
   subtype: road
   class: primary
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   road_surface:
     - value: paved
   lanes:

--- a/examples/transportation/segment/road/lanes/lanes-flow-alternating.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-flow-alternating.yaml
@@ -10,6 +10,7 @@ properties:
   version: 4
   subtype: road
   class: primary
+  
   connector_ids: [fooConnector, barConnector]
   connectors:
     - connector_id: fooConnector

--- a/examples/transportation/segment/road/lanes/lanes-flow-alternating.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-flow-alternating.yaml
@@ -10,7 +10,7 @@ properties:
   version: 4
   subtype: road
   class: primary
-  
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
   connectors:
     - connector_id: fooConnector

--- a/examples/transportation/segment/road/lanes/lanes-flow-reversible.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-flow-reversible.yaml
@@ -10,6 +10,7 @@ properties:
   version: 5
   subtype: road
   class: primary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
   connectors:
     - connector_id: fooConnector

--- a/examples/transportation/segment/road/lanes/lanes-flow-reversible.yaml
+++ b/examples/transportation/segment/road/lanes/lanes-flow-reversible.yaml
@@ -11,6 +11,11 @@ properties:
   subtype: road
   class: primary
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   road_surface:
     - value: paved
   lanes:

--- a/examples/transportation/segment/road/road-multiple-connectors.yaml
+++ b/examples/transportation/segment/road/road-multiple-connectors.yaml
@@ -1,0 +1,22 @@
+---
+id: overture:transportation:segment:0841f2c7ffffffff0477f88f6824635d
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[14.5161902, 56.6452609], [14.5151903, 56.6465165], [14.5128482, 56.6494576]]
+properties:
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: road
+  class: secondary
+  connector_ids: [08f1f2c6a5d612f20473f1d0ae2f3b9b, 08f1f2c78b6cd7480477fda99ff112b1, 08f1f2c78b6740300477f04e2259ca78]
+  road_surface:
+    - value: paved
+  connectors:
+    - connector_id: 08f1f2c6a5d612f20473f1d0ae2f3b9b
+      at: 0
+    - connector_id: 08f1f2c78b6cd7480477fda99ff112b1
+      at: 0.3
+    - connector_id: 08f1f2c78b6740300477f04e2259ca78
+      at: 1

--- a/examples/transportation/segment/road/road-multiple-connectors.yaml
+++ b/examples/transportation/segment/road/road-multiple-connectors.yaml
@@ -1,22 +1,23 @@
 ---
-id: overture:transportation:segment:0841f2c7ffffffff0477f88f6824635d
+id: overture:transportation:segment:123
 type: Feature
 geometry:
   type: LineString
-  coordinates: [[14.5161902, 56.6452609], [14.5151903, 56.6465165], [14.5128482, 56.6494576]]
+  coordinates: [[0, 0], [0.03, 0], [0.10, 0]]
 properties:
   theme: transportation
   type: segment
   version: 1
   subtype: road
   class: secondary
-  connector_ids: [08f1f2c6a5d612f20473f1d0ae2f3b9b, 08f1f2c78b6cd7480477fda99ff112b1, 08f1f2c78b6740300477f04e2259ca78]
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
+  connector_ids: [fooConnector, barConnector, bazConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 0.3
+    - connector_id: bazConnector
+      at: 1
   road_surface:
     - value: paved
-  connectors:
-    - connector_id: 08f1f2c6a5d612f20473f1d0ae2f3b9b
-      at: 0
-    - connector_id: 08f1f2c78b6cd7480477fda99ff112b1
-      at: 0.3
-    - connector_id: 08f1f2c78b6740300477f04e2259ca78
-      at: 1

--- a/examples/transportation/segment/road/road-oneway-no-lanes.yaml
+++ b/examples/transportation/segment/road/road-oneway-no-lanes.yaml
@@ -10,6 +10,7 @@ properties:
   version: 6
   subtype: road
   class: secondary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
   connectors:
     - connector_id: fooConnector

--- a/examples/transportation/segment/road/road-oneway-no-lanes.yaml
+++ b/examples/transportation/segment/road/road-oneway-no-lanes.yaml
@@ -11,6 +11,11 @@ properties:
   subtype: road
   class: secondary
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   # one way road in backward direction (forward access is denied)
   access_restrictions:
     - access_type: denied

--- a/examples/transportation/segment/road/road-oneway-with-lanes.yaml
+++ b/examples/transportation/segment/road/road-oneway-with-lanes.yaml
@@ -10,6 +10,7 @@ properties:
   version: 6
   subtype: road
   class: secondary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
   connectors:
     - connector_id: fooConnector

--- a/examples/transportation/segment/road/road-oneway-with-lanes.yaml
+++ b/examples/transportation/segment/road/road-oneway-with-lanes.yaml
@@ -11,6 +11,11 @@ properties:
   subtype: road
   class: secondary
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   # one way road in forward direction (lanes only in forward direction)
   lanes:
     - value:

--- a/examples/transportation/segment/road/road-with-lr-name.yaml
+++ b/examples/transportation/segment/road/road-with-lr-name.yaml
@@ -13,6 +13,7 @@ properties:
   version: 1
   subtype: road
   class: secondary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
   connectors:
     - connector_id: fooConnector

--- a/examples/transportation/segment/road/road-with-lr-name.yaml
+++ b/examples/transportation/segment/road/road-with-lr-name.yaml
@@ -14,6 +14,11 @@ properties:
   subtype: road
   class: secondary
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: Common Road Name 1
     rules:

--- a/examples/transportation/segment/road/road-with-lr-width.yaml
+++ b/examples/transportation/segment/road/road-with-lr-width.yaml
@@ -13,6 +13,7 @@ properties:
   version: 1
   subtype: road
   class: secondary
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
   connectors:
     - connector_id: fooConnector

--- a/examples/transportation/segment/road/road-with-lr-width.yaml
+++ b/examples/transportation/segment/road/road-with-lr-width.yaml
@@ -14,6 +14,11 @@ properties:
   subtype: road
   class: secondary
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   width_rules:
     - between: [0, 0.5]
       value: 1.5

--- a/examples/transportation/segment/road/road-with-route.yaml
+++ b/examples/transportation/segment/road/road-with-route.yaml
@@ -11,6 +11,7 @@ properties:
   version: 1
   subtype: road
   class: motorway
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
   connectors:
     - connector_id: fooConnector

--- a/examples/transportation/segment/road/road-with-route.yaml
+++ b/examples/transportation/segment/road/road-with-route.yaml
@@ -12,6 +12,11 @@ properties:
   subtype: road
   class: motorway
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   routes:
     - name: I 95
       network: US:I

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -16,7 +16,12 @@ properties:
   subclass: link
   subclass_rules:
     - value: link
-  connector_ids: [fooConnector, barConnector] # Topology: To discuss further.
+  connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: Common Road Name
   # no access nor lanes information -> means by default road is accessible in both directions with at least one lane in each direction

--- a/examples/transportation/segment/road/road.yaml
+++ b/examples/transportation/segment/road/road.yaml
@@ -16,6 +16,7 @@ properties:
   subclass: link
   subclass_rules:
     - value: link
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
   connectors:
     - connector_id: fooConnector

--- a/examples/transportation/segment/road/sidewalk.yaml
+++ b/examples/transportation/segment/road/sidewalk.yaml
@@ -14,5 +14,10 @@ properties:
   subclass_rules:
     - value: sidewalk
   connector_ids: [fooConnector, barConnector]
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   road_surface:
     - value: paved

--- a/examples/transportation/segment/road/sidewalk.yaml
+++ b/examples/transportation/segment/road/sidewalk.yaml
@@ -13,6 +13,7 @@ properties:
   subclass: sidewalk
   subclass_rules:
     - value: sidewalk
+  # `connector_ids` is deprecated in favor of `connectors`, planned to be removed for the October release
   connector_ids: [fooConnector, barConnector]
   connectors:
     - connector_id: fooConnector

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -61,6 +61,7 @@ properties:
           "$comment": >-
             Each entry in this array is the GERS ID of a transportation connector feature.
         uniqueItems: true
+        minItems: 2
         default: []
       connectors:
         description: >-
@@ -72,13 +73,14 @@ properties:
         items:
           type: object
           "$comment": >-
-            Each entry in this array is the GERS ID and LR of a transportation connector feature.
+            Contains the GERS ID and relative position between 0 and 1 of a connector feature along the segment.
           unevaluatedProperties: false
           required: [connector_id, at]
           properties:
             connector_id: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/id" }
             at: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/linearlyReferencedPosition" }
         uniqueItems: true
+        minItems: 2
         default: []
       routes: { "$ref": "#/$defs/propertyDefinitions/routes" }
 "$defs":

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -51,6 +51,9 @@ properties:
           kind has an (implied) set of default transport modes.
       connector_ids:
         description: >-
+          ** Deprecated** `connector_ids` is deprecated in favor of `connectors` and
+          is planned to be removed for the October release.
+
           List of connector IDs identifying the connectors this segment is physically
           connected to. Each connector is a possible routing decision point, meaning
           it defines a place along the segment in which there is possibility to
@@ -89,9 +92,9 @@ properties:
       description: >-
         The type of object of the destination label.
       type: string
-      enum: 
+      enum:
       - street
-      - country 
+      - country
       - route_ref
       - toward_route_ref
       - unknown
@@ -129,25 +132,25 @@ properties:
             uniqueItems: true
           symbols:
             description: >-
-              A collection of symbols or icons present on the sign next to current 
+              A collection of symbols or icons present on the sign next to current
               destination label.
             type: array
             items: { "$ref": "#/$defs/propertyDefinitions/destinationSignSymbol" }
             uniqueItems: true
-            minLength: 1            
-          from_connector_id:          
+            minLength: 1
+          from_connector_id:
             description: >-
               Identifies the point of physical connection on this segment before which
               the destination sign or marking is visible.
             type: string
           to_segment_id:
             description: >-
-              Identifies the segment to transition to reach the destination(s) labeled 
+              Identifies the segment to transition to reach the destination(s) labeled
               on the sign or marking.
             type: string
           to_connector_id:
             description: >-
-              Identifies the point of physical connection on the segment identified by 
+              Identifies the point of physical connection on the segment identified by
               'to_segment_id' to transition to for reaching the destination(s).
             type: string
           when:
@@ -157,9 +160,9 @@ properties:
             unevaluatedProperties: false
           final_heading:
             description: >-
-              Direction of travel on the segment identified by 'to_segment_id' that leads 
+              Direction of travel on the segment identified by 'to_segment_id' that leads
               to the destination.
-            "$ref": "#/$defs/propertyDefinitions/heading"    
+            "$ref": "#/$defs/propertyDefinitions/heading"
     roadClass:
       description:
         Captures the kind of road and its position in the road network
@@ -235,7 +238,7 @@ properties:
       description: >-
         Indicates what special symbol/icon is present on a signpost, visible as road marking or similar.
       type: string
-      enum: 
+      enum:
       - motorway
       - airport
       - hospital

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -62,6 +62,24 @@ properties:
             Each entry in this array is the GERS ID of a transportation connector feature.
         uniqueItems: true
         default: []
+      connectors:
+        description: >-
+          List of connectors which this segment is physically connected to and their
+          relative location. Each connector is a possible routing decision point, meaning
+          it defines a place along the segment in which there is possibility to
+          transition to other segments which share the same connector.
+        type: array
+        items:
+          type: object
+          "$comment": >-
+            Each entry in this array is the GERS ID and LR of a transportation connector feature.
+          unevaluatedProperties: false
+          required: [connector_id, at]
+          properties:
+            connector_id: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/id" }
+            at: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/linearlyReferencedPosition" }
+        uniqueItems: true
+        default: []
       routes: { "$ref": "#/$defs/propertyDefinitions/routes" }
 "$defs":
   propertyDefinitions:


### PR DESCRIPTION
# Description

Adds connector ids with pre-computed linear reference values as it isn't possible to accurately compute with the current segment geometry + connector coordinate data. This value will be computed during the transportation prep process when we still have all shape points.

An added benefit here is that in many cases, connector data will no longer need to be scanned until we have additional properties on those features.

Plan is to deprecate connector_ids for removal in October which will be a prereq for declaring transportation as GA-ready.

# Reference

1. https://github.com/OvertureMaps/schema/discussions/219
2. https://github.com/OvertureMaps/schema/discussions/226
3. https://github.com/OvertureMaps/tf-transportation/pull/295

# Testing

Testing done during [implementation](https://github.com/OvertureMaps/tf-transportation/pull/295)

# Checklist

1. [X] Add relevant examples.
4. [X] Add relevant counterexamples.
5. [X] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
6. [X] Update in-schema documentation using plain English written in complete sentences, if an update is required.
7. [X] Update Docusaurus documentation, if an update is required.
8. [X] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/257)
