### PR TITLE
Add is_indoor roadFlag

### DIFF
--- a/examples/transportation/segment/road/road-indoors.yaml
+++ b/examples/transportation/segment/road/road-indoors.yaml
@@ -1,5 +1,5 @@
 ---
-id: overture:transportation:segment:example:indoors
+id: overture:transportation:segment:example:indoor
 type: Feature
 geometry:
   type: LineString
@@ -14,4 +14,4 @@ properties:
   road_surface:
     - value: unknown
   road_flags:
-    - values: [is_indoors]
+    - values: [is_indoor]

--- a/examples/transportation/segment/road/road-indoors.yaml
+++ b/examples/transportation/segment/road/road-indoors.yaml
@@ -1,0 +1,17 @@
+---
+id: overture:transportation:segment:example:indoors
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  # Overture properties
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: road
+  class: tertiary
+  road_surface:
+    - value: unknown
+  road_flags:
+    - values: [is_indoors]

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -217,6 +217,7 @@ properties:
         - is_under_construction
         - is_abandoned
         - is_covered
+        - is_indoors
     roadSurface:
       description: Physical surface of the road
       type: string

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -217,7 +217,7 @@ properties:
         - is_under_construction
         - is_abandoned
         - is_covered
-        - is_indoors
+        - is_indoor
     roadSurface:
       description: Physical surface of the road
       type: string


### PR DESCRIPTION
# Description

Adds the road flag `is_indoor` to handle the inclusion of indoor road segments, which have been filtered until now as a result of https://github.com/OvertureMaps/tf-transportation/issues/83.

These segments are mostly footways and steps, and could be useful for indoor routing.

# Reference

1. https://github.com/OvertureMaps/tf-transportation/issues/421#event-16355827551
2. https://github.com/OvertureMaps/tf-transportation/pull/428
3. https://github.com/OvertureMaps/tf-transportation/issues/83

# Testing

Testing completed during [implementation](https://github.com/OvertureMaps/tf-transportation/pull/428)

# Checklist

1. [x] Add relevant examples.
4. [x] Add relevant counterexamples.
5. [x] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
6. [x] Update in-schema documentation using plain English written in complete sentences, if an update is required.
7. [x] Update Docusaurus documentation, if an update is required.
8. [x] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/327)
