### PR TITLE
Change defs import to relative path import in division.yml schema

### DIFF
--- a/schema/divisions/division.yaml
+++ b/schema/divisions/division.yaml
@@ -202,5 +202,5 @@ properties:     # JSON Schema: Top-level object properties.
         type: array
         minItems: 1
         uniqueItems: true
-        items: { "$ref": "defs.yaml#/$defs/propertyDefinitions/capitalOfDivisionItem" }
+        items: { "$ref": "./defs.yaml#/$defs/propertyDefinitions/capitalOfDivisionItem" }
       wikidata: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/wikidata" }


### PR DESCRIPTION
# Category

1. [x] Cosmetic change.
2. [ ] Documentation change by member.
3. [ ] Documentation change by Overture tech writer.
4. [ ] Material change.

# Description

From the validity point of view both are valid paths, or should be - it depends on the processor. However, since all imports, except of that one have given convention, it should be like it to facilitate and simplify the processing

# Reference
https://github.com/OvertureMaps/schema/issues/296 

# Testing

No much to test, the path is the same as the one in https://github.com/OvertureMaps/schema/blob/5b33a0236e389793e2dc5a8cd55725a1feb2ec2f/schema/divisions/division.yaml#L197
