### PR TITLE
Fix missing validation bug in names rules

### DIFF
--- a/counterexamples/common/names/names-invalid-language.yaml
+++ b/counterexamples/common/names/names-invalid-language.yaml
@@ -19,10 +19,13 @@ properties:
     rules:
       - language: etymology:wikidata
         value: Not allowed to have a colon
+        variant: common
       - language: etymology
         value: Too long
+        variant: alternate
       - language: pronunciation
         value: Too long
+        variant: official
   ext_expected_errors:
     - "additionalProperties 'zh_pinyin', 'en1', 'ja_rm' not allowed"
     - "[I#/properties/names/rules/0/language] [S#/$defs/propertyDefinitions/language/pattern] does not match pattern"

--- a/counterexamples/common/names/names-invalid-variant.yaml
+++ b/counterexamples/common/names/names-invalid-variant.yaml
@@ -1,0 +1,22 @@
+---
+id: names-invalid-variant
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: road
+  class: primary
+  names:
+    primary: Bar
+    rules:
+      - value: I am missing the variant
+      - language: en-us
+        value: I have a fake/unsupported variant
+        variant: fake-variant
+  ext_expected_errors:
+    - "'/properties/names/rules/0': missing property 'variant'"
+    - "'/properties/names/rules/1/variant': value must be one of 'common', 'official', 'alternate', 'short'"

--- a/examples/common/names/names-lexically-valid-language-tag.yaml
+++ b/examples/common/names/names-lexically-valid-language-tag.yaml
@@ -21,5 +21,7 @@ properties:
     rules:
       - language: be-Latn
         value: Use this instead of be-tarask.
+        variant: common
       - language: ja-Latn
         value: Use this instead of ja_rm.
+        variant: alternate

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -185,7 +185,7 @@ description: Common schema definitions shared by all themes
             5. *("-" extension)
     nameRule:
       type: object
-      required: [value]
+      required: [variant, value]
       allOf:
         - { "$ref": "#/$defs/propertyContainers/geometricRangeScopeContainer" }
         - { "$ref": "#/$defs/propertyContainers/sideScopeContainer" }


### PR DESCRIPTION
# Category

What kind of change is this?
Please select *one* of the following four options.
Consult [Pull request merging criteria](https://github.com/OvertureMaps/schema-wg#Pull-request-merging-criteria) for a description of each category.

1. [ ] Cosmetic change.
2. [ ] Documentation change by member.
3. [ ] Documentation change by Overture tech writer.
4. [X] Material change.

# Description

*Brief description of the business purpose and effect of the pull request.*

Fixes a bug noted by @DavidKarlas where the schema didn't require entries under `names.rules` to have a variant. This was an omission, as all name rules need a variant.

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

1. https://github.com/OvertureMaps/schema-wg/issues/324

# Testing

*Brief description of the testing done for this change showing why you are confident it works as expected and does not introduce regressions. Provide sample output data where appropriate.* 

1. Ran the example tests.
2. Verified that the last three months of releases pass the validation.

See the test SQL below run in Amazon Athena.

```sql
SELECT 'v2024_06_13_beta_0' AS version, type, id, names
  FROM v2024_06_13_beta_0
 WHERE any_match(names.rules, rule -> rule.variant IS NULL)

UNION ALL

SELECT 'v2024_06_13_beta_1' AS version, type, id, names
  FROM v2024_06_13_beta_1
 WHERE any_match(names.rules, rule -> rule.variant IS NULL)

UNION ALL

SELECT 'v2024_07_22_0' AS version, type, id, names
  FROM v2024_07_22_0
 WHERE any_match(names.rules, rule -> rule.variant IS NULL)

UNION ALL

SELECT 'v2024_08_20_0' AS version, type, id, names
  FROM v2024_08_20_0
 WHERE any_match(names.rules, rule -> rule.variant IS NULL)
```


# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [ ] Add relevant examples.
4. [x] Add relevant counterexamples.
5. [x] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
6. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
7. [ ] Update Docusaurus documentation, if an update is required.
8. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/277)
