### PR TITLE
Improve example validity

### DIFF
--- a/counterexamples/places/bad-geometry.yaml
+++ b/counterexamples/places/bad-geometry.yaml
@@ -5,5 +5,8 @@ geometry:
   type: MultiPolygon
   coordinates: [[[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]]
 properties:
+  theme: places
+  type: place
+  version: 0
   categories:
     primary: a_category

--- a/examples/base/water-river-example.yaml
+++ b/examples/base/water-river-example.yaml
@@ -1,4 +1,5 @@
 ---
+id: overture:base:water:123
 type: Feature
 geometry:
   type: LineString

--- a/examples/base/water-river-with-wikidata.yaml
+++ b/examples/base/water-river-with-wikidata.yaml
@@ -1,4 +1,5 @@
 ---
+id: overture:base:water:123
 type: Feature
 geometry:
   type: LineString

--- a/examples/buildings/empire-state-building.json
+++ b/examples/buildings/empire-state-building.json
@@ -18,7 +18,7 @@
     },
     "sources": [
       {
-        "property": "dataset",
+        "property": "",
         "dataset": "OpenStreetMap",
         "record_id": "w34633854@71"
       }

--- a/examples/places/place-null-categories.yaml
+++ b/examples/places/place-null-categories.yaml
@@ -1,29 +1,30 @@
 geometry:
   coordinates:
-  - 0
-  - 0
+    - 0
+    - 0
   type: Point
 id: overture:places:place:1
 properties:
   addresses:
-  - freeform: 770 Broadway, Floor 8
-    locality: New York
-  - country: US
-    freeform: '770 Broadway #802'
-    locality: New York
-    region: US-NY
+    - freeform: 770 Broadway, Floor 8
+      locality: New York
+    - country: US
+      freeform: "770 Broadway #802"
+      locality: New York
+      region: US-NY
   brand:
-    name: Example
+    names:
+      primary: Example
     wikidata: Q1000
   emails:
-  - info@example.com
+    - info@example.com
   phones:
-  - +32 1207
+    - +32 1207
   socials:
-  - https://www.twitter.com/example
+    - https://www.twitter.com/example
   theme: places
   type: place
   version: 1
   websites:
-  - https://www.example.com
+    - https://www.example.com
 type: Feature

--- a/examples/places/place2.yaml
+++ b/examples/places/place2.yaml
@@ -1,31 +1,32 @@
 geometry:
   coordinates:
-  - 0
-  - 0
+    - 0
+    - 0
   type: Point
 id: overture:places:place:1
 properties:
   addresses:
-  - freeform: 770 Broadway, Floor 8
-    locality: New York
-  - country: US
-    freeform: '770 Broadway #802'
-    locality: New York
-    region: US-NY
+    - freeform: 770 Broadway, Floor 8
+      locality: New York
+    - country: US
+      freeform: "770 Broadway #802"
+      locality: New York
+      region: US-NY
   brand:
-    name: Example
+    names:
+      primary: Example
     wikidata: Q1000
   categories:
     primary: some_category
   emails:
-  - info@example.com
+    - info@example.com
   phones:
-  - +32 1207
+    - +32 1207
   socials:
-  - https://www.twitter.com/example
+    - https://www.twitter.com/example
   theme: places
   type: place
   version: 1
   websites:
-  - https://www.example.com
+    - https://www.example.com
 type: Feature

--- a/examples/transportation/segment/road/road-with-lr-sources.yaml
+++ b/examples/transportation/segment/road/road-with-lr-sources.yaml
@@ -18,7 +18,7 @@ properties:
   names:
     primary: Main Street
   sources:
-    - property: ""
+    - property: "/names/primary"
       dataset: OpenStreetMap
       record_id: w12345@1
       between:


### PR DESCRIPTION
# Description

This fixes a number of (minor) validity problems with the examples discovered while experimenting with Zod and Pydantic.

Replaces #355.

# Reference

n/a

# Testing

`./test.sh` passes successfully.

These were also tested as part of (partial) Zod and Pydantic ports of the JSON Schema.