### PR TITLE
Remove confusing licensing information from schema repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,6 @@ The Overture Maps schema working group is responsible for designing the Overture
 The contents of this repository are presented in a more human-friendly format at [docs.overturemaps.org](https://docs.overturemaps.org/)
 
 ## Feedback
-Please use the [Discussions](https://github.com/OvertureMaps/schema/discussions) in this repository to provide feedback.
+Please provide feedback or ask questions at [Discussions](https://github.com/orgs/OvertureMaps/discussions).
 
----
 
-## Licensing
-### Copyright Licensing
-Each Working Group must specify the copyright license under which it will operate prior to initiating any work on any Draft Deliverable or Approved Deliverable other than source code or datasets. Source code and dataset copyright licenses are discussed below.
-
-### Patent License
-Each Working Group must specify the patent policy under which it will operate prior to initiating any work on any Draft Deliverable or Approved Deliverable. The patent policy for this Working Group is W3C https://www.w3.org/Consortium/Patent-Policy-20200915/
-
-### Source Code
-Working Group Participants contributing code to this Working Group must do so in source code form, and agree that those source code contributions are subject to the Developer Certificate of Origin version 1.1, available at http://developercertificate.org/, the license indicated below, and any policies and governance rules included in the source code’s repository. Source code may not be a required element of an Approved Deliverable specification
-
-- MIT License, available at https://opensource.org/licenses/MIT.
-
-### Dataset
-Working Group Participants contributing data to a dataset to this Working Group agree that those data contributions are subject to the license indicated below. The dataset may not be a required element of an Approved Deliverable specification.
-
-- For Overture data layers which are CDLA Permissive 2.0, there are no restrictions on use of external data other than the attribution requirements of that license.
-- For Overture data layers which are ODbL, those layers must adhere to ODbL license terms, specifically whether any referenced data is considered a collective database or a derivative database. See [OpenStreetMap Community Guidelines](https://wiki.osmfoundation.org/wiki/Licence/Community_Guidelines) for definitions on the differences.
-
-You are responsible for understanding the licenses relating to data you work with.


### PR DESCRIPTION
# Description

Remove confusing licensing information from schema repo README

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [ ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ x] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/<PUT THE PR # HERE>)
