### PR TITLE
Remove bbox from schema

### DIFF
--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -44,29 +44,6 @@ description: Common schema definitions shared by all themes
           type: array
           items: { "$ref": "#/$defs/propertyDefinitions/nameRule" }
           minItems: 1
-    bbox:
-      title: Bounding box that fully contains the feature.
-      type: object
-      description: >-
-        A bounding box object explicitly defining the 2d bounds of the feature.
-        Can be converted to an official GeoJSON bbox array as `[bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax]`
-      properties:
-        xmin:
-          type: number
-          minimum: -180
-          maximum: 180
-        xmax:
-          type: number
-          minimum: -180
-          maximum: 180
-        ymin:
-          type: number
-          minimum: -90
-          maximum: 90
-        ymax:
-          type: number
-          minimum: -90
-          maximum: 90
     commonNames:
       description: The common translations of the name.
       type: object
@@ -404,4 +381,3 @@ description: Common schema definitions shared by all themes
         type: { "$ref": "#/$defs/propertyDefinitions/featureType" }
         version: { "$ref": "#/$defs/propertyDefinitions/featureVersion" }
         sources: { "$ref": "#/$defs/propertyDefinitions/sources" }
-        bbox: { "$ref" : "#/$defs/propertyDefinitions/bbox"}


### PR DESCRIPTION
# Description

So here's the deal:

Since `bbox` is a top-level GeoJSON property, validators are upset with the notion of including it inside of `properties`, even though it's different.

Ultimately, our JSON schema declares how Overture data _should be_ represented as GeoJSON. A complete and valid conversion of our data from parquet to GeoJSON is as follows:

```
{
  "id": <id as string>,
  "bbox": <Build from `bbox` struct as [bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax],
  "geometry": <Convert from WKB to GeoJSON>,
  "properties": {
     ...everything else (Excluding id, bbox, geometry)
  }
}
```

Rather than include the bbox struct in the JSON schema, we should be very clearly documenting the above transformation in our schema docs and describing the `bbox` struct and how to use it in our docs. 

(We could probably do more to describe just the _difference_ between a GeoJSON representation and our parquet data structure). 

# Reference

# Testing

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [ ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/330)
