### PR TITLE
[WIP] Add spatial index container

### DIFF
--- a/counterexamples/buildings/bad-confidence-in-source.yaml
+++ b/counterexamples/buildings/bad-confidence-in-source.yaml
@@ -6,8 +6,8 @@ geometry:
   coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]
 properties:
   ext_expected_errors:
-    - "/property/properties/confidence/maximum]: maximum: got 100, want 1"
-    - "/property/properties/confidence/minimum]: minimum: got -1, want 0"
+    - "/sourcePropertyItem/properties/confidence/maximum]: maximum: got 100, want 1"
+    - "/sourcePropertyItem/properties/confidence/minimum]: minimum: got -1, want 0"
   theme: buildings
   type: building
   version: 1

--- a/schema/buildings/building.yaml
+++ b/schema/buildings/building.yaml
@@ -24,7 +24,6 @@ properties:
       - "$ref": ../defs.yaml#/$defs/propertyContainers/namesContainer
       - "$ref": ../defs.yaml#/$defs/propertyContainers/levelContainer
       - "$ref": ./defs.yaml#/$defs/propertyContainers/shapeContainer
-      - "$ref": ../defs.yaml#/$defs/propertyContainers/spatialIndexingContainer
     properties:
       subtype:
         description: >-

--- a/schema/buildings/building.yaml
+++ b/schema/buildings/building.yaml
@@ -24,6 +24,7 @@ properties:
       - "$ref": ../defs.yaml#/$defs/propertyContainers/namesContainer
       - "$ref": ../defs.yaml#/$defs/propertyContainers/levelContainer
       - "$ref": ./defs.yaml#/$defs/propertyContainers/shapeContainer
+      - "$ref": ../defs.yaml#/$defs/propertyContainers/spatialIndexingContainer
     properties:
       subtype:
         description: >-

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -380,3 +380,27 @@ description: Common schema definitions shared by all themes
                 of features with a higher number.
               type: integer
               default: 0
+    spatialIndexingContainer:
+      title: spatial indexing
+      description: Various spatial indexing systems
+      properties:
+        bbox:
+          title: Bounding box that fully contains the feature.
+          type: object
+          properties:
+            xmin:
+              type: number
+              minimum: -180
+              maximum: 180
+            xmax:
+              type: number
+              minimum: -180
+              maximum: 180
+            ymin:
+              type: number
+              minimum: -90
+              maximum: 90
+            ymax:
+              type: number
+              minimum: -90
+              maximum: 90

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -4,18 +4,104 @@ title: Overture Maps Feature Schema Common Definitions
 description: Common schema definitions shared by all themes
 "$defs":
   propertyDefinitions:
-    id:
-      type: string
+    address:
+      type: object
+      unevaluatedProperties: false
+      properties:
+        freeform:
+          description: >-
+            Free-form address that contains street name, house number
+            and other address info
+          type: string
+        locality:
+          description: >-
+            Name of the city or neighborhood where the address is
+            located
+          type: string
+        postcode:
+          description: Postal code where the address is located
+          type: string
+        region: { "$ref": "#/$defs/propertyDefinitions/iso3166_2SubdivisionCode" }
+        country: { "$ref": "#/$defs/propertyDefinitions/iso3166_1Alpha2CountryCode" }
+    allNames:
+      type: object
+      required: [primary]
+      unevaluatedProperties: false
+      properties:
+        primary:
+          description: The most commonly used name.
+          type: string
+          minLength: 1
+          pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
+        common: { "$ref": "#/$defs/propertyDefinitions/commonNames" }
+        rules:
+          description: >-
+            Rules for names that cannot be specified in the simple
+            common names property. These rules can cover other name
+            variants such as official, alternate, and short; and they
+            can optionally include geometric scoping (linear
+            referencing) and side-of-road scoping for complex cases.
+          type: array
+          items: { "$ref": "#/$defs/propertyDefinitions/nameRule" }
+          minItems: 1
+    bbox:
+      title: Bounding box that fully contains the feature.
+      type: object
       description: >-
