### PR TITLE
Use formal enum for geometry types (better type safety)

### DIFF
--- a/packages/overture-schema-addresses-theme/src/overture/schema/addresses/address/models.py
+++ b/packages/overture-schema-addresses-theme/src/overture/schema/addresses/address/models.py
@@ -10,6 +10,7 @@ from overture.schema.core import (
 )
 from overture.schema.core.geometry import (
     Geometry,
+    GeometryType,
     GeometryTypeConstraint,
 )
 from overture.schema.core.types import CountryCode, TrimmedString
@@ -47,7 +48,9 @@ class Address(Feature[Literal["addresses"], Literal["address"]]):
 
     # Core
     geometry: Annotated[
-        Geometry, GeometryTypeConstraint("Point"), Field(description="Geometry (Point)")
+        Geometry,
+        GeometryTypeConstraint(GeometryType.POINT),
+        Field(description="Geometry (Point)"),
     ]
 
     # Optional

--- a/packages/overture-schema-base-theme/src/overture/schema/base/bathymetry/models.py
+++ b/packages/overture-schema-base-theme/src/overture/schema/base/bathymetry/models.py
@@ -8,7 +8,7 @@ from overture.schema.base.types import Depth
 from overture.schema.core import (
     Feature,
 )
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import CartographicallyHinted, Stacked
 
 
@@ -24,7 +24,7 @@ class Bathymetry(
 
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("Polygon", "MultiPolygon"),
+        GeometryTypeConstraint(GeometryType.POLYGON, GeometryType.MULTI_POLYGON),
         Field(description="Geometry (Polygon or MultiPolygon)"),
     ]
 

--- a/packages/overture-schema-base-theme/src/overture/schema/base/infrastructure/models.py
+++ b/packages/overture-schema-base-theme/src/overture/schema/base/infrastructure/models.py
@@ -13,7 +13,7 @@ from overture.schema.base.types import Height
 from overture.schema.core import (
     Feature,
 )
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import Named, Stacked
 
 from ..enums import SurfaceMaterial
@@ -34,7 +34,12 @@ class Infrastructure(
 
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("Point", "LineString", "Polygon", "MultiPolygon"),
+        GeometryTypeConstraint(
+            GeometryType.POINT,
+            GeometryType.LINE_STRING,
+            GeometryType.POLYGON,
+            GeometryType.MULTI_POLYGON,
+        ),
         Field(description="Geometry (Point, LineString, Polygon, or MultiPolygon)"),
     ]
 

--- a/packages/overture-schema-base-theme/src/overture/schema/base/land/models.py
+++ b/packages/overture-schema-base-theme/src/overture/schema/base/land/models.py
@@ -10,7 +10,7 @@ from overture.schema.base.types import Elevation
 from overture.schema.core import (
     Feature,
 )
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import Named, Stacked
 
 from ..enums import SurfaceMaterial
@@ -30,7 +30,12 @@ class Land(
 
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("Point", "LineString", "Polygon", "MultiPolygon"),
+        GeometryTypeConstraint(
+            GeometryType.POINT,
+            GeometryType.LINE_STRING,
+            GeometryType.POLYGON,
+            GeometryType.MULTI_POLYGON,
+        ),
         Field(description="Geometry (Point, LineString, Polygon, or MultiPolygon)"),
     ]
 

--- a/packages/overture-schema-base-theme/src/overture/schema/base/land_cover/models.py
+++ b/packages/overture-schema-base-theme/src/overture/schema/base/land_cover/models.py
@@ -8,7 +8,7 @@ from overture.schema.base.land_cover.enums import LandCoverSubtype
 from overture.schema.core import (
     Feature,
 )
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import CartographicallyHinted, Stacked
 
 
@@ -23,7 +23,7 @@ class LandCover(
 
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("Polygon", "MultiPolygon"),
+        GeometryTypeConstraint(GeometryType.POLYGON, GeometryType.MULTI_POLYGON),
         Field(description="Geometry (Polygon or MultiPolygon)"),
     ]
 

