### PR TITLE
Require exactly 1 change type label on every schema PR

### DIFF
--- a/.github/workflows/github-actions-enforce-change-type-label.yaml
+++ b/.github/workflows/github-actions-enforce-change-type-label.yaml
@@ -1,0 +1,33 @@
+name: Change Type label verification
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize]
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require exactly one change type label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const allChangeTypeLabels = new Set([
+              'change type - cosmetic 🌹',
+              'change type - documentation - docs team 📝',
+              'change type - documentation - member 📝',
+              'change type - major 🚨',
+              'change type - minor 🤏',
+            ]);
+            const prLabels = context.payload.pull_request.labels.map(label => label.name);
+            const appliedChangeTypeLabels = prLabels.filter(prLabel => allChangeTypeLabels.has(prLabel));
+            if (appliedChangeTypeLabels.length !== 1) {
+              const baseMessage = `The PR must have EXACTLY one of the following CHANGE TYPE labels: ${Array.from(changeTypeLabels).sort().join(', ')}. `
+              let contextualMessage;
+              if (appliedChangeTypeLabels.length === 0) {
+                contextualMessage = 'It currently has no change type label. Add one.'
+              } else {
+                contextualMessage = `It currently has ${appliedChangeTypeLabels.length} change type labels (${JSON.stringify(appliedChangeTypeLabels)}). Remove one.
+              }
+              core.setFailed(baseMessage + contextualMessage);
+            }


### PR DESCRIPTION
# Category

What kind of change is this?

Please select *one* of the following four options.

Consult [Pull request merging criteria](https://github.com/OvertureMaps/schema-wg#Pull-request-merging-criteria) for a description of each category.

1. [ ] Cosmetic change.
2. [ ] Documentation change by member.
3. [ ] Documentation change by Overture tech writer.
4. [ ] Material change.

# Description

*Brief description of the business purpose and effect of the pull request.*

This PR creates an automatic GitHub actions workflow that forces every pull request to have EXACTLY one (no more, no less) of the following change type [labels](https://github.com/OvertureMaps/schema/labels):

![image](https://github.com/user-attachments/assets/103ca092-a049-477f-ae0f-2155d8d6919c)

The purpose behind this change is to:

1. Strengthen the mechanisms that will help us detect MAJOR schema changes and prevent their premature release. (See [Schema versioning and stability](https://lf-overturemaps.atlassian.net/wiki/x/GgDa) on the Overture Confluence wiki).
2. Automatically enforce that every change is categorized.
3. Enable streamlining the PR template by allowing us to delete the change category section.

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

1. [Schema versioning and stability](https://lf-overturemaps.atlassian.net/wiki/x/GgDa)
2. [Pull request merging criteria](https://github.com/OvertureMaps/schema-wg#Pull-request-merging-criteria).
3. https://github.com/OvertureMaps/schema/pull/306

# Testing

*Brief description of the testing done for this change showing why you are confident it works as expected and does not introduce regressions. Provide sample output data where appropriate.* 

N/A - Not really testable until merged. Please review carefully.

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [ ] Add relevant examples.
4. [ ] Add relevant counterexamples.
5. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
6. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
7. [ ] Update Docusaurus documentation, if an update is required.
8. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/<PUT THE PR # HERE>)
