### PR TITLE
Update water.yaml to specify `string` as type

### DIFF
--- a/schema/base/water.yaml
+++ b/schema/base/water.yaml
@@ -44,6 +44,7 @@ properties:
       class:
         description: Further description of the type of water
         default: [water]
+        type: string
         enum:
           - basin
           - bay


### PR DESCRIPTION
# Description

Adds a type to fix the parquet conversion. 

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/336)