--- a/packages/overture-schema-base-theme/src/overture/schema/base/land_use/models.py
+++ b/packages/overture-schema-base-theme/src/overture/schema/base/land_use/models.py
@@ -10,7 +10,7 @@ from overture.schema.base.types import Elevation
 from overture.schema.core import (
     Feature,
 )
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import Named, Stacked
 
 from ..enums import SurfaceMaterial
@@ -30,7 +30,12 @@ class LandUse(
 
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("Point", "LineString", "Polygon", "MultiPolygon"),
+        GeometryTypeConstraint(
+            GeometryType.POINT,
+            GeometryType.LINE_STRING,
+            GeometryType.POLYGON,
+            GeometryType.MULTI_POLYGON,
+        ),
         Field(
             description="Classifications of the human use of a section of land. Translates `landuse` from OpenStreetMap tag from OpenStreetMap.",
         ),

--- a/packages/overture-schema-base-theme/src/overture/schema/base/water/models.py
+++ b/packages/overture-schema-base-theme/src/overture/schema/base/water/models.py
@@ -9,7 +9,7 @@ from overture.schema.base.water.enums import WaterClass, WaterSubtype
 from overture.schema.core import (
     Feature,
 )
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import Named, Stacked
 
 
@@ -27,7 +27,12 @@ class Water(
 
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("Point", "LineString", "Polygon", "MultiPolygon"),
+        GeometryTypeConstraint(
+            GeometryType.POINT,
+            GeometryType.LINE_STRING,
+            GeometryType.POLYGON,
+            GeometryType.MULTI_POLYGON,
+        ),
         Field(
             description="Geometry (Point, LineString, Polygon, or MultiPolygon)",
         ),

--- a/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
@@ -111,23 +111,19 @@
               "items": {
                 "items": {
                   "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
+                    "type": "number"
                   },
-                  "minItems": 4,
+                  "minItems": 2,
                   "type": "array"
                 },
-                "minItems": 1,
+                "minItems": 4,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "MultiPolygon",
+              "const": "Polygon",
               "type": "string"
             }
           },
