### PR TITLE
Ensure some places attribute list fields cannot be empty

### DIFF
--- a/counterexamples/places/bad-empty-emails.yaml
+++ b/counterexamples/places/bad-empty-emails.yaml
@@ -1,0 +1,46 @@
+---
+id: overture:places:place:1
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    primary: some_category
+  confidence: 0.9
+  websites:
+    - https://www.example.com
+  emails: []
+  socials:
+    - https://www.twitter.com/example
+  phones:
+    - +32 1207
+  brand:
+    names:
+      primary: My Sweet POI Brand
+    wikidata: Q1000
+  addresses:
+    - freeform: "770 Broadway, Floor 8"
+      locality: "New York"
+    - freeform: "770 Brodway, #802"
+      locality: "New York"
+      region: "US-NY"
+      country: "US"
+  # Overture properties
+  theme: places
+  type: place
+  version: 1
+  sources:
+    - property: ""
+      dataset: metaPlaces
+      record_id: "10101"
+    - property: "/properties/brand"
+      dataset: msftPlaces
+      record_id: "10df72b8"
+  names:
+    primary: My Sweet POI
+    common:
+      es: Something in Spanish
+    rules:
+      - variant: short
+        value: MSPOI

--- a/counterexamples/places/bad-empty-phones.yaml
+++ b/counterexamples/places/bad-empty-phones.yaml
@@ -1,0 +1,46 @@
+---
+id: overture:places:place:1
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    primary: some_category
+  confidence: 0.9
+  websites:
+    - https://www.example.com
+  emails:
+    - info@example.com
+  socials:
+    - https://www.twitter.com/example
+  phones: []
+  brand:
+    names:
+      primary: My Sweet POI Brand
+    wikidata: Q1000
+  addresses:
+    - freeform: "770 Broadway, Floor 8"
+      locality: "New York"
+    - freeform: "770 Brodway, #802"
+      locality: "New York"
+      region: "US-NY"
+      country: "US"
+  # Overture properties
+  theme: places
+  type: place
+  version: 1
+  sources:
+    - property: ""
+      dataset: metaPlaces
+      record_id: "10101"
+    - property: "/properties/brand"
+      dataset: msftPlaces
+      record_id: "10df72b8"
+  names:
+    primary: My Sweet POI
+    common:
+      es: Something in Spanish
+    rules:
+      - variant: short
+        value: MSPOI

--- a/counterexamples/places/bad-empty-socials.yaml
+++ b/counterexamples/places/bad-empty-socials.yaml
@@ -1,0 +1,46 @@
+---
+id: overture:places:place:1
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    primary: some_category
+  confidence: 0.9
+  websites:
+    - https://www.example.com
+  emails:
+    - info@example.com
+  socials: []
+  phones:
+    - +32 1207
+  brand:
+    names:
+      primary: My Sweet POI Brand
+    wikidata: Q1000
+  addresses:
+    - freeform: "770 Broadway, Floor 8"
+      locality: "New York"
+    - freeform: "770 Brodway, #802"
+      locality: "New York"
+      region: "US-NY"
+      country: "US"
+  # Overture properties
+  theme: places
+  type: place
+  version: 1
+  sources:
+    - property: ""
+      dataset: metaPlaces
+      record_id: "10101"
+    - property: "/properties/brand"
+      dataset: msftPlaces
+      record_id: "10df72b8"
+  names:
+    primary: My Sweet POI
+    common:
+      es: Something in Spanish
+    rules:
+      - variant: short
+        value: MSPOI

--- a/counterexamples/places/bad-empty-websites.yaml
+++ b/counterexamples/places/bad-empty-websites.yaml
@@ -1,0 +1,46 @@
+---
+id: overture:places:place:1
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    primary: some_category
+  confidence: 0.9
+  websites: []
+  emails:
+    - info@example.com
+  socials:
+    - https://www.twitter.com/example
+  phones:
+    - +32 1207
+  brand:
+    names:
+      primary: My Sweet POI Brand
+    wikidata: Q1000
+  addresses:
+    - freeform: "770 Broadway, Floor 8"
+      locality: "New York"
+    - freeform: "770 Brodway, #802"
+      locality: "New York"
+      region: "US-NY"
+      country: "US"
+  # Overture properties
+  theme: places
+  type: place
+  version: 1
+  sources:
+    - property: ""
+      dataset: metaPlaces
+      record_id: "10101"
+    - property: "/properties/brand"
+      dataset: msftPlaces
+      record_id: "10df72b8"
+  names:
+    primary: My Sweet POI
+    common:
+      es: Something in Spanish
+    rules:
+      - variant: short
+        value: MSPOI

--- a/examples/places/place-no-emails-phones-socials-websites.yaml
+++ b/examples/places/place-no-emails-phones-socials-websites.yaml
@@ -1,0 +1,39 @@
+---
+id: overture:places:place:1
+type: Feature
+geometry:
+  type: Point
+  coordinates: [0, 0]
+properties:
+  categories:
+    primary: some_category
+  confidence: 0.9
+  brand:
+    names:
+      primary: My Sweet POI Brand
+    wikidata: Q1000
+  addresses:
+    - freeform: "770 Broadway, Floor 8"
+      locality: "New York"
+    - freeform: "770 Brodway, #802"
+      locality: "New York"
+      region: "US-NY"
+      country: "US"
+  # Overture properties
+  theme: places
+  type: place
+  version: 1
+  sources:
+    - property: ""
+      dataset: metaPlaces
+      record_id: "10101"
+    - property: "/properties/brand"
+      dataset: msftPlaces
+      record_id: "10df72b8"
+  names:
+    primary: My Sweet POI
+    common:
+      es: Something in Spanish
+    rules:
+      - variant: short
+        value: MSPOI

--- a/schema/places/place.yaml
+++ b/schema/places/place.yaml
@@ -53,6 +53,7 @@ properties:
           type: string
           format: uri
         uniqueItems: true
+        minItems: 1
       socials:
         description: The social media URLs of the place.
         type: array
@@ -60,6 +61,7 @@ properties:
           type: string
           format: uri
         uniqueItems: true
+        minItems: 1
       emails:
         description: The email addresses of the place.
         type: array
@@ -67,12 +69,14 @@ properties:
           type: string
           format: email
         uniqueItems: true
+        minItems: 1
       phones:
         description: The phone numbers of the place.
         type: array
         items:
           type: string
         uniqueItems: true
+        minItems: 1
       brand:
         description: >-
           The brand of the place. A location with multiple brands is
@@ -88,3 +92,4 @@ properties:
         items:
           "$ref": "../defs.yaml#/$defs/propertyDefinitions/address"
         uniqueItems: true
+        minItems: 1


### PR DESCRIPTION
Set minItems to 1 on each of emails, phones, socials, websites in places. Add counterexamples

# Description

The May 2025-05-21.0 Overture release introduced records where the websites field could be empty instead of null. Some records have the website field as null, some have as empty array. This is inconsistent. To ensure we don't allow this going forward, we ensure that minItems on emails, phones, socials, websites have minItems of 1. Add a new counterexample for each of those fields.

# Testing

Unit tests.

TODO.

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [x] Add relevant examples.
2. [x] Add relevant counterexamples.
3. [n/a] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [n/a] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/350)
