### PR TITLE
Remove superfluous change type info from PR template (minor)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,3 @@
-# Category
-
-What kind of change is this?
-
-Please select *one* of the following five options.
-
-Consult [Pull request merging criteria](https://github.com/OvertureMaps/schema-wg#Pull-request-merging-criteria) for a description of each category.
-
-1. [ ] MAJOR schema change as defined in [Schema versioning and stability](https://lf-overturemaps.atlassian.net/wiki/x/GgDa).
-2. [ ] MINOR schema change as defined in [Schema versioning and stability](https://lf-overturemaps.atlassian.net/wiki/x/GgDa).
-3. [ ] Cosmetic change.
-4. [ ] Documentation change by member.
-5. [ ] Documentation change by Overture tech writer.
-
 # Major change release plan
 
 TODO: For any non-MAJOR change, delete this whole section.
@@ -28,7 +14,7 @@ TODO.
 
 - TODO. List each related MINOR change as a bullet.
 
-## C. Public documentation and messaging lan
+## C. Public documentation and messaging plan
 
 TODO.
 
@@ -61,7 +47,7 @@ TODO.
 5. [ ] Update Docusaurus documentation, if an update is required.
 6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.
 
-# Documentation Website
+# Documentation website
 
 *Update the hyperlink below to put the pull request number in.*
 


### PR DESCRIPTION
# Description

This PR removes the `# Category` heading from the top of the PR template. Since change type is now handled (better) with the label system and associated GitHub action check, the *Category* is redundant.

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

N/A

# Testing

*Brief description of the testing done for this change showing why you are confident it works as expected and does not introduce regressions. Provide sample output data where appropriate.* 

N/A

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [ ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation Website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/322)