@@ -150,19 +146,23 @@
               "items": {
                 "items": {
                   "items": {
-                    "type": "number"
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "type": "array"
                   },
-                  "minItems": 2,
+                  "minItems": 4,
                   "type": "array"
                 },
-                "minItems": 4,
+                "minItems": 1,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "Polygon",
+              "const": "MultiPolygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
@@ -478,45 +478,6 @@
             },
             "coordinates": {
               "items": {
-                "items": {
-                  "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
-                  },
-                  "minItems": 4,
-                  "type": "array"
-                },
-                "minItems": 1,
-                "type": "array"
-              },
-              "minItems": 1,
-              "type": "array"
-            },
-            "type": {
-              "const": "MultiPolygon",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "type": "object"
-        },
-        {
-          "properties": {
-            "bbox": {
-              "items": {
-                "type": "number"
-              },
-              "minItems": 4,
-              "type": "array"
-            },
-            "coordinates": {
-              "items": {
                 "type": "number"
               },
               "minItems": 2,
@@ -559,6 +520,45 @@
             },
             "type": {
               "const": "Polygon",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "coordinates"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "bbox": {
+              "items": {
+                "type": "number"
+              },
+              "minItems": 4,
+              "type": "array"
+            },
+            "coordinates": {
+              "items": {
+                "items": {
+                  "items": {
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "type": "array"
+                  },
+                  "minItems": 4,
+                  "type": "array"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "type": {
+              "const": "MultiPolygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-base-theme/tests/land_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_baseline_schema.json
@@ -352,45 +352,6 @@
             },
             "coordinates": {
               "items": {
-                "items": {
-                  "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
-                  },
-                  "minItems": 4,
-                  "type": "array"
-                },
-                "minItems": 1,
-                "type": "array"
-              },
-              "minItems": 1,
-              "type": "array"
-            },
-            "type": {
-              "const": "MultiPolygon",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "type": "object"
-        },
-        {
-          "properties": {
-            "bbox": {
-              "items": {
-                "type": "number"
-              },
-              "minItems": 4,
-              "type": "array"
-            },
-            "coordinates": {
-              "items": {
                 "type": "number"
               },
               "minItems": 2,
@@ -433,6 +394,45 @@
             },
             "type": {
               "const": "Polygon",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "coordinates"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "bbox": {
+              "items": {
+                "type": "number"
+              },
+              "minItems": 4,
+              "type": "array"
+            },
+            "coordinates": {
+              "items": {
+                "items": {
+                  "items": {
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "type": "array"
+                  },
+                  "minItems": 4,
+                  "type": "array"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "type": {
+              "const": "MultiPolygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
@@ -128,23 +128,19 @@
               "items": {
                 "items": {
                   "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
+                    "type": "number"
                   },
-                  "minItems": 4,
+                  "minItems": 2,
                   "type": "array"
                 },
-                "minItems": 1,
+                "minItems": 4,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "MultiPolygon",
+              "const": "Polygon",
               "type": "string"
             }
           },
@@ -167,19 +163,23 @@
               "items": {
                 "items": {
                   "items": {
-                    "type": "number"
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "type": "array"
                   },
-                  "minItems": 2,
+                  "minItems": 4,
                   "type": "array"
                 },
-                "minItems": 4,
+                "minItems": 1,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "Polygon",
+              "const": "MultiPolygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
@@ -430,45 +430,6 @@
             },
             "coordinates": {
               "items": {
-                "items": {
-                  "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
-                  },
-                  "minItems": 4,
-                  "type": "array"
-                },
-                "minItems": 1,
-                "type": "array"
-              },
-              "minItems": 1,
-              "type": "array"
-            },
-            "type": {
-              "const": "MultiPolygon",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "type": "object"
-        },
-        {
-          "properties": {
-            "bbox": {
-              "items": {
-                "type": "number"
-              },
-              "minItems": 4,
-              "type": "array"
-            },
-            "coordinates": {
-              "items": {
                 "type": "number"
               },
               "minItems": 2,
@@ -511,6 +472,45 @@
             },
             "type": {
               "const": "Polygon",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "coordinates"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "bbox": {
+              "items": {
+                "type": "number"
+              },
+              "minItems": 4,
+              "type": "array"
+            },
+            "coordinates": {
+              "items": {
+                "items": {
+                  "items": {
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "type": "array"
+                  },
+                  "minItems": 4,
+                  "type": "array"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "type": {
+              "const": "MultiPolygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-base-theme/tests/water_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/water_baseline_schema.json
@@ -313,45 +313,6 @@
             },
             "coordinates": {
               "items": {
-                "items": {
-                  "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
-                  },
-                  "minItems": 4,
-                  "type": "array"
-                },
-                "minItems": 1,
-                "type": "array"
-              },
-              "minItems": 1,
-              "type": "array"
-            },
-            "type": {
-              "const": "MultiPolygon",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "type": "object"
-        },
-        {
-          "properties": {
-            "bbox": {
-              "items": {
-                "type": "number"
-              },
-              "minItems": 4,
-              "type": "array"
-            },
-            "coordinates": {
-              "items": {
                 "type": "number"
               },
               "minItems": 2,
@@ -394,6 +355,45 @@
             },
             "type": {
               "const": "Polygon",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "coordinates"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "bbox": {
+              "items": {
+                "type": "number"
+              },
+              "minItems": 4,
+              "type": "array"
+            },
+            "coordinates": {
+              "items": {
+                "items": {
+                  "items": {
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "type": "array"
+                  },
+                  "minItems": 4,
+                  "type": "array"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "type": {
+              "const": "MultiPolygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-buildings-theme/src/overture/schema/buildings/building/models.py
+++ b/packages/overture-schema-buildings-theme/src/overture/schema/buildings/building/models.py
@@ -5,7 +5,7 @@ from typing import Annotated, Literal
 from pydantic import ConfigDict, Field
 
 from overture.schema.core import Feature
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import Named, Stacked
 
 from ..models import Shape
@@ -29,9 +29,9 @@ class Building(
     # Core
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("Polygon", "MultiPolygon"),
+        GeometryTypeConstraint(GeometryType.POLYGON, GeometryType.MULTI_POLYGON),
         Field(
-            description="""A regular building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). It MUST be a Polygon or MultiPolygon as defined by the GeoJSON schema.""",
+            description="""The building's footprint or roofprint (if traced from aerial/satellite imagery).""",
         ),
     ]
 

--- a/packages/overture-schema-buildings-theme/src/overture/schema/buildings/building_part/models.py
+++ b/packages/overture-schema-buildings-theme/src/overture/schema/buildings/building_part/models.py
@@ -5,7 +5,7 @@ from typing import Annotated, Literal
 from pydantic import Field
 
 from overture.schema.core import Feature
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import Named, Stacked
 from overture.schema.core.types import Id
 
@@ -24,9 +24,9 @@ class BuildingPart(
     # Core
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("Polygon", "MultiPolygon"),
+        GeometryTypeConstraint(GeometryType.POLYGON, GeometryType.MULTI_POLYGON),
         Field(
-            description="The part's geometry. It must be a polygon or multipolygon.",
+            description="The part's geometry.",
         ),
     ]
 

--- a/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
@@ -391,8 +391,43 @@
   },
   "properties": {
     "geometry": {
-      "description": "A regular building's geometry is defined as its footprint or roofprint (if traced from aerial/satellite imagery). It MUST be a Polygon or MultiPolygon as defined by the GeoJSON schema.",
+      "description": "The building's footprint or roofprint (if traced from aerial/satellite imagery).",
       "oneOf": [
+        {
+          "properties": {
+            "bbox": {
+              "items": {
+                "type": "number"
+              },
+              "minItems": 4,
+              "type": "array"
+            },
+            "coordinates": {
+              "items": {
+                "items": {
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "type": "array"
+                },
+                "minItems": 4,
+                "type": "array"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "type": {
+              "const": "Polygon",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "coordinates"
+          ],
+          "type": "object"
+        },
         {
           "properties": {
             "bbox": {
@@ -423,41 +458,6 @@
             },
             "type": {
               "const": "MultiPolygon",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "type": "object"
-        },
-        {
-          "properties": {
-            "bbox": {
-              "items": {
-                "type": "number"
-              },
-              "minItems": 4,
-              "type": "array"
-            },
-            "coordinates": {
-              "items": {
-                "items": {
-                  "items": {
-                    "type": "number"
-                  },
-                  "minItems": 2,
-                  "type": "array"
-                },
-                "minItems": 4,
-                "type": "array"
-              },
-              "minItems": 1,
-              "type": "array"
-            },
-            "type": {
-              "const": "Polygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
@@ -277,8 +277,43 @@
   },
   "properties": {
     "geometry": {
-      "description": "The part's geometry. It must be a polygon or multipolygon.",
+      "description": "The part's geometry.",
       "oneOf": [
+        {
+          "properties": {
+            "bbox": {
+              "items": {
+                "type": "number"
+              },
+              "minItems": 4,
+              "type": "array"
+            },
+            "coordinates": {
+              "items": {
+                "items": {
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "type": "array"
+                },
+                "minItems": 4,
+                "type": "array"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "type": {
+              "const": "Polygon",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "coordinates"
+          ],
+          "type": "object"
+        },
         {
           "properties": {
             "bbox": {
@@ -309,41 +344,6 @@
             },
             "type": {
               "const": "MultiPolygon",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "type": "object"
-        },
-        {
-          "properties": {
-            "bbox": {
-              "items": {
-                "type": "number"
-              },
-              "minItems": 4,
-              "type": "array"
-            },
-            "coordinates": {
-              "items": {
-                "items": {
-                  "items": {
-                    "type": "number"
-                  },
-                  "minItems": 2,
-                  "type": "array"
-                },
-                "minItems": 4,
-                "type": "array"
-              },
-              "minItems": 1,
-              "type": "array"
-            },
-            "type": {
-              "const": "Polygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-core/tests/test_geometry.py
+++ b/packages/overture-schema-core/tests/test_geometry.py
@@ -1,12 +1,34 @@
+import re
 from collections.abc import Iterator
 from dataclasses import dataclass
 from itertools import chain, combinations
 from typing import Annotated, Any
 
 import pytest
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from pydantic import BaseModel, ValidationError
 from pytest_subtests import SubTests
+
+
+def test_geometry_type_sorted() -> None:
+    enumerated_order = tuple(GeometryType)
+
+    assert enumerated_order == tuple(sorted(enumerated_order))
+
+    indices = [item._value for item in enumerated_order]
+
+    assert indices == list(range(0, len(indices)))
+
+
+def test_geometry_type_geo_json_type() -> None:
+    def to_upper_camel_case(s: str) -> str:
+        parts = re.split(r"[^a-zA-Z0-9]", s)
+        return "".join(word.capitalize() for word in parts if word)
+
+    actual = [item.geo_json_type for item in GeometryType]
+    expected = [to_upper_camel_case(item.name) for item in GeometryType]
+
+    assert actual == expected
 
 
 def test_geometry_type_constraint_empty() -> None:
@@ -25,14 +47,14 @@ def test_geometry_type_constraint_invalid() -> None:
 
 @dataclass
 class GeometryTypeCase:
-    geometry_type: str
+    geometry_type: GeometryType
     examples: tuple[dict[Any, Any], ...] = ()
     counterexamples: tuple[dict[Any, Any], ...] = ()
 
 
 TEST_GEOMETRY_TYPE_CASES: tuple[GeometryTypeCase] = (
     GeometryTypeCase(
-        geometry_type="Point",
+        geometry_type=GeometryType.POINT,
         examples=(
             {"type": "Point", "coordinates": [0, 0]},
             {"type": "Point", "coordinates": [-90, 131.5]},

--- a/packages/overture-schema-divisions-theme/src/overture/schema/divisions/division/models.py
+++ b/packages/overture-schema-divisions-theme/src/overture/schema/divisions/division/models.py
@@ -8,7 +8,7 @@ from overture.schema.core import (
     Feature,
 )
 from overture.schema.core.enums import Side
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import (
     CartographicallyHinted,
     Named,
@@ -61,9 +61,9 @@ class Division(
     # Core
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("Point"),
+        GeometryTypeConstraint(GeometryType.POINT),
         Field(
-            description="""Division geometry MUST be a Point as defined by GeoJSON schema. It represents the approximate location of a position commonly associated with the real-world entity modeled by the division feature.""",
+            description="""Approximate location of a position commonly associated with the real-world entity modeled by the division feature.""",
         ),
     ]
 

--- a/packages/overture-schema-divisions-theme/src/overture/schema/divisions/division_area/models.py
+++ b/packages/overture-schema-divisions-theme/src/overture/schema/divisions/division_area/models.py
@@ -7,7 +7,7 @@ from pydantic import ConfigDict, Field
 from overture.schema.core import (
     Feature,
 )
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import (
     Named,
     Names,
@@ -37,9 +37,9 @@ class DivisionArea(Feature[Literal["divisions"], Literal["division_area"]], Name
     # Core
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("Polygon", "MultiPolygon"),
+        GeometryTypeConstraint(GeometryType.POLYGON, GeometryType.MULTI_POLYGON),
         Field(
-            description="Division area geometries MUST be polygons or multi-polygons as defined by the GeoJSON schema.",
+            description="The area covered by the division with which this area feature is associated",
         ),
     ]
 

--- a/packages/overture-schema-divisions-theme/src/overture/schema/divisions/division_boundary/models.py
+++ b/packages/overture-schema-divisions-theme/src/overture/schema/divisions/division_boundary/models.py
@@ -7,7 +7,7 @@ from pydantic import ConfigDict, Field
 from overture.schema.core import (
     Feature,
 )
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import Perspectives
 from overture.schema.core.types import (
     CountryCode,
@@ -37,9 +37,11 @@ class DivisionBoundary(Feature[Literal["divisions"], Literal["division_boundary"
     # Core
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("LineString", "MultiLineString"),
+        GeometryTypeConstraint(
+            GeometryType.LINE_STRING, GeometryType.MULTI_LINE_STRING
+        ),
         Field(
-            description="Boundary's geometry which MUST be a LineString or MultiLineString as defined by the GeoJSON schema.",
+            description="Boundary line or lines",
         ),
     ]
 

--- a/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
@@ -1,12 +1,12 @@
 {
   "$defs": {
-    "AreaBoundaryClass": {
+    "AreaClass": {
       "description": "Area and boundary class designations.",
       "enum": [
         "land",
         "maritime"
       ],
-      "title": "AreaBoundaryClass",
+      "title": "AreaClass",
       "type": "string"
     },
     "NameRule": {
@@ -236,8 +236,43 @@
   },
   "properties": {
     "geometry": {
-      "description": "Division area geometries MUST be polygons or multi-polygons as defined by the GeoJSON schema.",
+      "description": "The area covered by the division with which this area feature is associated",
       "oneOf": [
+        {
+          "properties": {
+            "bbox": {
+              "items": {
+                "type": "number"
+              },
+              "minItems": 4,
+              "type": "array"
+            },
+            "coordinates": {
+              "items": {
+                "items": {
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "type": "array"
+                },
+                "minItems": 4,
+                "type": "array"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "type": {
+              "const": "Polygon",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "coordinates"
+          ],
+          "type": "object"
+        },
         {
           "properties": {
             "bbox": {
@@ -268,41 +303,6 @@
             },
             "type": {
               "const": "MultiPolygon",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "type": "object"
-        },
-        {
-          "properties": {
-            "bbox": {
-              "items": {
-                "type": "number"
-              },
-              "minItems": 4,
-              "type": "array"
-            },
-            "coordinates": {
-              "items": {
-                "items": {
-                  "items": {
-                    "type": "number"
-                  },
-                  "minItems": 2,
-                  "type": "array"
-                },
-                "minItems": 4,
-                "type": "array"
-              },
-              "minItems": 1,
-              "type": "array"
-            },
-            "type": {
-              "const": "Polygon",
               "type": "string"
             }
           },
@@ -347,7 +347,7 @@
       },
       "properties": {
         "class": {
-          "$ref": "#/$defs/AreaBoundaryClass"
+          "$ref": "#/$defs/AreaClass"
         },
         "country": {
           "description": "ISO 3166-1 alpha-2 country code of the division this area belongs to.",

--- a/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
@@ -337,7 +337,7 @@
   },
   "properties": {
     "geometry": {
-      "description": "Division geometry MUST be a Point as defined by GeoJSON schema. It represents the approximate location of a position commonly associated with the real-world entity modeled by the division feature.",
+      "description": "Approximate location of a position commonly associated with the real-world entity modeled by the division feature.",
       "properties": {
         "bbox": {
           "items": {

--- a/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
@@ -128,7 +128,7 @@
   },
   "properties": {
     "geometry": {
-      "description": "Boundary's geometry which MUST be a LineString or MultiLineString as defined by the GeoJSON schema.",
+      "description": "Boundary line or lines",
       "oneOf": [
         {
           "properties": {

--- a/packages/overture-schema-places-theme/src/overture/schema/places/place/models.py
+++ b/packages/overture-schema-places-theme/src/overture/schema/places/place/models.py
@@ -8,7 +8,7 @@ from overture.schema.core import (
     Feature,
     StrictBaseModel,
 )
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import (
     Address,
     Named,
@@ -72,9 +72,9 @@ class Place(Feature[Literal["places"], Literal["place"]], Named):
     # Required
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("Point"),
+        GeometryTypeConstraint(GeometryType.POINT),
         Field(
-            description="Geometry (Point)",
+            description="Position of the place",
         ),
     ]
 

--- a/packages/overture-schema-places-theme/tests/place_baseline_schema.json
+++ b/packages/overture-schema-places-theme/tests/place_baseline_schema.json
@@ -291,7 +291,7 @@
   },
   "properties": {
     "geometry": {
-      "description": "Geometry (Point)",
+      "description": "Position of the place",
       "properties": {
         "bbox": {
           "items": {

--- a/packages/overture-schema-transportation-theme/src/overture/schema/transportation/connector/models.py
+++ b/packages/overture-schema-transportation-theme/src/overture/schema/transportation/connector/models.py
@@ -7,7 +7,7 @@ from pydantic import ConfigDict, Field
 from overture.schema.core import (
     Feature,
 )
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 
 
 class Connector(Feature[Literal["transportation"], Literal["connector"]]):
@@ -21,8 +21,8 @@ class Connector(Feature[Literal["transportation"], Literal["connector"]]):
     # Core
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("Point"),
+        GeometryTypeConstraint(GeometryType.POINT),
         Field(
-            description="Connector's geometry which MUST be a Point as defined by GeoJSON schema.",
+            description="Position of the connector",
         ),
     ]

--- a/packages/overture-schema-transportation-theme/src/overture/schema/transportation/segment/models.py
+++ b/packages/overture-schema-transportation-theme/src/overture/schema/transportation/segment/models.py
@@ -7,7 +7,7 @@ from pydantic import ConfigDict, Field
 from overture.schema.core import (
     Feature,
 )
-from overture.schema.core.geometry import Geometry, GeometryTypeConstraint
+from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from overture.schema.core.models import (
     Named,
     Stacked,
@@ -41,8 +41,8 @@ class TransportationSegment(
     # Core
     geometry: Annotated[
         Geometry,
-        GeometryTypeConstraint("LineString"),
-        Field(description="Geometry (LineString)"),
+        GeometryTypeConstraint(GeometryType.LINE_STRING),
+        Field(description="Segment centerline"),
     ]
 
     # Required

--- a/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
@@ -62,7 +62,7 @@
   },
   "properties": {
     "geometry": {
-      "description": "Connector's geometry which MUST be a Point as defined by GeoJSON schema.",
+      "description": "Position of the connector",
       "properties": {
         "bbox": {
           "items": {

--- a/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
@@ -613,7 +613,7 @@
       },
       "properties": {
         "geometry": {
-          "description": "Geometry (LineString)",
+          "description": "Segment centerline",
           "properties": {
             "bbox": {
               "items": {
@@ -874,7 +874,7 @@
       },
       "properties": {
         "geometry": {
-          "description": "Geometry (LineString)",
+          "description": "Segment centerline",
           "properties": {
             "bbox": {
               "items": {
@@ -1531,7 +1531,7 @@
       },
       "properties": {
         "geometry": {
-          "description": "Geometry (LineString)",
+          "description": "Segment centerline",
           "properties": {
             "bbox": {
               "items": {


### PR DESCRIPTION
# Description

This is a minor change to use a formal Python `Enum` class to model the geometry types instead of using string values. 

As well as being generally more consistent, this should allow for better IDE introspection and compatibility with other systems that use Python type annotations.

# Testing

```shell
$ make check
```