### PR TITLE
Add bounding box to model [Updated 8/19]

### DIFF
--- a/packages/overture-schema-addresses-theme/tests/address_baseline_schema.json
+++ b/packages/overture-schema-addresses-theme/tests/address_baseline_schema.json
@@ -76,6 +76,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "Geometry (Point)",
       "properties": {

--- a/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
@@ -95,6 +95,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "Geometry (Polygon or MultiPolygon)",
       "oneOf": [

--- a/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
@@ -433,6 +433,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "Geometry (Point, LineString, Polygon, or MultiPolygon)",
       "oneOf": [

--- a/packages/overture-schema-base-theme/tests/land_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_baseline_schema.json
@@ -307,6 +307,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "Geometry (Point, LineString, Polygon, or MultiPolygon)",
       "oneOf": [

--- a/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
@@ -112,6 +112,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "Geometry (Polygon or MultiPolygon)",
       "oneOf": [

--- a/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
@@ -385,6 +385,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "Classifications of the human use of a section of land. Translates `landuse` from OpenStreetMap tag from OpenStreetMap.",
       "oneOf": [

--- a/packages/overture-schema-base-theme/tests/water_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/water_baseline_schema.json
@@ -268,6 +268,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "Geometry (Point, LineString, Polygon, or MultiPolygon)",
       "oneOf": [

--- a/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
@@ -390,6 +390,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "The building's footprint or roofprint (if traced from aerial/satellite imagery).",
       "oneOf": [

--- a/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
@@ -276,6 +276,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "The part's geometry.",
       "oneOf": [

--- a/packages/overture-schema-core/pyproject.toml
+++ b/packages/overture-schema-core/pyproject.toml
@@ -20,6 +20,7 @@ packages = ["src/overture"]
 
 [dependency-groups]
 dev = [
+    "jsonpath-ng>=1.7.0",
     "pytest-subtests>=0.14.2",
     "types-pyyaml>=6.0.12.20250516",
     "types-shapely>=2.1.0.20250710",

--- a/packages/overture-schema-core/src/overture/schema/core/bbox.py
+++ b/packages/overture-schema-core/src/overture/schema/core/bbox.py
@@ -1,0 +1,200 @@
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import (
+    GetCoreSchemaHandler,
+    GetJsonSchemaHandler,
+    ValidationError,
+    ValidationInfo,
+)
+from pydantic_core import InitErrorDetails, core_schema
+
+
+@dataclass(order=True, frozen=True, slots=True)
+class BBox:
+    """
+    Two-dimensional bounding box.
+
+    Parameters
+    ----------
+    xmin : float | int
+        Minimum X-coordinate
+    ymin : float | int
+        Minimum Y-coordiate
+    xmax : float | int
+        Maximum X-coordinate
+    ymax : float | int
+        Maximum Y-coordinate
+
+
+    Attributes
+    ----------
+    xmin : float | int
+        Minimum X-coordinate
+    ymin : float | int
+        Minimum Y-coordiate
+    xmax : float | int
+        Maximum X-coordinate
+    ymax : float | int
+        Maximum Y-coordinate
+
+
+    Examples
+    --------
+    Create a bounding box:
+
+    >>> bbox = BBox(xmin=-123.5, ymin=37.7, xmax=-122.4, ymax=38.0)
+
+    Serialize a bounding box to its GeoJSON representation:
+
+    >>> BBox(1, 2, 3, 4).to_geo_json()
+    (1, 2, 3, 4)
+
+    Read a bounding box from its GeoJSON representation:
+
+    >>> BBox.from_geo_json([1, 2, 3, 4])
+    BBox(xmin=1, ymin=2, xmax=3, ymax=4)
+
+    Read a bounding box from its GeoJSON representation (simplified form for easier interactive use):
+
+    >>> BBox.from_geo_json(1, 2, 3, 4)
+    BBox(xmin=1, ymin=2, xmax=3, ymax=4)
+    """
+
+    xmin: float | int
+    ymin: float | int
+    xmax: float | int
+    ymax: float | int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.xmin, float | int):
+            raise TypeError(f"`xmin` must be a `float` or `int`; but {repr(self.xmin)} is a `{type(self.xmin).__name__}`")
+        elif not isinstance(self.ymin, float | int):
+            raise TypeError(f"`ymin` must be a `float` or `int`; but {repr(self.ymin)} is a `{type(self.ymin).__name__}`")
+        elif not isinstance(self.xmax, float | int):
+            raise TypeError(f"`xmax` must be a `float` or `int`; but {repr(self.xmax)} is a `{type(self.xmax).__name__}`")
+        elif not isinstance(self.ymax, float | int):
+            raise TypeError(f"`ymax` must be a `float` or `int`; but {repr(self.ymax)} is a `{type(self.ymax).__name__}`")
+
+    def to_geo_json(self) -> tuple[float | int, ...]:
+        """
+        Return a GeoJSON-compliant `bbox` array.
+
+        Returns
+        -------
+        tuple of float
+            GeoJSON-compliant bounding box coordinates array.
+        """
+        return (self.xmin, self.ymin, self.xmax, self.ymax)
+
+    @classmethod
+    def from_geo_json(cls, *bbox: float | int | tuple[float | int, ...] | list[float | int]) -> "BBox":
+        """
+        Convert a GeoJSON-compliant `bbox` array into a `Bbox` value.
+
+        Parameters
+        ----------
+        bbox : tuple[float | int, ...] | list[float | int]
+            GeoJSON-compliant `bbox` array containing 4 numbers
+
+        Returns
+        -------
+        BBox
+            `BBox` instance corresponding to the input `bbox` array
+
+        Raises
+        ------
+        TypeError
+            If `bbox` is not a `tuple` or `list` or contains non-numeric values
+        ValueError
+            If `bbox` is a `tuple` or `list` and does not have length 4
+        """
+        if len(bbox) == 1 and isinstance(bbox[0], tuple | list):
+            return cls._from_geo_json(bbox[0])
+        else:
+            return cls._from_geo_json(bbox)
+
+    @classmethod
+    def _from_geo_json(cls, bbox: tuple | list) -> "BBox":
+        n: int = len(bbox)
+
+        if not isinstance(bbox, tuple | list):
+            raise TypeError(
+                f"`bbox` must be a `tuple` or `list`; but {repr(bbox)} is a `{type(bbox).__name__}`"
+            )
+        elif n != 4:
+            raise ValueError(
+                f"`bbox` must have length 4; but {repr(bbox)} has length {n}"
+            )
+
+        incompatible_items = [
+            (i, v, type(v).__name__)
+            for i, v in enumerate(bbox)
+            if not isinstance(v, float | int)
+        ]
+        if len(incompatible_items) > 0:
+            incompatible_str = ",".join(
+                f"{repr(v)} (type `{t}` at index {i})" for (i, v, t) in incompatible_items
+            )
+            raise TypeError(
+                f"`bbox` must contain only `float` or `int`; but {repr(bbox)} contains the following incompatible values: {incompatible_str} "
+            )
+
+        return BBox(bbox[0], bbox[1], bbox[2], bbox[3])
+
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, _source_type: type[Any], _handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        def validator(value: BBox | tuple[float | int, ...] | list[float | int], info: ValidationInfo) -> "BBox":
+            try:
+                if isinstance(value, BBox):
+                    return value
+                elif isinstance(value, tuple | list):
+                    return cls.from_geo_json(value)
+                elif isinstance(value, dict):
+                    BBox(**value)
+                else:
+                    raise TypeError(
+                        f"expected `BBox` or `tuple` or `list`; got `{type(value).__name__}` with value {repr(value)}"
+                    )
+            except Exception as e:
+                context = info.context or {}
+                loc = context.get("loc_prefix", ()) + ("value",)
+                raise ValidationError.from_exception_data(
+                    title=cls.__name__,
+                    line_errors=[
+                        InitErrorDetails(
+                            type="value_error",
+                            loc=loc,
+                            input=value,
+                            ctx={"error": f"invalid bounding box value: {str(e)}"}
+                        )
+                    ]
+                ) from e
+
+        def serialize_bbox(v: "BBox", info: ValidationInfo | None) -> "tuple[float | int, ...] | 'BBox'":
+            if info and info.mode == "json":
+                return v.to_geo_json()
+            return v
+
+        return core_schema.with_info_plain_validator_function(
+            validator,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                serialize_bbox, info_arg=True
+            ),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+    ) -> dict[str, Any]:
+        return {
+            'type': 'array',
+            'minItems': 4,
+            'maxItems': 4,  # Expressly limit to subset of GeoJSON bboxes that are 2D.
+            'items': {
+                'type': 'number',
+            }
+        }

--- a/packages/overture-schema-core/src/overture/schema/core/geometry.py
+++ b/packages/overture-schema-core/src/overture/schema/core/geometry.py
@@ -203,16 +203,18 @@ class Geometry:
         cls, _source_type: type[Any], _handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
         def validator(
-            value: dict[str, Any] | BaseGeometry | bytes | str | Geometry,
+            value: Geometry | dict[str, Any] | BaseGeometry | bytes | str,
             info: ValidationInfo,
         ) -> Geometry:
             try:
-                # Handle Shapely geometry directly
-                if isinstance(value, BaseGeometry):
-                    return cls(value)
+                if isinstance(value, Geometry):
+                    return value
                 # Handle GeoJSON dict
                 elif isinstance(value, dict):
                     return cls.from_geo_json(value)
+                # Handle Shapely geometry directly
+                elif isinstance(value, BaseGeometry):
+                    return cls(value)
                 # Handle WKB bytes
                 elif isinstance(value, bytes):
                     return cls.from_wkb(value)
@@ -221,7 +223,7 @@ class Geometry:
                     return cls.from_wkt(value)
                 else:
                     raise TypeError(
-                        f"Expected dict, BaseGeometry, bytes, str, or Geometry, got {type(value).__name__}"
+                        f"expected `Geometry`, `dict` (GeoJSON), `BaseGeometry`, `bytes` (WKB), or `str` (WKT); got `{type(value).__name__}` with value {value}"
                     )
             except Exception as e:
                 context = info.context or {}

--- a/packages/overture-schema-core/tests/test_bbox.py
+++ b/packages/overture-schema-core/tests/test_bbox.py
@@ -1,0 +1,150 @@
+from typing import Any
+
+import jsonpath_ng  # type: ignore[import-untyped]
+import pytest
+from overture.schema.core.bbox import BBox
+from pydantic import BaseModel, ValidationError
+
+
+@pytest.mark.parametrize("xmin, ymin, xmax, ymax", [
+    ('foo', 2, 3, 4),
+    (1, 'foo', 3, 4),
+    (1, 2, 'foo', 4),
+    (1, 2, 3, 'foo'),
+])
+def test_bbox_construct_invalid_type(xmin: Any, ymin: Any, xmax: Any, ymax: Any) -> None:
+    with pytest.raises(TypeError):
+        BBox(xmin, ymin, xmax, ymax)
+
+
+def test_bbox_construct_positional() -> None:
+    bbox = BBox(1, 2, 3, 4.0)
+
+    assert bbox.xmin == 1
+    assert bbox.ymin == 2
+    assert bbox.xmax == 3
+    assert bbox.ymax == 4.0
+
+
+def test_bbox_construct_keyword() -> None:
+    bbox = BBox(xmin=1.0, ymin=2.0, xmax=3.0, ymax=4)
+
+    assert bbox.xmin == 1.0
+    assert bbox.ymin == 2.0
+    assert bbox.xmax == 3.0
+    assert bbox.ymax == 4
+
+
+def test_bbox_to_geo_json() -> None:
+    bbox = BBox(-10, -20, 30, 40)
+
+    assert bbox.to_geo_json() == (-10, -20, 30, 40)
+
+
+@pytest.mark.parametrize("geo_json, expect", [
+    [(1, 2, 3, 4), BBox(1, 2, 3, 4)],
+    [[-1.0, -2.0, 1.0, 2.0], BBox(-1.0, -2.0, 1.0, 2.0)],
+])
+def test_bbox_from_geo_json_success(geo_json: tuple[float | int, ...], expect: BBox) -> None:
+    # Test the sequence form where you pass in a tuple/list.
+    actual = BBox.from_geo_json(geo_json)
+    assert actual == expect
+
+    # Test the vararg form.
+    actual = BBox.from_geo_json(*geo_json)
+    assert actual == expect
+
+
+@pytest.mark.parametrize("bad_input", [
+    ({}, 2, 3, 4),
+    [1, 2, 3, 'foo'],
+])
+def test_bbox_from_geo_json_type_error(bad_input: Any) -> None:
+    # Test the sequence form where you pass in a tuple/list.
+    with pytest.raises(TypeError):
+        BBox.from_geo_json(bad_input)
+
+    # Test the vararg form.
+    with pytest.raises(TypeError):
+        BBox.from_geo_json(*bad_input)
+
+
+
+@pytest.mark.parametrize("bad_input", [
+    (()),
+    ((1,)),
+    ((1, 2)),
+    ((1, 2, 3)),
+    ((1, 2, 3, 4, 5)),
+    ([]),
+    (['foo']),
+    (['foo', 'bar']),
+    (['foo', 'bar', 'baz']),
+    (['foo', 'bar', 'baz', 'qux', 'corge']),
+])
+def test_bbox_from_geo_json_value_error(bad_input: tuple[float | int, ...]) -> None:
+    # Test the sequence form where you pass in a tuple/list.
+    with pytest.raises(ValueError):
+        BBox.from_geo_json(bad_input)
+
+    # Test the vararg form.
+    with pytest.raises(ValueError):
+        BBox.from_geo_json(*bad_input)
+
+
+def test_pydantic_json() -> None:
+    class TestModel(BaseModel):
+        bbox: BBox
+
+    bbox = BBox(1, 2, 3, 4)
+    test_model = TestModel(bbox = bbox)
+
+    expect = {
+        'bbox': [1, 2, 3, 4],
+    }
+
+    assert test_model.model_dump(mode = 'json') == expect
+
+
+@pytest.mark.parametrize("input, expect", [
+    ((1, 2, 3, 4), BBox(xmin=1, ymin=2, xmax=3, ymax=4)),
+    (BBox(0, -1, -2, 3), BBox(0, -1, -2, 3)),
+])
+def test_pydantic_validation_success(input: Any, expect: BBox) -> None:
+    class TestModel(BaseModel):
+        bbox: BBox
+
+    test_model = TestModel(bbox = input)
+
+    assert test_model.bbox == expect
+
+
+@pytest.mark.parametrize("input", [
+    'foo',
+])
+def test_pydantic_validation_error(input: Any) -> None:
+    class TestModel(BaseModel):
+        bbox: BBox
+
+    with pytest.raises(ValidationError):
+        TestModel(bbox = input)
+
+
+def test_pydantic_json_schema() -> None:
+    class TestModel(BaseModel):
+        bbox: BBox
+
+    expr = jsonpath_ng.parse('$.properties.bbox')
+
+    matches = expr.find(TestModel.model_json_schema())
+
+    assert len(matches) == 1
+    assert matches[0].value == {
+        'title': 'Bbox',
+        'type': 'array',
+        'minItems': 4,
+        'maxItems': 4,
+        'items': {
+            'type': 'number',
+        }
+    }

--- a/packages/overture-schema-core/tests/test_models.py
+++ b/packages/overture-schema-core/tests/test_models.py
@@ -1,0 +1,667 @@
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+from overture.schema.core.bbox import BBox
+from overture.schema.core.geometry import Geometry
+from overture.schema.core.models import Feature
+from shapely.geometry import LineString, Point
+
+
+def prune_dict(data: dict[str, Any] | tuple | list, remove_list: tuple[str, ...]) -> None:
+    if isinstance(data, Mapping):
+        keys_to_remove = [k for k in data if k in remove_list]
+        for k in keys_to_remove:
+            data.pop(k)
+        for v in data.values():
+            prune_dict(v, remove_list)
+    elif isinstance(data, tuple | list):
+        for item in data:
+            prune_dict(item, remove_list)
+
+def prune_json_schema(data: dict[str, Any]) -> dict[str, Any]:
+    prune_dict(data, ('title', 'description'))
+    return data
+
+def test_feature_json_schema() -> None:
+    actual = prune_json_schema(Feature.model_json_schema())
+
+    expect = {
+    '$defs': {
+        'SourcePropertyItem': {
+            'additionalProperties': False,
+            'properties': {
+                'between': {
+                    'anyOf': [
+                        {
+                            'items': {
+                                'maximum': 1.0,
+                                'minimum': 0.0,
+                                'type': 'number',
+                            },
+                            'maxItems': 2,
+                            'minItems': 2,
+                            'type': 'array',
+                        },
+                        {
+                            'type': 'null',
+                        },
+                    ],
+                    'default': None,
+                },
+                'confidence': {
+                    'anyOf': [
+                        {
+                            'maximum': 1.0,
+                            'minimum': 0.0,
+                            'type': 'number',
+                        },
+                        {
+                            'type': 'null',
+                        },
+                    ],
+                    'default': None,
+                },
+                'dataset': {
+                    'type': 'string',
+                },
+                'property': {
+                    'type': 'string',
+                },
+                'record_id': {
+                    'anyOf': [
+                        {
+                            'type': 'string',
+                        },
+                        {
+                            'type': 'null',
+                        },
+                    ],
+                    'default': None,
+                },
+                'update_time': {
+                    'anyOf': [
+                        {
+                            'format': 'date-time',
+                            'pattern': '^([1-9]\\d{3})-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])T([01]\\d|2[0-3]):([0-5]\\d):([0-5]\\d|60)(\\.\\d{1,3})?(Z|[-+]([01]\\d|2[0-3]):[0-5]\\d)$',
+                            'type': 'string',
+                        },
+                        {
+                            'type': 'null',
+                        },
+                    ],
+                    'default': None,
+                },
+            },
+            'required': [
+                'property',
+                'dataset',
+            ],
+            'type': 'object',
+        },
+    },
+    'additionalProperties': False,
+    'patternProperties': {
+        '^ext_.*$': {},
+    },
+    'properties': {
+        'bbox': {
+            'anyOf': [
+                {
+                    'items': {
+                        'type': 'number',
+                    },
+                    'minItems': 4,
+                    'maxItems': 4,
+                    'type': 'array',
+                },
+                {
+                    'type': 'null',
+                },
+            ],
+            'default': None,
+        },
+        'geometry': {
+            'oneOf': [
+                {
+                    'properties': {
+                        'bbox': {
+                            'items': {
+                                'type': 'number',
+                            },
+                            'minItems': 4,
+                            'type': 'array',
+                        },
+                        'geometries': {
+                            'oneOf': [
+                                {
+                                    'properties': {
+                                        'bbox': {
+                                            'items': {
+                                                'type': 'number',
+                                            },
+                                            'minItems': 4,
+                                            'type': 'array',
+                                        },
+                                        'coordinates': {
+                                            'items': {
+                                                'items': {
+                                                    'type': 'number',
+                                                },
+                                                'minItems': 2,
+                                                'type': 'array',
+                                            },
+                                            'minItems': 2,
+                                            'type': 'array',
+                                        },
+                                        'type': {
+                                            'const': 'LineString',
+                                            'type': 'string',
+                                        },
+                                    },
+                                    'required': [
+                                        'type',
+                                        'coordinates',
+                                    ],
+                                    'type': 'object',
+                                },
+                                {
+                                    'properties': {
+                                        'bbox': {
+                                            'items': {
+                                                'type': 'number',
+                                            },
+                                            'minItems': 4,
+                                            'type': 'array',
+                                        },
+                                        'coordinates': {
+                                            'items': {
+                                                'type': 'number',
+                                            },
+                                            'minItems': 2,
+                                            'type': 'array',
+                                        },
+                                        'type': {
+                                            'const': 'Point',
+                                            'type': 'string',
+                                        },
+                                    },
+                                    'required': [
+                                        'type',
+                                        'coordinates',
+                                    ],
+                                    'type': 'object',
+                                },
+                                {
+                                    'properties': {
+                                        'bbox': {
+                                            'items': {
+                                                'type': 'number',
+                                            },
+                                            'minItems': 4,
+                                            'type': 'array',
+                                        },
+                                        'coordinates': {
+                                            'items': {
+                                                'items': {
+                                                    'items': {
+                                                        'type': 'number',
+                                                    },
+                                                    'minItems': 2,
+                                                    'type': 'array',
+                                                },
+                                                'minItems': 4,
+                                                'type': 'array',
+                                            },
+                                            'minItems': 1,
+                                            'type': 'array',
+                                        },
+                                        'type': {
+                                            'const': 'Polygon',
+                                            'type': 'string',
+                                        },
+                                    },
+                                    'required': [
+                                        'type',
+                                        'coordinates',
+                                    ],
+                                    'type': 'object',
+                                },
+                                {
+                                    'properties': {
+                                        'bbox': {
+                                            'items': {
+                                                'type': 'number',
+                                            },
+                                            'minItems': 4,
+                                            'type': 'array',
+                                        },
+                                        'coordinates': {
+                                            'items': {
+                                                'items': {
+                                                    'items': {
+                                                        'type': 'number',
+                                                    },
+                                                    'minItems': 2,
+                                                    'type': 'array',
+                                                },
+                                                'minItems': 2,
+                                                'type': 'array',
+                                            },
+                                            'minItems': 1,
+                                            'type': 'array',
+                                        },
+                                        'type': {
+                                            'const': 'MultiLineString',
+                                            'type': 'string',
+                                        },
+                                    },
+                                    'required': [
+                                        'type',
+                                        'coordinates',
+                                    ],
+                                    'type': 'object',
+                                },
+                                {
+                                    'properties': {
+                                        'bbox': {
+                                            'items': {
+                                                'type': 'number',
+                                            },
+                                            'minItems': 4,
+                                            'type': 'array',
+                                        },
+                                        'coordinates': {
+                                            'items': {
+                                                'items': {
+                                                    'type': 'number',
+                                                },
+                                                'minItems': 2,
+                                                'type': 'array',
+                                            },
+                                            'minItems': 1,
+                                            'type': 'array',
+                                        },
+                                        'type': {
+                                            'const': 'MultiPoint',
+                                            'type': 'string',
+                                        },
+                                    },
+                                    'required': [
+                                        'type',
+                                        'coordinates',
+                                    ],
+                                    'type': 'object',
+                                },
+                                {
+                                    'properties': {
+                                        'bbox': {
+                                            'items': {
+                                                'type': 'number',
+                                            },
+                                            'minItems': 4,
+                                            'type': 'array',
+                                        },
+                                        'coordinates': {
+                                            'items': {
+                                                'items': {
+                                                    'items': {
+                                                        'items': {
+                                                            'type': 'number',
+                                                        },
+                                                        'minItems': 2,
+                                                        'type': 'array',
+                                                    },
+                                                    'minItems': 4,
+                                                    'type': 'array',
+                                                },
+                                                'minItems': 1,
+                                                'type': 'array',
+                                            },
+                                            'minItems': 1,
+                                            'type': 'array',
+                                        },
+                                        'type': {
+                                            'const': 'MultiPolygon',
+                                            'type': 'string',
+                                        },
+                                    },
+                                    'required': [
+                                        'type',
+                                        'coordinates',
+                                    ],
+                                    'type': 'object',
+                                },
+                            ],
+                        },
+                        'type': {
+                            'const': 'GeometryCollection',
+                            'type': 'string',
+                        },
+                    },
+                    'required': [
+                        'type',
+                        'geometries',
+                    ],
+                    'type': 'object',
+                },
+                {
+                    'properties': {
+                        'bbox': {
+                            'items': {
+                                'type': 'number',
+                            },
+                            'minItems': 4,
+                            'type': 'array',
+                        },
+                        'coordinates': {
+                            'items': {
+                                'items': {
+                                    'type': 'number',
+                                },
+                                'minItems': 2,
+                                'type': 'array',
+                            },
+                            'minItems': 2,
+                            'type': 'array',
+                        },
+                        'type': {
+                            'const': 'LineString',
+                            'type': 'string',
+                        },
+                    },
+                    'required': [
+                        'type',
+                        'coordinates',
+                    ],
+                    'type': 'object',
+                },
+                {
+                    'properties': {
+                        'bbox': {
+                            'items': {
+                                'type': 'number',
+                            },
+                            'minItems': 4,
+                            'type': 'array',
+                        },
+                        'coordinates': {
+                            'items': {
+                                'type': 'number',
+                            },
+                            'minItems': 2,
+                            'type': 'array',
+                        },
+                        'type': {
+                            'const': 'Point',
+                            'type': 'string',
+                        },
+                    },
+                    'required': [
+                        'type',
+                        'coordinates',
+                    ],
+                    'type': 'object',
+                },
+                {
+                    'properties': {
+                        'bbox': {
+                            'items': {
+                                'type': 'number',
+                            },
+                            'minItems': 4,
+                            'type': 'array',
+                        },
+                        'coordinates': {
+                            'items': {
+                                'items': {
+                                    'items': {
+                                        'type': 'number',
+                                    },
+                                    'minItems': 2,
+                                    'type': 'array',
+                                },
+                                'minItems': 4,
+                                'type': 'array',
+                            },
+                            'minItems': 1,
+                            'type': 'array',
+                        },
+                        'type': {
+                            'const': 'Polygon',
+                            'type': 'string',
+                        },
+                    },
+                    'required': [
+                        'type',
+                        'coordinates',
+                    ],
+                    'type': 'object',
+                },
+                {
+                    'properties': {
+                        'bbox': {
+                            'items': {
+                                'type': 'number',
+                            },
+                            'minItems': 4,
+                            'type': 'array',
+                        },
+                        'coordinates': {
+                            'items': {
+                                'items': {
+                                    'items': {
+                                        'type': 'number',
+                                    },
+                                    'minItems': 2,
+                                    'type': 'array',
+                                },
+                                'minItems': 2,
+                                'type': 'array',
+                            },
+                            'minItems': 1,
+                            'type': 'array',
+                        },
+                        'type': {
+                            'const': 'MultiLineString',
+                            'type': 'string',
+                        },
+                    },
+                    'required': [
+                        'type',
+                        'coordinates',
+                    ],
+                    'type': 'object',
+                },
+                {
+                    'properties': {
+                        'bbox': {
+                            'items': {
+                                'type': 'number',
+                            },
+                            'minItems': 4,
+                            'type': 'array',
+                        },
+                        'coordinates': {
+                            'items': {
+                                'items': {
+                                    'type': 'number',
+                                },
+                                'minItems': 2,
+                                'type': 'array',
+                            },
+                            'minItems': 1,
+                            'type': 'array',
+                        },
+                        'type': {
+                            'const': 'MultiPoint',
+                            'type': 'string',
+                        },
+                    },
+                    'required': [
+                        'type',
+                        'coordinates',
+                    ],
+                    'type': 'object',
+                },
+                {
+                    'properties': {
+                        'bbox': {
+                            'items': {
+                                'type': 'number',
+                            },
+                            'minItems': 4,
+                            'type': 'array',
+                        },
+                        'coordinates': {
+                            'items': {
+                                'items': {
+                                    'items': {
+                                        'items': {
+                                            'type': 'number',
+                                        },
+                                        'minItems': 2,
+                                        'type': 'array',
+                                    },
+                                    'minItems': 4,
+                                    'type': 'array',
+                                },
+                                'minItems': 1,
+                                'type': 'array',
+                            },
+                            'minItems': 1,
+                            'type': 'array',
+                        },
+                        'type': {
+                            'const': 'MultiPolygon',
+                            'type': 'string',
+                        },
+                    },
+                    'required': [
+                        'type',
+                        'coordinates',
+                    ],
+                    'type': 'object',
+                },
+            ],
+        },
+        'id': {
+            'minLength': 1,
+            'pattern': '^\\S+$',
+            'type': 'string',
+        },
+        'properties': {
+            'additionalProperties': False,
+            'patternProperties': {
+                '^ext_.*$': {},
+            },
+            'properties': {
+                'sources': {
+                    'anyOf': [
+                        {
+                            'items': {
+                                '$ref': '#/$defs/SourcePropertyItem',
+                            },
+                            'minItems': 1,
+                            'type': 'array',
+                            'uniqueItems': True,
+                        },
+                        {
+                            'type': 'null',
+                        },
+                    ],
+                    'default': None,
+                },
+                'theme': {
+                    'type': 'string',
+                },
+                'type': {
+                    'type': 'string',
+                },
+                'version': {
+                    'minimum': 0,
+                    'type': 'integer',
+                },
+            },
+            'required': [
+                'theme',
+                'type',
+                'version',
+            ],
+            'type': 'object',
+            'unevaluatedProperties': False,
+        },
+        'type': {
+            'const': 'Feature',
+            'type': 'string',
+        },
+    },
+    'required': [
+        'id',
+        'geometry',
+        'properties',
+        'type',
+    ],
+    'type': 'object',
+}
+
+    assert actual == expect
+
+
+@pytest.mark.parametrize("feature, expect", [
+    (
+        Feature(
+            id = "foo",
+            theme = "bar",
+            type = "baz",
+            geometry = Geometry(Point(-1, 1)),
+            version = 1,
+        ),
+        {
+            'type': 'Feature',
+            'id': 'foo',
+            'bbox': None,
+            'geometry': {
+                'type': 'Point',
+                'coordinates': [-1, 1],
+            },
+            'properties': {
+                'theme': 'bar',
+                'type': 'baz',
+                'version': 1,
+                'sources': None,
+            }
+        },
+    ),
+
+    (
+        Feature(
+            id = "foo",
+            theme = "bar",
+            type = "baz",
+            bbox = BBox(0, 0, 1, 1),
+            geometry = Geometry(LineString(((0, 0), (1, 1)))),
+            version = 2,
+        ),
+        {
+            'type': 'Feature',
+            'id': 'foo',
+            'bbox': [0, 0, 1, 1],
+            'geometry': {
+                'type': 'LineString',
+                'coordinates': [
+                    [0, 0],
+                    [1, 1],
+                ]
+            },
+            'properties': {
+                'theme': 'bar',
+                'type': 'baz',
+                'version': 2,
+                'sources': None,
+            }
+        },
+    ),
+])
+def test_feature_json(feature: Feature, expect: dict[str, Any]) -> None:
+    assert feature.model_dump(mode = 'json') == expect

--- a/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
@@ -235,6 +235,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "The area covered by the division with which this area feature is associated",
       "oneOf": [

--- a/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
@@ -336,6 +336,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "Approximate location of a position commonly associated with the real-world entity modeled by the division feature.",
       "properties": {

--- a/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
@@ -127,6 +127,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "Boundary line or lines",
       "oneOf": [

--- a/packages/overture-schema-places-theme/tests/place_baseline_schema.json
+++ b/packages/overture-schema-places-theme/tests/place_baseline_schema.json
@@ -290,6 +290,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "Position of the place",
       "properties": {

--- a/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
@@ -61,6 +61,15 @@
     }
   },
   "properties": {
+    "bbox": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
     "geometry": {
       "description": "Position of the connector",
       "properties": {

--- a/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
@@ -612,6 +612,15 @@
         }
       },
       "properties": {
+        "bbox": {
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 4,
+          "minItems": 4,
+          "title": "Bbox",
+          "type": "array"
+        },
         "geometry": {
           "description": "Segment centerline",
           "properties": {
@@ -873,6 +882,15 @@
         }
       },
       "properties": {
+        "bbox": {
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 4,
+          "minItems": 4,
+          "title": "Bbox",
+          "type": "array"
+        },
         "geometry": {
           "description": "Segment centerline",
           "properties": {
@@ -1530,6 +1548,15 @@
         }
       },
       "properties": {
+        "bbox": {
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 4,
+          "minItems": 4,
+          "title": "Bbox",
+          "type": "array"
+        },
         "geometry": {
           "description": "Segment centerline",
           "properties": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+"**/tests/*.py" = ["ANN401"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -255,6 +255,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonpath-ng"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ply" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/86/08646239a313f895186ff0a4573452038eed8c86f54380b3ebac34d32fb2/jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c", size = 37838, upload-time = "2024-10-11T15:41:42.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/5a/73ecb3d82f8615f32ccdadeb9356726d6cae3a4bbc840b437ceb95708063/jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6", size = 30105, upload-time = "2024-11-20T17:58:30.418Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -590,6 +602,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "jsonpath-ng" },
     { name = "pytest-subtests" },
     { name = "types-pyyaml" },
     { name = "types-shapely" },
@@ -603,6 +616,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "jsonpath-ng", specifier = ">=1.7.0" },
     { name = "pytest-subtests", specifier = ">=0.14.2" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
     { name = "types-shapely", specifier = ">=2.1.0.20250710" },
@@ -751,6 +765,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "ply"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# History

1. Initial revision created week of 8/11.
2. Discussion with @mojodna 8/18.
3. Updates made on 8/19:
    - Flattened bounding box to 2D and removed `Dims`.
    - Restored files accidentally deleted ..... For now!
    - Updated Pydantic validation method to support `dict`.


# Description

This change adds a primitive type called `BBox` representing bounding box whose JSON Schema representation is GeoJSON-compatible, and adds a `bbox` field to the Feature model.

## Key Design Decisions

1. **Primitive Type**. Like `Geometry`, `BBox` is modeled as a "primitive" with Pydantic accessories rather than being derived from a Pydantic `BaseModel` itself. It is structured so it is a "basic value type" that will fit seamlessly within a Pydantic model with appropriate GeoJSON-compatible JSON Schema, serde, and Pydantic validation, without itself being a `BaseModel`.
2. **Code Generation Corollary**. A corollary to being designed as a primitive type is that `BBox` will need special case handling for all code generation targets (when we get there) rather than working out of the box with generic code that can handle any `BaseModel`.
5. **Dimensions/Usability**. The `BBox` type is designed to maximize the usability of the 2D case while supporting higher dimensionalities (3D, 4D, *etc.*) if necessary.
    - This is aligned with the GeoJSON spec where 2D is the minimum but an arbitrary number of extra dimensions may be added (see [section 5, *Bounding Box*](https://datatracker.ietf.org/doc/html/rfc7946#section-5)).
    - This is also aligned with how `Geometry` is currently implemented as a Shapely geometry (which is hard-limited to 2.5D, since the underlying Shapely geometry carries a Z-coordinate but doesn't do spatial operations on it) and at the JSON Schema level (since [the current JSON Schema for a GeoJSON position](https://github.com/OvertureMaps/schema/blob/pydantic/packages/overture-schema-core/src/overture/schema/core/geometry.py#L274-L280) just has `"minItems": 2`.
    - It should be noted that the current Overture `bbox` column at the Parquet level only supports the 2D case with `xmin, `ymin`, `xmax`, and `ymax`. We will have to decide whether we want to support additional dimension there or not.
6. **Validation Considerations**. The main validation rules currently enforced are that a `BBox` has to have at least 2 evenly-matched number (`float`/`int`) pairs, so it is made up of an even number of primitive numbers, at least 4.
    - There is currently no validation of the number values of the coordinate position pairs to ensure they remain within bounds.
    - This is moistly aligned with the current implementation of `Geometry` as a wrapper around a Shapely geometry, which actually has no attached CRS and doesn't care what values the numbers have.
    - As we start to build up a code generation system that can generate code to directly validate a Spark dataframe, we can and probably should add validation in at the `Feature` level that verifies that any `BBox`  is in fact the bounding envelope of the feature's geometry. We would add this both in Pydantic itself and in the code generated targets, for example the envisioned Spark in-dataframe validation.
7. **Evolution of Feature Type**. The currently "active" Overture JSON Schema does not model `bbox`, although there was at one time an abortive [attempt to do so](https://github.com/OvertureMaps/schema/commit/5d0ea0dd506b2b3f1e564ea7cd49572eb0ddb067) that was [later reverted](https://github.com/OvertureMaps/schema/commit/163060d056fa479d06221a67c8a87646cd547908), so addition of `bbox` directly into the feature model is an evolution and a step toward bringing all representations of the schema into a cohesive whole.

# Reference

1. https://github.com/OvertureMaps/schema/pull/313
2. https://github.com/OvertureMaps/schema/pull/330

# Testing

Added new unit tests.