-        A feature ID. This may be an ID associated with the Global
-        Entity Reference System (GERS) if—and-only-if the feature
-        represents an entity that is part of GERS.
-      minLength: 1
-      pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
-    level:
-      description: Z-order of the feature where 0 is visual level
-      type: integer
-      default: 0
+        A bounding box object explicitly defining the 2d bounds of the feature.
+        Can be converted to an official GeoJSON bbox array as `[bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax]`
+      properties:
+        xmin:
+          type: number
+          minimum: -180
+          maximum: 180
+        xmax:
+          type: number
+          minimum: -180
+          maximum: 180
+        ymin:
+          type: number
+          minimum: -90
+          maximum: 90
+        ymax:
+          type: number
+          minimum: -90
+          maximum: 90
+    commonNames:
+      description: The common translations of the name.
+      type: object
+      minProperties: 1
+      additionalProperties: false
+      patternProperties:
+        "^(?:(?:[A-Za-z]{2,3}(?:-[A-Za-z]{3}){0,3}?)|(?:[A-Za-z]{4,8}))(?:-[A-Za-z]{4})?(?:-[A-Za-z]{2}|[0-9]{3})?(?:-(?:[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(?:-[A-WY-Za-wy-z0-9](?:-[A-Za-z0-9]{2,8})+)*$":
+          description: >-
+            Each entry consists of a key that is an IETF-BCP47 language tag; and
+            a value that reflects the common name in the language represented by
+            the key's language tag.
+
+            The validating regular expression for this property follows the
+            pattern described in https://www.rfc-editor.org/rfc/bcp/bcp47.txt
+            with the exception that private use tags are not supported.
+          "$comment": >-
+            This pattern recognizes BCP-47 language tags at the lexical or
+            syntactic level. It verifies that candidate tags follow the grammar
+            described in the RFC, but not that they are validly registered tag
+            in IANA's language subtag registry.
+
+            In understanding the regular expression, remark that '(:?' indicates
+            a non-capturing group, and that all the top-level or non-nested
+            groups represent top-level components of `langtag` referenced in the
+            syntax section of https://www.rfc-editor.org/rfc/bcp/bcp47.txt. In
+            particular, the top-level groups in left-to-right order represent:
+
+              1. language
+              2. ["-" script]
+              3. ["-" region]
+              4. *("-" variant)
+              5. *("-" extension)
+          type: string
+          minLength: 1
+          pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
     featureType:
       description: Specific feature type within the theme
       type: string
@@ -62,54 +148,56 @@ description: Common schema definitions shared by all themes
         version number in which the feature changed. The downside to
         doing this is that the number would cease to be indicative of
         the "rate of change" of the feature.
