### PR TITLE
Adds `names` to building part officially.

### DIFF
--- a/counterexamples/buildings/bad-type.json
+++ b/counterexamples/buildings/bad-type.json
@@ -8,6 +8,6 @@
   "properties": {
     "theme": "buildings",
     "type": "fake",
-    "version": 1,
+    "version": 1
   }
 }

--- a/counterexamples/buildings/building-part-bad-name.yaml
+++ b/counterexamples/buildings/building-part-bad-name.yaml
@@ -1,0 +1,32 @@
+---
+id: overture:buildings:part:2345
+type: Feature
+geometry:
+  type: Polygon
+  coordinates: [[
+            [-77.036873, 38.897804],
+            [-77.036873, 38.897559],
+            [-77.036260, 38.897559],
+            [-77.036260, 38.897804],
+            [-77.036873, 38.897804]
+          ]]
+properties:
+  # Overture properties
+  theme: buildings
+  type: building_part
+  version: 1
+  level: 1
+  building_id: abc1234
+  names:
+    main: "East Wing"
+  height: 21.34
+  num_floors: 4
+  min_height: 15.0
+  min_floor: 2
+  roof_shape: dome
+  roof_orientation: across
+  roof_direction: 23.4
+  roof_height: 3.4
+  sources:
+  - property: ""
+    dataset: OpenStreetMap

--- a/examples/buildings/building-part-name.yaml
+++ b/examples/buildings/building-part-name.yaml
@@ -1,0 +1,32 @@
+---
+id: overture:buildings:part:2345
+type: Feature
+geometry:
+  type: Polygon
+  coordinates: [[
+            [-77.036873, 38.897804],
+            [-77.036873, 38.897559],
+            [-77.036260, 38.897559],
+            [-77.036260, 38.897804],
+            [-77.036873, 38.897804]
+          ]]
+properties:
+  # Overture properties
+  theme: buildings
+  type: building_part
+  version: 1
+  level: 1
+  building_id: abc1234
+  names:
+    primary: "East Wing"
+  height: 21.34
+  num_floors: 4
+  min_height: 15.0
+  min_floor: 2
+  roof_shape: dome
+  roof_orientation: across
+  roof_direction: 23.4
+  roof_height: 3.4
+  sources:
+  - property: ""
+    dataset: OpenStreetMap

--- a/schema/buildings/building_part.yaml
+++ b/schema/buildings/building_part.yaml
@@ -17,6 +17,7 @@ properties:
     unevaluatedProperties: false
     allOf:
       - "$ref": ../defs.yaml#/$defs/propertyContainers/overtureFeaturePropertiesContainer
+      - "$ref": ../defs.yaml#/$defs/propertyContainers/namesContainer
       - "$ref": ../defs.yaml#/$defs/propertyContainers/levelContainer
       - "$ref": ./defs.yaml#/$defs/propertyContainers/shapeContainer
     required: [building_id]


### PR DESCRIPTION
# Description

We previously had `names` on building parts, but it wasn't actually in the schema. We took names out when it started failing the new schema validation. 

The Buildings TF actually wants the `names` on building parts, so this PR adds it back.

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

# Testing

*Brief description of the testing done for this change showing why you are confident it works as expected and does not introduce regressions. Provide sample output data where appropriate.* 

Tests Pass ✅ 

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [x] Add relevant examples.
2. [x] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/341)
