### PR TITLE
Linear Referencing for Sources

### DIFF
--- a/counterexamples/transportation/segment/bad-source-between.yaml
+++ b/counterexamples/transportation/segment/bad-source-between.yaml
@@ -1,0 +1,24 @@
+---
+id: overture:transportation:segment:123
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  ext_expected_errors:
+    - "minItems: got 0, want 2"
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: road
+  class: secondary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
+  sources:
+    - record_id: w123
+      property: ""
+      dataset: some source
+      between: []

--- a/docs/schema/0-Schema.mdx
+++ b/docs/schema/0-Schema.mdx
@@ -49,7 +49,7 @@ In the Overture schema, all features have a unique `id` called a [GERS ID](https
 | **theme** | *string* | one of six Overture data themes |
 | **type** | *string* | one of 14 Overture feature types | 
 | **version** | *int32* | version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed |
-| **sources** | *list\<element: struct\<property: string, dataset: string, record_id: string, update_time: string, confidence: double\>\>* | array of source information for the properties of a given feature |
+| **sources** | *list\<element: struct\<property: string, dataset: string, record_id: string, update_time: string, confidence: double, between: list\<double\>\>\>* | array of source information for the properties of a given feature |
 </details>
 
 ### Other key schema properties

--- a/examples/transportation/segment/road/road-with-lr-sources.yaml
+++ b/examples/transportation/segment/road/road-with-lr-sources.yaml
@@ -1,0 +1,32 @@
+---
+id: overture:transportation:segment:456
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1], [2, 2]]
+properties:
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: road
+  class: secondary
+  connectors:
+    - connector_id: startConnector
+      at: 0
+    - connector_id: endConnector
+      at: 1
+  names:
+    primary: Main Street
+  sources:
+    - property: ""
+      dataset: OpenStreetMap
+      record_id: w12345@1
+      between:
+        - 0
+        - 0.5
+    - property: ""
+      dataset: OpenStreetMap
+      record_id: w67890@1
+      between:
+        - 0.5
+        - 1

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -253,6 +253,8 @@ description: Common schema definitions shared by all themes
         the relevant metadata for that dataset including license source organization.
       type: object
       required: [property, dataset]
+      allOf:
+        - { "$ref": "#/$defs/propertyContainers/geometricRangeScopeContainer" }
       unevaluatedProperties: false
       properties:
         property:

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -193,7 +193,7 @@ description: Common schema definitions shared by all themes
         Represents a non-empty range of positions along a path as a pair
         linearly-referenced positions. For example, the pair [0.25, 0.5]
         represents the range beginning 25% of the distance from the
-        start of the path and ending 50% oof the distance from the path
+        start of the path and ending 50% of the distance from the path
         start.
       type: array
       items: { "$ref": "#/$defs/propertyDefinitions/linearlyReferencedPosition" }


### PR DESCRIPTION
# Description

Transportation segments are composed from many individual features, primarily sourced from OSM. OSM features by design must have attributes that apply to the entire feature, so using linear referencing allows us to maintain a stable network even as rich attributes continue to be added upstream, because we don’t have to re-segment in lock-step with OSM.

For a consumer of transportation, it is currently impossible to trace how a segment was stitched together all the way back to the OSM feature. This is problematic in particular for the GERS bridge tables, which need the ability to map sources to Overture features. It’s also been a pain point for individuals using the transportation splitter, who want to identify the subset of contributing sources after splitting.

Sources is the only Overture attribute for segments that does not have linear referencing.

# Reference

1. https://lf-overturemaps.atlassian.net/wiki/spaces/PROJ/pages/258244658/0004+-+Linear+Referencing+for+Sources
2. https://github.com/OvertureMaps/tf-transportation/pull/395
3. Schema TF meeting minutes [2025-04-30](https://github.com/OvertureMaps/schema-wg/issues/360)

# Testing

Added new examples, counterexamples

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [X] Add relevant examples.
4. [X] Add relevant counterexamples.
5. [X] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
6. [X] Update in-schema documentation using plain English written in complete sentences, if an update is required.
7. [X] Update Docusaurus documentation, if an update is required.
8. [X] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/346)
