### PR TITLE
Correct minor typo

### DIFF
--- a/docs/schema/concepts/by-theme/addresses/index.mdx
+++ b/docs/schema/concepts/by-theme/addresses/index.mdx
@@ -6,7 +6,7 @@ draft: true
 ## Overview
 The Overture Address theme is a compilation of open address datasets usually
 published by local authorized sources. In our initial release, we use the datasets
-that are collected and distributed by [OpenAdddresses](https://openaddresses.io).
+that are collected and distributed by [OpenAddresses](https://openaddresses.io).
 
 The initial schema for addresses is fairly simple and is expected to expand into
 more complex addressing schemes.

--- a/docs/schema/reference/addresses/address.mdx
+++ b/docs/schema/reference/addresses/address.mdx
@@ -17,7 +17,7 @@ import TabItem from '@theme/TabItem';
 
 The Overture Address type is a compilation of open address datasets usually
 published by local authorized sources. In our initial release, we use the datasets
-that are collected and distributed by [OpenAdddresses](https://openaddresses.io).
+that are collected and distributed by [OpenAddresses](https://openaddresses.io).
 
 The initial schema for addresses is fairly simple and is expected to expand into
 more complex addressing schemes.


### PR DESCRIPTION
This PR corrects a minor typo in two of the addresses reference docs, from "OpenAdddresses" to "OpenAddresses."
