### PR TITLE
1.11.0 Schema Release

### DIFF
--- a/counterexamples/places/bad-geometry.yaml
+++ b/counterexamples/places/bad-geometry.yaml
@@ -5,5 +5,8 @@ geometry:
   type: MultiPolygon
   coordinates: [[[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]]
 properties:
+  theme: places
+  type: place
+  version: 0
   categories:
     primary: a_category

--- a/examples/base/water-river-example.yaml
+++ b/examples/base/water-river-example.yaml
@@ -1,4 +1,5 @@
 ---
+id: overture:base:water:123
 type: Feature
 geometry:
   type: LineString

--- a/examples/base/water-river-with-wikidata.yaml
+++ b/examples/base/water-river-with-wikidata.yaml
@@ -1,4 +1,5 @@
 ---
+id: overture:base:water:123
 type: Feature
 geometry:
   type: LineString

--- a/examples/buildings/empire-state-building.json
+++ b/examples/buildings/empire-state-building.json
@@ -18,7 +18,7 @@
     },
     "sources": [
       {
-        "property": "dataset",
+        "property": "",
         "dataset": "OpenStreetMap",
         "record_id": "w34633854@71"
       }

--- a/examples/places/place-null-categories.yaml
+++ b/examples/places/place-null-categories.yaml
@@ -1,29 +1,30 @@
 geometry:
   coordinates:
-  - 0
-  - 0
+    - 0
+    - 0
   type: Point
 id: overture:places:place:1
 properties:
   addresses:
-  - freeform: 770 Broadway, Floor 8
-    locality: New York
-  - country: US
-    freeform: '770 Broadway #802'
-    locality: New York
-    region: US-NY
+    - freeform: 770 Broadway, Floor 8
+      locality: New York
+    - country: US
+      freeform: "770 Broadway #802"
+      locality: New York
+      region: US-NY
   brand:
-    name: Example
+    names:
+      primary: Example
     wikidata: Q1000
   emails:
-  - info@example.com
+    - info@example.com
   phones:
-  - +32 1207
+    - +32 1207
   socials:
-  - https://www.twitter.com/example
+    - https://www.twitter.com/example
   theme: places
   type: place
   version: 1
   websites:
-  - https://www.example.com
+    - https://www.example.com
 type: Feature

--- a/examples/places/place2.yaml
+++ b/examples/places/place2.yaml
@@ -1,31 +1,32 @@
 geometry:
   coordinates:
-  - 0
-  - 0
+    - 0
+    - 0
   type: Point
 id: overture:places:place:1
 properties:
   addresses:
-  - freeform: 770 Broadway, Floor 8
-    locality: New York
-  - country: US
-    freeform: '770 Broadway #802'
-    locality: New York
-    region: US-NY
+    - freeform: 770 Broadway, Floor 8
+      locality: New York
+    - country: US
+      freeform: "770 Broadway #802"
+      locality: New York
+      region: US-NY
   brand:
-    name: Example
+    names:
+      primary: Example
     wikidata: Q1000
   categories:
     primary: some_category
   emails:
-  - info@example.com
+    - info@example.com
   phones:
-  - +32 1207
+    - +32 1207
   socials:
-  - https://www.twitter.com/example
+    - https://www.twitter.com/example
   theme: places
   type: place
   version: 1
   websites:
-  - https://www.example.com
+    - https://www.example.com
 type: Feature

--- a/examples/transportation/segment/road/road-with-lr-sources.yaml
+++ b/examples/transportation/segment/road/road-with-lr-sources.yaml
@@ -18,7 +18,7 @@ properties:
   names:
     primary: Main Street
   sources:
-    - property: ""
+    - property: "/names/primary"
       dataset: OpenStreetMap
       record_id: w12345@1
       between:

--- a/schema/base/infrastructure.yaml
+++ b/schema/base/infrastructure.yaml
@@ -38,6 +38,7 @@ properties:
           - pedestrian
           - pier
           - power
+          - quay
           - recreation
           - tower
           - transit
@@ -55,6 +56,7 @@ properties:
           - airstrip
           - apron
           - aqueduct
+          - artwork
           - atm
           - barrier
           - bell_tower
@@ -165,6 +167,7 @@ properties:
           - power_tower
           - private_airport
           - pylon
+          - quay
           - radar
           - railway_halt
           - railway_station

--- a/schema/base/land_use.yaml
+++ b/schema/base/land_use.yaml
@@ -130,6 +130,7 @@ properties:
           - protected
           - protected_landscape_seascape
           - quarry
+          - railway
           - range
           - recreation_ground
           - religious


### PR DESCRIPTION
## What's Changed

Read the full release notes here: https://docs.overturemaps.org/blog/2025/07/23/release-notes/. Below is a list of changes to the schema since the last release.

## Schema-Wide Changes

No changes.

## Theme-Specific Schema Changes

### Addresses (Status: Alpha)

🏗 *The addresses theme is in* ***alpha*** *status. Schema changes with potential backward-incompatibility are likely from month to month until the addresses schema increases in maturity. When these changes occur, we will try to provide some notice and a "bridge" period where the old schema is also supported.*

No changes.

### Base (Status: GA)

🟢 *The base theme is in* ***GA*** *status. We are striving to avoid backwardly-incompatible schema changes and to deliver adequate notice should they occur.*

- Add new subclass for `infrastructure` feature type: `quay`. #357 
- Add new classes for `infrastructure` feature type: `artwork`, `quay`. #357
- Add new class for `land_use` feature type: `railway`. #357

### Buildings (Status: GA)

🟢 *The buildings theme is in* ***GA*** *status. We are striving to avoid backwardly-incompatible schema changes and to deliver adequate notice should they occur.*

No changes.

### Divisions (Status: GA)

🟢 *The divisions theme is in* ***GA*** *status. We are striving to avoid backwardly-incompatible schema changes and to deliver adequate notice should they occur.*

No changes.

### Places (Status: GA)

🟢 *The places theme is in* ***GA*** *status. We are striving to avoid backwardly-incompatible schema changes and to deliver adequate notice should they occur.*

No changes.

### Transportation (Status: GA)

🟢 *The transportation theme is in* ***GA*** *status. We are striving to avoid backwardly-incompatible schema changes and to deliver adequate notice should they occur.*

No Changes.



## Full Changelog
**Full Changelog**: https://github.com/OvertureMaps/schema/compare/v1.10.0...v1.11.0