### PR TITLE
[proposal] add perspectives to base theme

### DIFF
--- a/examples/base/water-body-disputed.yaml
+++ b/examples/base/water-body-disputed.yaml
@@ -1,0 +1,29 @@
+---
+type: Feature
+geometry:
+  type: Polygon
+  coordinates: [[-91.8307764, 43.7899936], [-91.8309309, 43.7901326], [-91.8315202, 43.7906232], [-91.8320790, 43.7911798], [-91.8325770, 43.7917638], [-91.8328390, 43.7921615]  ]
+properties:
+  theme: base
+  type: water
+  subtype: ocean
+  class: ocean
+  names:
+    primary: Gulf of Gerdaus Mercator
+    rules:
+      - variant: disputed
+        language: en
+        value: Gulf of Cartographer's Tears
+  source_tags:
+    water: ocean
+  sources:
+    - record_id: w1234567
+      property: ""
+      dataset: OpenStreetMap
+  is_salt: false
+  is_intermittent: false
+  is_disputed: true
+  perspectives:
+    mode: disputed_by
+    countries: [XX] # Random country disputing the actual feature
+  version: 0

--- a/schema/base/defs.yaml
+++ b/schema/base/defs.yaml
@@ -48,6 +48,22 @@ description: Common schema definitions the base theme (primarily from OSM)
         - unpaved
         - wood
         - woodchips
+    perspectives:
+      description: Political perspectives from which division is viewed.
+      type: object
+      unevaluatedProperties: false
+      required: [mode, countries]
+      properties:
+        mode:
+          description: Whether perspective holder accept or dispute this division.
+          type: string
+          enum: [accepted_by, disputed_by]
+        countries:
+          description: Countries holding the given mode of perspective.
+          type: array
+          items: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/iso3166_1Alpha2CountryCode" }
+          minItems: 1
+          uniqueItems: true
   propertyContainers:
     osmPropertiesContainer:
       title: "OSM Properties"

--- a/schema/base/water.yaml
+++ b/schema/base/water.yaml
@@ -86,3 +86,44 @@ properties:
       is_intermittent:
         description: Is it intermittent water or not
         type: boolean
+      is_disputed:
+        description: >-
+          Indicator if there are entities disputing this division boundary.
+          Information about entities disputing this boundary should be included in perspectives
+          property.
+
+          This property should also be true if boundary between two entities is unclear
+          and this is "best guess". So having it true and no perspectives gives map creators
+          reason not to fully trust the boundary, but use it if they have no other.
+        type: boolean
+      perspectives:
+        description: >-
+          Political perspectives from which this division boundary is considered
+          to be an accurate representation.
+      
+          If this property is absent, then this boundary is not known to
+          be disputed from any political perspective. Consequently,
+          there is only one boundary feature representing the entire
+          real world entity.
+      
+          If this property is present, it means the boundary represents
+          one of several alternative perspectives on the same real-world
+          entity.
+      
+          There are two modes of perspective:
+          
+            1. `accepted_by` means the representation of the boundary is
+               accepted by the listed entities and would be included on
+               a map drawn from their perspective.
+      
+            2. `disputed_by` means the representation of the boundary is
+               disputed by the listed entities and would be excluded
+               from a map drawn from their perspective.
+              
+          When drawing a map from the perspective of a given country,
+          one would start by gathering all the undisputed boundary
+          (with no `perspectives` property), and then adding to that
+          first all boundary explicitly accepted by the country, and
+          second all boundary not explicitly disputed by the country.
+        allOf: 
+          - "$ref": "./defs.yaml#/$defs/propertyDefinitions/perspectives"

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -198,6 +198,7 @@ description: Common schema definitions shared by all themes
             - official
             - alternate
             - short
+            - disputed
         language: { "$ref": "#/$defs/propertyDefinitions/language" }
         value:
           type: string


### PR DESCRIPTION
# Category

What kind of change is this?

Please select *one* of the following five options.

Consult [Pull request merging criteria](https://github.com/OvertureMaps/schema-wg#Pull-request-merging-criteria) for a description of each category.

1. [ ] MAJOR schema change as defined in [Schema versioning and stability](https://lf-overturemaps.atlassian.net/wiki/x/GgDa).
2. [x] MINOR schema change as defined in [Schema versioning and stability](https://lf-overturemaps.atlassian.net/wiki/x/GgDa).
3. [ ] Cosmetic change.
4. [ ] Documentation change by member.
5. [ ] Documentation change by Overture tech writer.

# Major change release plan

TODO: For any non-MAJOR change, delete this whole section.

*For a MAJOR change as defined in [Schema versioning and stability](https://lf-overturemaps.atlassian.net/wiki/x/GgDa),
indicate the expected release date, related minor change steps, and your
public documentation and messaging plan.*

## A. Expected release date for this MAJOR change

TODO.

## B. Related MINOR change steps

- TODO. List each related MINOR change as a bullet.

## C. Public documentation and messaging lan

TODO.

# Description

### Perspectives for Geographic Features

We are all familiar with disputes and perspectives as a function of dealing with administrative names and borders. There also exist complex perspectives over geographic features. Common examples that our users may need to support are the [Sea of Japan](https://en.wikipedia.org/wiki/Sea_of_Japan_naming_dispute#:~:text=A%20dispute%20exists%20over%20the,the%20Standardization%20of%20Geographical%20Names.)  and the [Falkland Islands](https://en.wikipedia.org/wiki/Falkland_Islands_sovereignty_dispute). 

This PR proposes the following changes:
- adds `is_disputed` to the base theme to flag features like mountain points, polygonal water bodies, polygonal land bodies, etc. that may contain disputed name
- adds `perspectives` to the base theme, when used in conjunction with `is_disputed` this allows users to create the proper perspective view.
- adds `disputed` as a valid value to the rules for names. Disputed names may be a separate thing from the common or official names.




TODO.

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

1. TODO.

# Testing

*Brief description of the testing done for this change showing why you are confident it works as expected and does not introduce regressions. Provide sample output data where appropriate.* 

TODO.

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [ ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/<PUT THE PR # HERE>)