-    sources:
-      description: >-
-        The array of source information for the properties of a
-        given feature, with each entry being a source object which
-        lists the property in JSON Pointer notation and the dataset
-        that specific value came from. All features must have a root
-        level source which is the default source if a specific
-        property's source is not specified.
-      type: array
-      items: { "$ref": "#/$defs/propertyDefinitions/property" }
-      minItems: 1
-      uniqueItems: true
-    property:
-      description: >-
-        An object storing the source for a specificed property. The property
-        is a reference to the property element within this Feature, and will be
-        referenced using JSON Pointer Notation RFC 6901
-        (https://datatracker.ietf.org/doc/rfc6901/). The source dataset for
-        that referenced property will be specified in the overture list of
-        approved sources from the Overture Data Working Group that contains
-        the relevant metadata for that dataset including license source organization.
-      type: object
-      required: [property, dataset]
-      unevaluatedProperties: false
-      properties:
-        property:
-          type: string
-        dataset:
-          type: string
-        record_id:
-          type: string
-          description: Refers to the specific record within the dataset that was used.
-        update_time: { "$ref": "#/$defs/propertyDefinitions/featureUpdateTime" }
-        confidence:
-          description: Confidence value from the source dataset, particularly relevant for ML-derived data.
-          type: number
-          minimum: 0
-          maximum: 1
-    theme:
-      description: Top-level Overture theme this feature belongs to
+    id:
       type: string
-      enum:
-        - addresses
-        - base
-        - buildings
-        - divisions
-        - places
-        - transportation
+      description: >-
+        A feature ID. This may be an ID associated with the Global
+        Entity Reference System (GERS) if—and-only-if the feature
+        represents an entity that is part of GERS.
+      minLength: 1
+      pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
+    iso3166_1Alpha2CountryCode:
+      description: ISO 3166-1 alpha-2 country code.
+      type: string
+      minLength: 2
+      maxLength: 2
+      pattern: ^[A-Z]{2}$
+    iso3166_2SubdivisionCode:
+      description: ISO 3166-2 principal subdivision code.
+      type: string
+      minLength: 4
+      maxLength: 6
+      pattern: ^[A-Z]{2}-[A-Z0-9]{1,3}$
+    language:
+      description: >-
+        A IETF-BCP47 language tag.
+
+        The validating regular expression for this property follows the pattern
+        described in https://www.rfc-editor.org/rfc/bcp/bcp47.txt with the
+        exception that private use subtags are omitted from the pattern.
+      type: string
+      pattern: "^(?:(?:[A-Za-z]{2,3}(?:-[A-Za-z]{3}){0,3}?)|(?:[A-Za-z]{4,8}))(?:-[A-Za-z]{4})?(?:-[A-Za-z]{2}|[0-9]{3})?(?:-(?:[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(?:-[A-WY-Za-wy-z0-9](?:-[A-Za-z0-9]{2,8})+)*$"
+      "$comment": >-
+          This pattern recognizes BCP-47 language tags at the lexical or
+          syntactic level. It verifies that candidate tags follow the grammar
+          described in the RFC, but not that they are validly registered tag in
+          IANA's language subtag registry.
+
+          In understanding the regular expression, remark that '(:?' indicates
+          a non-capturing group, and that all the top-level or non-nested
+          groups represent top-level components of `langtag` referenced in the
+          syntax section of https://www.rfc-editor.org/rfc/bcp/bcp47.txt. In
+          particular, the top-level groups in left-to-right order represent:
+
+            1. language
+            2. ["-" script]
+            3. ["-" region]
+            4. *("-" variant)
+            5. *("-" extension)
+    level:
+      description: Z-order of the feature where 0 is visual level
+      type: integer
+      default: 0
     linearlyReferencedPosition:
       description: >-
         Represents a linearly-referenced position between 0% and 100% of
@@ -138,52 +226,6 @@ description: Common schema definitions shared by all themes
       "$comment":
         Ideally we would enforce sorted order of this pair, but sorting
         assertions aren't (yet?) supported by JSON schema.
-    side:
-      description:
-        Represents the side on which something appears relative to a
-        facing or heading direction, e.g. the side of a road relative
-        to the road orientation, or relative to the direction of travel
-        of a person or vehicle.
-      type: string
-      enum: [left, right]
-    openingHours:
-      description: >-
-        Time span or time spans during which something is open or
-        active, specified in the OSM opening hours specification:
-          https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification
-      type: string
-      "$comment": >-
-          Validating the opening hours value is going to have to happen outside of JSON Schema.
-
-          Reasons for using the OSM opening hours specification for
-          transportation rule time restrictions are documented in
-          https://github.com/OvertureMaps/schema-wg/pull/10
-    language:
-      description: >-
-        A IETF-BCP47 language tag.
-
-        The validating regular expression for this property follows the pattern
-        described in https://www.rfc-editor.org/rfc/bcp/bcp47.txt with the
-        exception that private use subtags are omitted from the pattern.
-      type: string
-      pattern: "^(?:(?:[A-Za-z]{2,3}(?:-[A-Za-z]{3}){0,3}?)|(?:[A-Za-z]{4,8}))(?:-[A-Za-z]{4})?(?:-[A-Za-z]{2}|[0-9]{3})?(?:-(?:[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(?:-[A-WY-Za-wy-z0-9](?:-[A-Za-z0-9]{2,8})+)*$"
-      "$comment": >-
-          This pattern recognizes BCP-47 language tags at the lexical or
-          syntactic level. It verifies that candidate tags follow the grammar
-          described in the RFC, but not that they are validly registered tag in
-          IANA's language subtag registry.
-
-          In understanding the regular expression, remark that '(:?' indicates
-          a non-capturing group, and that all the top-level or non-nested
-          groups represent top-level components of `langtag` referenced in the
-          syntax section of https://www.rfc-editor.org/rfc/bcp/bcp47.txt. In
-          particular, the top-level groups in left-to-right order represent:
-
-            1. language
-            2. ["-" script]
-            3. ["-" region]
-            4. *("-" variant)
-            5. *("-" extension)
     nameRule:
       type: object
       required: [variant, value]
@@ -203,140 +245,80 @@ description: Common schema definitions shared by all themes
           type: string
           minLength: 1
           pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
-    allNames:
+    openingHours:
+      description: >-
+        Time span or time spans during which something is open or
+        active, specified in the OSM opening hours specification:
+          https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification
+      type: string
+      "$comment": >-
+          Validating the opening hours value is going to have to happen outside of JSON Schema.
+
+          Reasons for using the OSM opening hours specification for
+          transportation rule time restrictions are documented in
+          https://github.com/OvertureMaps/schema-wg/pull/10
+    side:
+      description:
+        Represents the side on which something appears relative to a
+        facing or heading direction, e.g. the side of a road relative
+        to the road orientation, or relative to the direction of travel
+        of a person or vehicle.
+      type: string
+      enum: [left, right]
+    sourcePropertyItem:
+      description: >-
+        An object storing the source for a specificed property. The property
+        is a reference to the property element within this Feature, and will be
+        referenced using JSON Pointer Notation RFC 6901
+        (https://datatracker.ietf.org/doc/rfc6901/). The source dataset for
+        that referenced property will be specified in the overture list of
+        approved sources from the Overture Data Working Group that contains
+        the relevant metadata for that dataset including license source organization.
       type: object
-      required: [primary]
+      required: [property, dataset]
       unevaluatedProperties: false
       properties:
-        primary:
-          description: The most commonly used name.
+        property:
           type: string
-          minLength: 1
-          pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
-        common: { "$ref": "#/$defs/propertyDefinitions/commonNames" }
-        rules:
-          description: >-
-            Rules for names that cannot be specified in the simple
-            common names property. These rules can cover other name
-            variants such as official, alternate, and short; and they
-            can optionally include geometric scoping (linear
-            referencing) and side-of-road scoping for complex cases.
-          type: array
-          items: { "$ref": "#/$defs/propertyDefinitions/nameRule" }
-          minItems: 1
-    commonNames:
-      description: The common translations of the name.
-      type: object
-      minProperties: 1
-      additionalProperties: false
-      patternProperties:
-        "^(?:(?:[A-Za-z]{2,3}(?:-[A-Za-z]{3}){0,3}?)|(?:[A-Za-z]{4,8}))(?:-[A-Za-z]{4})?(?:-[A-Za-z]{2}|[0-9]{3})?(?:-(?:[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(?:-[A-WY-Za-wy-z0-9](?:-[A-Za-z0-9]{2,8})+)*$":
-          description: >-
-            Each entry consists of a key that is an IETF-BCP47 language tag; and
-            a value that reflects the common name in the language represented by
-            the key's language tag.
-
-            The validating regular expression for this property follows the
-            pattern described in https://www.rfc-editor.org/rfc/bcp/bcp47.txt
-            with the exception that private use tags are not supported.
-          "$comment": >-
-            This pattern recognizes BCP-47 language tags at the lexical or
-            syntactic level. It verifies that candidate tags follow the grammar
-            described in the RFC, but not that they are validly registered tag
-            in IANA's language subtag registry.
-
-            In understanding the regular expression, remark that '(:?' indicates
-            a non-capturing group, and that all the top-level or non-nested
-            groups represent top-level components of `langtag` referenced in the
-            syntax section of https://www.rfc-editor.org/rfc/bcp/bcp47.txt. In
-            particular, the top-level groups in left-to-right order represent:
-
-              1. language
-              2. ["-" script]
-              3. ["-" region]
-              4. *("-" variant)
-              5. *("-" extension)
+        dataset:
           type: string
-          minLength: 1
-          pattern: ^(\S.*)?\S$    # Leading and trailing whitespace are not allowed.
-    iso3166_1Alpha2CountryCode:
-      description: ISO 3166-1 alpha-2 country code.
+        record_id:
+          type: string
+          description: Refers to the specific record within the dataset that was used.
+        update_time: { "$ref": "#/$defs/propertyDefinitions/featureUpdateTime" }
+        confidence:
+          description: Confidence value from the source dataset, particularly relevant for ML-derived data.
+          type: number
+          minimum: 0
+          maximum: 1
+    sources:
+      description: >-
+        The array of source information for the properties of a
+        given feature, with each entry being a source object which
+        lists the property in JSON Pointer notation and the dataset
+        that specific value came from. All features must have a root
+        level source which is the default source if a specific
+        property's source is not specified.
+      type: array
+      items: {"$ref" : "#/$defs/propertyDefinitions/sourcePropertyItem"}
+      minItems: 1
+      uniqueItems: true
+    theme:
+      description: Top-level Overture theme this feature belongs to
       type: string
-      minLength: 2
-      maxLength: 2
-      pattern: ^[A-Z]{2}$
-    iso3166_2SubdivisionCode:
-      description: ISO 3166-2 principal subdivision code.
-      type: string
-      minLength: 4
-      maxLength: 6
-      pattern: ^[A-Z]{2}-[A-Z0-9]{1,3}$
-    address:
-      type: object
-      unevaluatedProperties: false
-      properties:
-        freeform:
-          description: >-
-            Free-form address that contains street name, house number
-            and other address info
-          type: string
-        locality:
-          description: >-
-            Name of the city or neighborhood where the address is
-            located
-          type: string
-        postcode:
-          description: Postal code where the address is located
-          type: string
-        region: { "$ref": "#/$defs/propertyDefinitions/iso3166_2SubdivisionCode" }
-        country: { "$ref": "#/$defs/propertyDefinitions/iso3166_1Alpha2CountryCode" }
+      enum:
+        - addresses
+        - base
+        - buildings
+        - divisions
+        - places
+        - transportation
     wikidata:
       description: A wikidata ID if available, as found on https://www.wikidata.org/.
       type: string
       pattern: ^Q\d+
+
   propertyContainers:
-    overtureFeaturePropertiesContainer:
-      title: overture properties
-      description: Top-level properties shared by all Overture features
-      type: object
-      required: [ theme, type, version ]
-      patternProperties:
-        ^ext_.*$:
-          description: "Additional top-level properties must be prefixed with `ext_`."
-      properties:
-        theme: { "$ref": "#/$defs/propertyDefinitions/theme" }
-        type: { "$ref": "#/$defs/propertyDefinitions/featureType" }
-        version: { "$ref": "#/$defs/propertyDefinitions/featureVersion" }
-        sources: { "$ref": "#/$defs/propertyDefinitions/sources" }
-    namesContainer:
-      title: names
-      description: Properties defining the names of a feature.
-      type: object
-      properties:
-        names:
-          "$ref": "#/$defs/propertyDefinitions/allNames"
-    levelContainer:
-      title: level
-      description: Properties defining feature Z-order, i.e., stacking order
-      type: object
-      properties:
-        level:
-          "$ref": "#/$defs/propertyDefinitions/level"
-    geometricRangeScopeContainer:
-      title: range
-      description: >-
-        Geometric scoping properties defining the range of positions on
-        the segment where something is physically located or where a
-        rule is active.
-      properties:
-        between: { "$ref": "#/$defs/propertyDefinitions/linearlyReferencedRange" }
-    sideScopeContainer:
-      title: side
-      description: >-
-        Geometric scoping properties defining the side of a road modeled when
-        moving along the line from beginning to end
-      properties:
-        side: { "$ref": "#/$defs/propertyDefinitions/side" }
     cartographyContainer:
       description: Defines cartographic hints for optimal use of Overture features in map-making.
       properties:
@@ -380,27 +362,46 @@ description: Common schema definitions shared by all themes
                 of features with a higher number.
               type: integer
               default: 0
-    spatialIndexingContainer:
-      title: spatial indexing
-      description: Various spatial indexing systems
+    geometricRangeScopeContainer:
+      title: range
+      description: >-
+        Geometric scoping properties defining the range of positions on
+        the segment where something is physically located or where a
+        rule is active.
       properties:
-        bbox:
-          title: Bounding box that fully contains the feature.
-          type: object
-          properties:
-            xmin:
-              type: number
-              minimum: -180
-              maximum: 180
-            xmax:
-              type: number
-              minimum: -180
-              maximum: 180
-            ymin:
-              type: number
-              minimum: -90
-              maximum: 90
-            ymax:
-              type: number
-              minimum: -90
-              maximum: 90
+        between: { "$ref": "#/$defs/propertyDefinitions/linearlyReferencedRange" }
+    levelContainer:
+      title: level
+      description: Properties defining feature Z-order, i.e., stacking order
+      type: object
+      properties:
+        level:
+          "$ref": "#/$defs/propertyDefinitions/level"
+    sideScopeContainer:
+      title: side
+      description: >-
+        Geometric scoping properties defining the side of a road modeled when
+        moving along the line from beginning to end
+      properties:
+        side: { "$ref": "#/$defs/propertyDefinitions/side" }
+    namesContainer:
+      title: names
+      description: Properties defining the names of a feature.
+      type: object
+      properties:
+        names:
+          "$ref": "#/$defs/propertyDefinitions/allNames"
+    overtureFeaturePropertiesContainer:
+      title: overture properties
+      description: Top-level properties shared by all Overture features
+      type: object
+      required: [ theme, type, version ]
+      patternProperties:
+        ^ext_.*$:
+          description: "Additional top-level properties must be prefixed with `ext_`."
+      properties:
+        theme: { "$ref": "#/$defs/propertyDefinitions/theme" }
+        type: { "$ref": "#/$defs/propertyDefinitions/featureType" }
+        version: { "$ref": "#/$defs/propertyDefinitions/featureVersion" }
+        sources: { "$ref": "#/$defs/propertyDefinitions/sources" }
+        bbox: { "$ref" : "#/$defs/propertyDefinitions/bbox"}


### PR DESCRIPTION
# Category

What kind of change is this?

Please select *one* of the following five options.

Consult [Pull request merging criteria](https://github.com/OvertureMaps/schema-wg#Pull-request-merging-criteria) for a description of each category.

1. [ ] MAJOR schema change as defined in [Schema versioning and stability](https://lf-overturemaps.atlassian.net/wiki/x/GgDa).
2. [X] MINOR schema change as defined in [Schema versioning and stability](https://lf-overturemaps.atlassian.net/wiki/x/GgDa).
3. [ ] Cosmetic change.
4. [ ] Documentation change by member.
5. [ ] Documentation change by Overture tech writer.

# Description

The `bbox` attribute should really be described in the schema, this adds it.

Instead of a spatial indexing container, it adds `bbox` to the overture properties container. 

# Reference

# Testing

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [ ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/313)
