### PR TITLE
Remove "value" as required element of address_level

### DIFF
--- a/examples/addresses/address_all_missing_address_levels.yaml
+++ b/examples/addresses/address_all_missing_address_levels.yaml
@@ -10,8 +10,8 @@ properties:
   version: 0
   country: US
   address_levels:
-    - null
-    - null
+    - {}
+    - {}
   postcode: '02459'
   street: COMMONWEALTH AVE
   number: '1000'

--- a/examples/addresses/address_all_missing_address_levels.yaml
+++ b/examples/addresses/address_all_missing_address_levels.yaml
@@ -1,0 +1,17 @@
+---
+id: overture:addresses:addres:1
+type: Feature
+geometry:
+  type: Point
+  coordinates: [-71.2086153, 42.3373725]
+properties:
+  theme: addresses
+  type: address
+  version: 0
+  country: US
+  address_levels:
+    - null
+    - null
+  postcode: '02459'
+  street: COMMONWEALTH AVE
+  number: '1000'

--- a/examples/addresses/address_missing_address_level.yaml
+++ b/examples/addresses/address_missing_address_level.yaml
@@ -10,8 +10,8 @@ properties:
   version: 0
   country: US
   address_levels:
-    - null
     - value: NEWTON CENTRE
+    - {}
   postcode: '02459'
   street: COMMONWEALTH AVE
   number: '1000'

--- a/examples/addresses/address_missing_address_level.yaml
+++ b/examples/addresses/address_missing_address_level.yaml
@@ -10,7 +10,7 @@ properties:
   version: 0
   country: US
   address_levels:
-    - value: NEWTON CENTRE
+    - value: MA
     - {}
   postcode: '02459'
   street: COMMONWEALTH AVE

--- a/examples/addresses/address_missing_address_level.yaml
+++ b/examples/addresses/address_missing_address_level.yaml
@@ -1,0 +1,17 @@
+---
+id: overture:addresses:addres:1
+type: Feature
+geometry:
+  type: Point
+  coordinates: [-71.2086153, 42.3373725]
+properties:
+  theme: addresses
+  type: address
+  version: 0
+  country: US
+  address_levels:
+    - null
+    - value: NEWTON CENTRE
+  postcode: '02459'
+  street: COMMONWEALTH AVE
+  number: '1000'

--- a/schema/addresses/address.yaml
+++ b/schema/addresses/address.yaml
@@ -67,10 +67,7 @@ properties:     # JSON Schema: Top-level object properties.
           has not supplied it and we have not derived it from another source,
           the array element can be null.
         type: array
-        items:
-          oneOf:
-            - { "$ref": "#/$defs/propertyContainers/addressLevelContainer" }
-            - type: "null"
+        items: { "$ref": "#/$defs/propertyContainers/addressLevelContainer" }
         minItems: 1
         maxItems: 5
 "$defs":
@@ -83,7 +80,6 @@ properties:     # JSON Schema: Top-level object properties.
         levels with per-country rules indicating which parts of a country's
         address goes to which numbered level.
       type: object
-      required: ["value"]
       properties:
         value:
           type: string

--- a/schema/addresses/address.yaml
+++ b/schema/addresses/address.yaml
@@ -65,7 +65,8 @@ properties:     # JSON Schema: Top-level object properties.
 
           Note: when a level is not known - most likely because the data provider
           has not supplied it and we have not derived it from another source,
-          the array element can be null.
+          the array element container must be present, but the "value" field
+          should be omitted
         type: array
         items: { "$ref": "#/$defs/propertyContainers/addressLevelContainer" }
         minItems: 1

--- a/schema/addresses/address.yaml
+++ b/schema/addresses/address.yaml
@@ -63,7 +63,10 @@ properties:     # JSON Schema: Top-level object properties.
           Other countries could have three or more. The array is ordered
           with the highest levels first.
         type: array
-        items: { "$ref": "#/$defs/propertyContainers/addressLevelContainer" }
+        items:
+          oneOf:
+            - { "$ref": "#/$defs/propertyContainers/addressLevelContainer" }
+            - type: "null"
         minItems: 1
         maxItems: 5
 "$defs":

--- a/schema/addresses/address.yaml
+++ b/schema/addresses/address.yaml
@@ -62,6 +62,10 @@ properties:     # JSON Schema: Top-level object properties.
           and the municipality. In other countries there might be only one.
           Other countries could have three or more. The array is ordered
           with the highest levels first.
+
+          Note: when a level is not known - most likely because the data provider
+          has not supplied it and we have not derived it from another source,
+          the array element can be null.
         type: array
         items:
           oneOf:


### PR DESCRIPTION
# Category

What kind of change is this?
Please select *one* of the following four options.
Consult [Pull request merging criteria](https://github.com/OvertureMaps/schema-wg#Pull-request-merging-criteria) for a description of each category.

1. [ ] Cosmetic change.
2. [ ] Documentation change by member.
3. [ ] Documentation change by Overture tech writer.
4. [x] Material change.

# Description

This fixes a bug in the schema where unknown address_levels were disallowed. Allow them by still requiring the 
addressLevelContainer struct, but make the "value" field optional.

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

1. TODO.

# Testing

jv

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [x] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [x] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/283)
