### PR TITLE
Geometry primitives housekeeping

### DIFF
--- a/packages/overture-schema-addresses-theme/tests/address_baseline_schema.json
+++ b/packages/overture-schema-addresses-theme/tests/address_baseline_schema.json
@@ -99,6 +99,7 @@
           "items": {
             "type": "number"
           },
+          "maxItems": 3,
           "minItems": 2,
           "type": "array"
         },

--- a/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
@@ -120,19 +120,24 @@
               "items": {
                 "items": {
                   "items": {
-                    "type": "number"
+                    "items": {
+                      "type": "number"
+                    },
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
                   },
-                  "minItems": 2,
+                  "minItems": 4,
                   "type": "array"
                 },
-                "minItems": 4,
+                "minItems": 1,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "Polygon",
+              "const": "MultiPolygon",
               "type": "string"
             }
           },
@@ -155,23 +160,20 @@
               "items": {
                 "items": {
                   "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
+                    "type": "number"
                   },
-                  "minItems": 4,
+                  "maxItems": 3,
+                  "minItems": 2,
                   "type": "array"
                 },
-                "minItems": 1,
+                "minItems": 4,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "MultiPolygon",
+              "const": "Polygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
@@ -459,6 +459,7 @@
                 "items": {
                   "type": "number"
                 },
+                "maxItems": 3,
                 "minItems": 2,
                 "type": "array"
               },
@@ -487,8 +488,49 @@
             },
             "coordinates": {
               "items": {
+                "items": {
+                  "items": {
+                    "items": {
+                      "type": "number"
+                    },
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
+                  },
+                  "minItems": 4,
+                  "type": "array"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "type": {
+              "const": "MultiPolygon",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "coordinates"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "bbox": {
+              "items": {
                 "type": "number"
               },
+              "minItems": 4,
+              "type": "array"
+            },
+            "coordinates": {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 3,
               "minItems": 2,
               "type": "array"
             },
@@ -518,6 +560,7 @@
                   "items": {
                     "type": "number"
                   },
+                  "maxItems": 3,
                   "minItems": 2,
                   "type": "array"
                 },
@@ -529,45 +572,6 @@
             },
             "type": {
               "const": "Polygon",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "type": "object"
-        },
-        {
-          "properties": {
-            "bbox": {
-              "items": {
-                "type": "number"
-              },
-              "minItems": 4,
-              "type": "array"
-            },
-            "coordinates": {
-              "items": {
-                "items": {
-                  "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
-                  },
-                  "minItems": 4,
-                  "type": "array"
-                },
-                "minItems": 1,
-                "type": "array"
-              },
-              "minItems": 1,
-              "type": "array"
-            },
-            "type": {
-              "const": "MultiPolygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-base-theme/tests/land_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_baseline_schema.json
@@ -333,6 +333,7 @@
                 "items": {
                   "type": "number"
                 },
+                "maxItems": 3,
                 "minItems": 2,
                 "type": "array"
               },
@@ -361,8 +362,49 @@
             },
             "coordinates": {
               "items": {
+                "items": {
+                  "items": {
+                    "items": {
+                      "type": "number"
+                    },
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
+                  },
+                  "minItems": 4,
+                  "type": "array"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "type": {
+              "const": "MultiPolygon",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "coordinates"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "bbox": {
+              "items": {
                 "type": "number"
               },
+              "minItems": 4,
+              "type": "array"
+            },
+            "coordinates": {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 3,
               "minItems": 2,
               "type": "array"
             },
@@ -392,6 +434,7 @@
                   "items": {
                     "type": "number"
                   },
+                  "maxItems": 3,
                   "minItems": 2,
                   "type": "array"
                 },
@@ -403,45 +446,6 @@
             },
             "type": {
               "const": "Polygon",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "type": "object"
-        },
-        {
-          "properties": {
-            "bbox": {
-              "items": {
-                "type": "number"
-              },
-              "minItems": 4,
-              "type": "array"
-            },
-            "coordinates": {
-              "items": {
-                "items": {
-                  "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
-                  },
-                  "minItems": 4,
-                  "type": "array"
-                },
-                "minItems": 1,
-                "type": "array"
-              },
-              "minItems": 1,
-              "type": "array"
-            },
-            "type": {
-              "const": "MultiPolygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
@@ -137,19 +137,24 @@
               "items": {
                 "items": {
                   "items": {
-                    "type": "number"
+                    "items": {
+                      "type": "number"
+                    },
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
                   },
-                  "minItems": 2,
+                  "minItems": 4,
                   "type": "array"
                 },
-                "minItems": 4,
+                "minItems": 1,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "Polygon",
+              "const": "MultiPolygon",
               "type": "string"
             }
           },
@@ -172,23 +177,20 @@
               "items": {
                 "items": {
                   "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
+                    "type": "number"
                   },
-                  "minItems": 4,
+                  "maxItems": 3,
+                  "minItems": 2,
                   "type": "array"
                 },
-                "minItems": 1,
+                "minItems": 4,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "MultiPolygon",
+              "const": "Polygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
@@ -411,6 +411,7 @@
                 "items": {
                   "type": "number"
                 },
+                "maxItems": 3,
                 "minItems": 2,
                 "type": "array"
               },
@@ -439,8 +440,49 @@
             },
             "coordinates": {
               "items": {
+                "items": {
+                  "items": {
+                    "items": {
+                      "type": "number"
+                    },
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
+                  },
+                  "minItems": 4,
+                  "type": "array"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "type": {
+              "const": "MultiPolygon",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "coordinates"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "bbox": {
+              "items": {
                 "type": "number"
               },
+              "minItems": 4,
+              "type": "array"
+            },
+            "coordinates": {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 3,
               "minItems": 2,
               "type": "array"
             },
@@ -470,6 +512,7 @@
                   "items": {
                     "type": "number"
                   },
+                  "maxItems": 3,
                   "minItems": 2,
                   "type": "array"
                 },
@@ -481,45 +524,6 @@
             },
             "type": {
               "const": "Polygon",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "type": "object"
-        },
-        {
-          "properties": {
-            "bbox": {
-              "items": {
-                "type": "number"
-              },
-              "minItems": 4,
-              "type": "array"
-            },
-            "coordinates": {
-              "items": {
-                "items": {
-                  "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
-                  },
-                  "minItems": 4,
-                  "type": "array"
-                },
-                "minItems": 1,
-                "type": "array"
-              },
-              "minItems": 1,
-              "type": "array"
-            },
-            "type": {
-              "const": "MultiPolygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-base-theme/tests/water_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/water_baseline_schema.json
@@ -294,6 +294,7 @@
                 "items": {
                   "type": "number"
                 },
+                "maxItems": 3,
                 "minItems": 2,
                 "type": "array"
               },
@@ -322,8 +323,49 @@
             },
             "coordinates": {
               "items": {
+                "items": {
+                  "items": {
+                    "items": {
+                      "type": "number"
+                    },
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
+                  },
+                  "minItems": 4,
+                  "type": "array"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "type": {
+              "const": "MultiPolygon",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "coordinates"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "bbox": {
+              "items": {
                 "type": "number"
               },
+              "minItems": 4,
+              "type": "array"
+            },
+            "coordinates": {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 3,
               "minItems": 2,
               "type": "array"
             },
@@ -353,6 +395,7 @@
                   "items": {
                     "type": "number"
                   },
+                  "maxItems": 3,
                   "minItems": 2,
                   "type": "array"
                 },
@@ -364,45 +407,6 @@
             },
             "type": {
               "const": "Polygon",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "type": "object"
-        },
-        {
-          "properties": {
-            "bbox": {
-              "items": {
-                "type": "number"
-              },
-              "minItems": 4,
-              "type": "array"
-            },
-            "coordinates": {
-              "items": {
-                "items": {
-                  "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
-                  },
-                  "minItems": 4,
-                  "type": "array"
-                },
-                "minItems": 1,
-                "type": "array"
-              },
-              "minItems": 1,
-              "type": "array"
-            },
-            "type": {
-              "const": "MultiPolygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
@@ -415,19 +415,24 @@
               "items": {
                 "items": {
                   "items": {
-                    "type": "number"
+                    "items": {
+                      "type": "number"
+                    },
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
                   },
-                  "minItems": 2,
+                  "minItems": 4,
                   "type": "array"
                 },
-                "minItems": 4,
+                "minItems": 1,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "Polygon",
+              "const": "MultiPolygon",
               "type": "string"
             }
           },
@@ -450,23 +455,20 @@
               "items": {
                 "items": {
                   "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
+                    "type": "number"
                   },
-                  "minItems": 4,
+                  "maxItems": 3,
+                  "minItems": 2,
                   "type": "array"
                 },
-                "minItems": 1,
+                "minItems": 4,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "MultiPolygon",
+              "const": "Polygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
@@ -301,19 +301,24 @@
               "items": {
                 "items": {
                   "items": {
-                    "type": "number"
+                    "items": {
+                      "type": "number"
+                    },
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
                   },
-                  "minItems": 2,
+                  "minItems": 4,
                   "type": "array"
                 },
-                "minItems": 4,
+                "minItems": 1,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "Polygon",
+              "const": "MultiPolygon",
               "type": "string"
             }
           },
@@ -336,23 +341,20 @@
               "items": {
                 "items": {
                   "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
+                    "type": "number"
                   },
-                  "minItems": 4,
+                  "maxItems": 3,
+                  "minItems": 2,
                   "type": "array"
                 },
-                "minItems": 1,
+                "minItems": 4,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "MultiPolygon",
+              "const": "Polygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-core/src/overture/schema/core/bbox.py
+++ b/packages/overture-schema-core/src/overture/schema/core/bbox.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Any
 
 from pydantic import (
@@ -10,10 +9,13 @@ from pydantic import (
 from pydantic_core import InitErrorDetails, core_schema
 
 
-@dataclass(order=True, frozen=True, slots=True)
 class BBox:
     """
-    Two-dimensional bounding box.
+    Immutable 2D bounding box primitive.
+
+    This type is a geometric primitive with representations that can differ significantly between
+    different data formats. Consequently, does not derive from the Pydantic `BaseModel` although it
+    can participate in a `BaseModel` as a field.
 
     Parameters
     ----------
@@ -25,19 +27,6 @@ class BBox:
         Maximum X-coordinate
     ymax : float | int
         Maximum Y-coordinate
-
-
-    Attributes
-    ----------
-    xmin : float | int
-        Minimum X-coordinate
-    ymin : float | int
-        Minimum Y-coordiate
-    xmax : float | int
-        Maximum X-coordinate
-    ymax : float | int
-        Maximum Y-coordinate
-
 
     Examples
     --------
@@ -61,20 +50,73 @@ class BBox:
     BBox(xmin=1, ymin=2, xmax=3, ymax=4)
     """
 
-    xmin: float | int
-    ymin: float | int
-    xmax: float | int
-    ymax: float | int
+    __slots__ = ('_xmin', '_ymin', '_xmax', '_ymax')
 
-    def __post_init__(self) -> None:
-        if not isinstance(self.xmin, float | int):
-            raise TypeError(f"`xmin` must be a `float` or `int`; but {repr(self.xmin)} is a `{type(self.xmin).__name__}`")
-        elif not isinstance(self.ymin, float | int):
-            raise TypeError(f"`ymin` must be a `float` or `int`; but {repr(self.ymin)} is a `{type(self.ymin).__name__}`")
-        elif not isinstance(self.xmax, float | int):
-            raise TypeError(f"`xmax` must be a `float` or `int`; but {repr(self.xmax)} is a `{type(self.xmax).__name__}`")
-        elif not isinstance(self.ymax, float | int):
-            raise TypeError(f"`ymax` must be a `float` or `int`; but {repr(self.ymax)} is a `{type(self.ymax).__name__}`")
+    _xmin: float | int
+    _ymin: float | int
+    _xmax: float | int
+    _ymax: float | int
+
+    def __init__(self, xmin: float | int, ymin: float | int, xmax: float | int, ymax: float | int) -> None:
+        if not isinstance(xmin, float | int):
+            raise TypeError(f"`xmin` must be a `float` or `int`; but {repr(xmin)} is a `{type(xmin).__name__}`")
+        elif not isinstance(ymin, float | int):
+            raise TypeError(f"`ymin` must be a `float` or `int`; but {repr(ymin)} is a `{type(ymin).__name__}`")
+        elif not isinstance(xmax, float | int):
+            raise TypeError(f"`xmax` must be a `float` or `int`; but {repr(xmax)} is a `{type(xmax).__name__}`")
+        elif not isinstance(ymax, float | int):
+            raise TypeError(f"`ymax` must be a `float` or `int`; but {repr(ymax)} is a `{type(ymax).__name__}`")
+        object.__setattr__(self, '_xmin', xmin)
+        object.__setattr__(self, '_ymin', ymin)
+        object.__setattr__(self, '_xmax', xmax)
+        object.__setattr__(self, '_ymax', ymax)
+
+    def __setattr__(self, _: str, __: object) -> None:
+        raise AttributeError(f"`{self.__class__.__name__} is immutable")
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, BBox) and \
+            self.xmin == other.xmin and \
+            self.ymin == other.ymin and \
+            self.xmax == other.xmax and \
+            self.ymax == other.ymax
+
+    def __hash__(self) -> int:
+        return hash((self.xmin, self.ymin, self.xmax, self.ymax))
+
+    def __repr__(self) -> str:
+        return f"BBox({self.xmin}, {self.ymin}, {self.xmax}, {self.ymax})"
+
+    def __str__(self) -> str:
+        return f"({self.xmin}, {self.ymin}, {self.xmax}, {self.ymax})"
+
+    @property
+    def xmin(self) -> float | int:
+        """
+        float | int: Minimum X-coordinate
+        """
+        return self._xmin
+
+    @property
+    def ymin(self) -> float | int:
+        """
+        float | int: Minimum Y-coordinate
+        """
+        return self._ymin
+
+    @property
+    def xmax(self) -> float | int:
+        """
+        float | int: Maximum X-coordinate
+        """
+        return self._xmax
+
+    @property
+    def ymax(self) -> float | int:
+        """
+        float | int: Maximum Y-coordinate
+        """
+        return self._ymax
 
     def to_geo_json(self) -> tuple[float | int, ...]:
         """

--- a/packages/overture-schema-core/tests/test_bbox.py
+++ b/packages/overture-schema-core/tests/test_bbox.py
@@ -35,6 +35,71 @@ def test_bbox_construct_keyword() -> None:
     assert bbox.ymax == 4
 
 
+def test_bbox_immutable() -> None:
+    bbox = BBox(1, 2, 3, 4)
+
+    with pytest.raises(AttributeError):
+        bbox.xmin = -1 # type: ignore[misc]
+
+    with pytest.raises(AttributeError):
+        bbox.ymin = -2 # type: ignore[misc]
+
+    with pytest.raises(AttributeError):
+        bbox.xmax = -3 # type: ignore[misc]
+
+    with pytest.raises(AttributeError):
+        bbox.ymax = -4 # type: ignore[misc]
+
+    assert bbox == BBox(1, 2, 3, 4)
+
+
+@pytest.mark.parametrize("a, b", [
+    (BBox(0, 0, 0, 0), BBox(0, 0, 0, 0)),
+    (BBox(0, 0, 0, 0), BBox(0.0, 0.0, 0.0, 0.0)),
+    (BBox(1, 2, 3, 4), BBox(1.0, 2.0, 3.0, 4.0)),
+    (BBox(-1.0, 0.5, 1.5, 2.5), BBox(-1, 0.5, 1.5, 2.5)),
+])
+def test_bbox_eq(a: BBox, b: BBox) -> None:
+    assert a == a
+    assert b == b
+    assert a == b
+    assert b == a
+    assert hash(a) == hash(a)
+    assert hash(a) == hash(b)
+
+    c = BBox(a.xmin+1, a.ymin, a.xmax, a.ymax)
+    assert c == c
+    assert a != c
+    assert c != a
+
+    d = BBox(a.xmin, a.ymin+1, a.xmax, a.ymax)
+    assert d == d
+    assert a != d
+    assert d != a
+
+    e = BBox(a.xmin, a.ymin, a.xmax+1, a.ymax)
+    assert e == e
+    assert a != e
+    assert e != a
+
+    f = BBox(a.xmin, a.ymin, a.xmax, a.ymax+1)
+    assert f == f
+    assert a != f
+    assert f != a
+
+
+def test_bbox_repr() -> None:
+    bbox = BBox(1, 2, 3.5, 4)
+
+    assert repr(bbox) == "BBox(1, 2, 3.5, 4)"
+
+
+def test_bbox_str() -> None:
+    bbox = BBox(-1.25, 2.0, -3, 4.75)
+
+    assert str(bbox) == "(-1.25, 2.0, -3, 4.75)"
+
+
 def test_bbox_to_geo_json() -> None:
     bbox = BBox(-10, -20, 30, 40)
 

--- a/packages/overture-schema-core/tests/test_geometry.py
+++ b/packages/overture-schema-core/tests/test_geometry.py
@@ -8,16 +8,13 @@ import pytest
 from overture.schema.core.geometry import Geometry, GeometryType, GeometryTypeConstraint
 from pydantic import BaseModel, ValidationError
 from pytest_subtests import SubTests
+from shapely import wkt
 
 
 def test_geometry_type_sorted() -> None:
     enumerated_order = tuple(GeometryType)
 
     assert enumerated_order == tuple(sorted(enumerated_order))
-
-    indices = [item._value for item in enumerated_order]
-
-    assert indices == list(range(0, len(indices)))
 
 
 def test_geometry_type_geo_json_type() -> None:
@@ -52,11 +49,111 @@ class GeometryTypeCase:
     counterexamples: tuple[dict[Any, Any], ...] = ()
 
 
-TEST_GEOMETRY_TYPE_CASES: tuple[GeometryTypeCase] = (
+TEST_GEOMETRY_TYPE_CASES: tuple[GeometryTypeCase, ...] = (
+    GeometryTypeCase(
+        geometry_type=GeometryType.GEOMETRY_COLLECTION,
+        examples=(
+            {"type": "GeometryCollection", "geometries": [{"type": "LineString", "coordinates": [[0, 0], [-1, -1]]}]},
+            {"type": "GeometryCollection", "geometries": [{"type": "MultiLineString", "coordinates": [[[0, 0], [1, 1]]]}]},
+            {"type": "GeometryCollection", "geometries": [{"type": "MultiPoint", "coordinates": [[0, 0], [1, 1]]}]},
+            {"type": "GeometryCollection", "geometries": [{"type": "MultiPolygon", "coordinates": [[[[0, 0], [-1, 0], [-1, -1], [0, 0]]]]}]},
+            {"type": "GeometryCollection", "geometries": [{"type": "Point", "coordinates": [0, 0]}]},
+            {"type": "GeometryCollection", "geometries": [{"type": "Polygon", "coordinates": [[[0, 0], [-1, 0], [-1, -1], [0, 0]]]}]},
+            {
+                "type": "GeometryCollection",
+                "geometries": [
+                    {"type": "LineString", "coordinates": [[0, 0], [-1, -1]]},
+                    {"type": "MultiLineString", "coordinates": [[[0, 0], [1, 1]]]},
+                    {"type": "MultiPoint", "coordinates": [[0, 0], [1, 1]]},
+                    {"type": "MultiPolygon", "coordinates": [[[[0, 0], [-1, 0], [-1, -1], [0, 0]]]]},
+                    {"type": "Point", "coordinates": [0, 0]},
+                    {"type": "Polygon", "coordinates": [[[0, 0], [-1, 0], [-1, -1], [0, 0]]]},
+                ]
+            },
+        ),
+        counterexamples=(
+            {"type": "GeometryCollection", "geometry": []},
+            {"type": "GeometryCollection", "geometries": []},
+            {
+                "type": "GeometryCollection",
+                "geometries": [
+                    {"type": "LineString", "coordinates": [[0, 0], [-1, -1]]},
+                    {"type": "MultiLineString", "coordinates": [[[0, 0], [1, 1]]]},
+                    {"type": "MultiPoint", "coordinates": [[0, 0], [1, 1]]},
+                    {"type": "MultiPolygon", "coordinates": [[[[0, 0], [-1, 0], [-1, -1], [0, 0]]]]},
+                    {"type": "Point", "coordinates": [0, 0]},
+                    {"type": "Polygon", "coordinates": [[[0, 0], [-1, 0], [-1, -1], [0, 0]]]},
+                    {"type": "foo", "coordinates": []},
+                ]
+            },
+        ),
+    ),
+    GeometryTypeCase(
+        geometry_type=GeometryType.LINE_STRING,
+        examples=(
+            {"type": "LineString", "coordinates": [[0,0], [1,1]]},
+            {"type": "LineString", "coordinates": [[0,0], [1,1], [2, 2]]},
+            {"type": "LineString", "coordinates": [[-1.5, 3], [-1.0, 2.0], [0.0, 0]]}
+        ),
+        counterexamples=(
+            {},
+            {"type": "LineString"},
+            {"coordinates": [[0, 0], [1, 1]]},
+            {"type": "LineString", "coordinates": []},
+            {"type": "LineString", "coordinates": [0]},
+            {"type": "LineString", "coordinates": [0, 0]},
+            {"type": "LineString", "coordinates": [[0, 0]]},
+        )
+    ),
+    GeometryTypeCase(
+        geometry_type=GeometryType.MULTI_LINE_STRING,
+        examples=(
+            {"type": "MultiLineString", "coordinates": [[[0,0], [1, 1]]]},
+            {"type": "MultiLineString", "coordinates": [[[0,0], [1, 1]], [[2, 2], [3, 3], [4, 4]]]},
+        ),
+        counterexamples=(
+            {"type": "MultiLineString"},
+            {"type": "MultiLineString", "coordinates": []},
+            {"type": "MultiLineString", "coordinates": [[]]},
+            {"type": "MultiLineString", "coordinates": [0, 0]},
+            {"type": "MultiLineString", "coordinates": [[0, 0]]},
+            {"type": "MultiLineString", "coordinates": [[[0, 0]]]},
+        ),
+    ),
+    GeometryTypeCase(
+        geometry_type=GeometryType.MULTI_POINT,
+        examples=(
+            {"type": "MultiPoint", "coordinates": [[0,0]]},
+            {"type": "MultiPoint", "coordinates": [[0,0], [1, 1]]},
+            {"type": "MultiPoint", "coordinates": [[0,0], [1, 1], [2, 2]], "bbox": [0, 0, 2, 2]},
+        ),
+        counterexamples=(
+            {"type": "MultiPoint"},
+            {"type": "MultiPoint", "coordinates": []},
+            {"type": "MultiPoint", "coordinates": [[]]},
+            {"type": "MultiPoint", "coordinates": [0, 0]},
+        ),
+    ),
+    GeometryTypeCase(
+        geometry_type=GeometryType.MULTI_POLYGON,
+        examples=(
+            {"type": "MultiPolygon", "coordinates": [[[[0, 0], [0, 1], [1, 1], [0, 0]]]]},
+            {"type": "MultiPolygon", "coordinates": [[[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]]},
+            {"type": "MultiPolygon", "coordinates": [[[[-2, -2], [-2, 2], [2, 2], [2, -2], [-2, -2]], [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]]},
+        ),
+        counterexamples=(
+           {"type": "MultiPolygon", "coordinates": []},
+           {"type": "MultiPolygon", "coordinates": [0, 0]},
+           {"type": "MultiPolygon", "coordinates": [[0, 0], [1, 1]]},
+           {"type": "MultiPolygon", "coordinates": [[[0, 0], [1, 1]]]},
+           {"type": "MultiPolygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [0, 0]]]},
+        )
+    ),
     GeometryTypeCase(
         geometry_type=GeometryType.POINT,
         examples=(
-            {"type": "Point", "coordinates": [0, 0]},
+            {"type": "Point", "coordinates": [0, 0], "bbox": [0, 0, 0, 0]},
+            {"type": "Point", "coordinates": [0, 0, 0]},
             {"type": "Point", "coordinates": [-90, 131.5]},
         ),
         counterexamples=(
@@ -67,6 +164,20 @@ TEST_GEOMETRY_TYPE_CASES: tuple[GeometryTypeCase] = (
             {"type": "Point", "coordinates": [0]},
             {"type": "Point", "coordinates": [[0, 0], [1, 1]]},
         ),
+    ),
+    GeometryTypeCase(
+        geometry_type=GeometryType.POLYGON,
+        examples=(
+            {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [0, 0]]]},
+            {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]},
+            {"type": "Polygon", "coordinates": [[[-2, -2], [-2, 2], [2, 2], [2, -2], [-2, -2]], [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]},
+        ),
+        counterexamples=(
+           {"type": "Polygon", "coordinates": []},
+           {"type": "Polygon", "coordinates": [0, 0]},
+           {"type": "Polygon", "coordinates": [[0, 0], [1, 1]]},
+           {"type": "Polygon", "coordinates": [[[0, 0], [1, 1]]]},
+        )
     ),
 )
 
@@ -84,7 +195,7 @@ TEST_GEOMETRY_TYPE_CASE_SUBSETS = tuple(
 
 
 @pytest.mark.parametrize("geometry_type_case_subset", TEST_GEOMETRY_TYPE_CASE_SUBSETS)
-def test_geometry_type_constraint_valid(
+def test_geometry_type_constraint_on_allowed_geometry(
     geometry_type_case_subset: tuple[GeometryTypeCase, ...], subtests: SubTests
 ) -> None:
     allowed_types = tuple(g.geometry_type for g in geometry_type_case_subset)
@@ -97,7 +208,91 @@ def test_geometry_type_constraint_valid(
             for example in geometry_type_case.examples:
                 with subtests.test(example=example):
                     ConstrainedModel(geometry=example)
+
+
+@pytest.mark.parametrize("geometry_type_case_subset", TEST_GEOMETRY_TYPE_CASE_SUBSETS)
+def test_geometry_type_constraint_on_disallowed_geometry(
+    geometry_type_case_subset: tuple[GeometryTypeCase, ...], subtests: SubTests
+) -> None:
+    allowed_types = tuple(g.geometry_type for g in geometry_type_case_subset)
+
+    class ConstrainedModel(BaseModel):
+        geometry: Annotated[Geometry, GeometryTypeConstraint(*allowed_types)]
+
+    # Find the geometry type cases that are not allowed.
+    non_allowed_cases = tuple(c for c in TEST_GEOMETRY_TYPE_CASES if c not in geometry_type_case_subset)
+
+    # For each non-allowed case, test one valid example to verify that it doesn't validate.
+    for non_allowed_case in non_allowed_cases:
+        non_allowed_example = non_allowed_case.examples[0]
+        with subtests.test(non_allowed_example=non_allowed_example):
+            with pytest.raises(ValidationError):
+                ConstrainedModel(geometry=non_allowed_example)
+
+
+@pytest.mark.parametrize("geometry_type_case_subset", TEST_GEOMETRY_TYPE_CASE_SUBSETS)
+def test_geometry_type_constraint_on_geometry_counterexamples(
+    geometry_type_case_subset: tuple[GeometryTypeCase, ...], subtests: SubTests
+) -> None:
+    allowed_types = tuple(g.geometry_type for g in geometry_type_case_subset)
+
+    class ConstrainedModel(BaseModel):
+        geometry: Annotated[Geometry, GeometryTypeConstraint(*allowed_types)]
+
+    for geometry_type_case in geometry_type_case_subset:
+        with subtests.test(geometry_type=geometry_type_case.geometry_type):
             for counterexample in geometry_type_case.counterexamples:
                 with subtests.test(counterexample=counterexample):
                     with pytest.raises(ValidationError):
                         ConstrainedModel(geometry=counterexample)
+
+
+
+def test_geometry_immutable() -> None:
+    geom = Geometry.from_wkt("POINT(0 0)")
+
+    with pytest.raises(AttributeError):
+        geom.geom = wkt.loads("POINT(1 1)") # type: ignore[misc]
+
+    assert geom == Geometry.from_wkt("POINT(0 0)")
+
+
+@pytest.mark.parametrize("geometry_type_case", TEST_GEOMETRY_TYPE_CASES)
+def test_geometry_geom_type(geometry_type_case: GeometryTypeCase) -> None:
+    geo_json = geometry_type_case.examples[0]
+
+    geom = Geometry.from_geo_json(geo_json)
+
+    assert geom.geom_type == geometry_type_case.geometry_type
+
+
+@pytest.mark.parametrize("wkt", [
+    "LINESTRING(0 0, 1 1)",
+    "MULTILINESTRING((0 0, 1 1), (2 2, 3 3))",
+    "MULTIPOINT((0 0), (1 1))",
+    "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0)), ((2 2, 3 2, 3 3, 2 3, 2 2)))",
+    "POINT(1 1)",
+    "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+])
+def test_geometry_wkt(wkt: str) -> None:
+    a = Geometry.from_wkt(wkt)
+
+    def normalize_whitespace(s: str) -> str:
+        s = re.sub(r'\s+\(', '(', s)
+        s = re.sub(r',\s+', ',', s)
+        return s
+
+    assert normalize_whitespace(a.wkt) == normalize_whitespace(wkt)
+
+    b = Geometry.from_wkt(a.wkt)
+
+    assert a == b
+
+
+def test_geometry_from_wkb() -> None:
+    expect = Geometry.from_wkt("POINT(0 0)")
+    wkb = b"\x01\x01\x00\x00\x00" + b"\x00" * 16
+
+    actual = Geometry.from_wkb(wkb)
+
+    assert actual == expect

--- a/packages/overture-schema-core/tests/test_models.py
+++ b/packages/overture-schema-core/tests/test_models.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import pytest
+from deepdiff import DeepDiff
 from overture.schema.core.bbox import BBox
 from overture.schema.core.geometry import Geometry
 from overture.schema.core.models import Feature
@@ -19,593 +20,528 @@ def prune_dict(data: dict[str, Any] | tuple | list, remove_list: tuple[str, ...]
         for item in data:
             prune_dict(item, remove_list)
 
+
 def prune_json_schema(data: dict[str, Any]) -> dict[str, Any]:
     prune_dict(data, ('title', 'description'))
     return data
+
 
 def test_feature_json_schema() -> None:
     actual = prune_json_schema(Feature.model_json_schema())
 
     expect = {
-    '$defs': {
-        'SourcePropertyItem': {
-            'additionalProperties': False,
-            'properties': {
-                'between': {
-                    'anyOf': [
-                        {
+        '$defs': {
+            'SourcePropertyItem': {
+                'additionalProperties': False,
+                'properties': {
+                    'between': {
+                        'anyOf': [{
                             'items': {
                                 'maximum': 1.0,
                                 'minimum': 0.0,
-                                'type': 'number',
+                                'type': 'number'
                             },
                             'maxItems': 2,
                             'minItems': 2,
-                            'type': 'array',
-                        },
-                        {
-                            'type': 'null',
-                        },
-                    ],
-                    'default': None,
-                },
-                'confidence': {
-                    'anyOf': [
-                        {
-                            'maximum': 1.0,
-                            'minimum': 0.0,
-                            'type': 'number',
-                        },
-                        {
-                            'type': 'null',
-                        },
-                    ],
-                    'default': None,
-                },
-                'dataset': {
-                    'type': 'string',
-                },
-                'property': {
-                    'type': 'string',
-                },
-                'record_id': {
-                    'anyOf': [
-                        {
-                            'type': 'string',
-                        },
-                        {
-                            'type': 'null',
-                        },
-                    ],
-                    'default': None,
-                },
-                'update_time': {
-                    'anyOf': [
-                        {
+                            'type': 'array'
+                        }, {
+                            'type': 'null'
+                        }],
+                        'default': None,
+                    },
+                    'property': {
+                        'type': 'string'
+                    },
+                    'dataset': {
+                        'type': 'string'
+                    },
+                    'record_id': {
+                        'anyOf': [{
+                            'type': 'string'
+                        }, {
+                            'type': 'null'
+                        }],
+                        'default': None,
+                    },
+                    'update_time': {
+                        'anyOf': [{
                             'format': 'date-time',
                             'pattern': '^([1-9]\\d{3})-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])T([01]\\d|2[0-3]):([0-5]\\d):([0-5]\\d|60)(\\.\\d{1,3})?(Z|[-+]([01]\\d|2[0-3]):[0-5]\\d)$',
-                            'type': 'string',
-                        },
-                        {
-                            'type': 'null',
-                        },
-                    ],
-                    'default': None,
-                },
-            },
-            'required': [
-                'property',
-                'dataset',
-            ],
-            'type': 'object',
-        },
-    },
-    'additionalProperties': False,
-    'patternProperties': {
-        '^ext_.*$': {},
-    },
-    'properties': {
-        'bbox': {
-            'anyOf': [
-                {
-                    'items': {
-                        'type': 'number',
+                            'type': 'string'
+                        }, {
+                            'type': 'null'
+                        }],
+                        'default': None,
                     },
-                    'minItems': 4,
-                    'maxItems': 4,
-                    'type': 'array',
+                    'confidence': {
+                        'anyOf': [{
+                            'maximum': 1.0,
+                            'minimum': 0.0,
+                            'type': 'number'
+                        }, {
+                            'type': 'null'
+                        }],
+                        'default': None,
+                    }
                 },
-                {
-                    'type': 'null',
-                },
-            ],
-            'default': None,
+                'required': ['property', 'dataset'],
+                'type': 'object'
+            }
         },
-        'geometry': {
-            'oneOf': [
-                {
+        'additionalProperties': False,
+        'patternProperties': {
+            '^ext_.*$': {
+            }
+        },
+        'properties': {
+            'id': {
+                'minLength': 1,
+                'pattern': '^\\S+$',
+                'type': 'string'
+            },
+            'geometry': {
+                'oneOf': [{
                     'properties': {
-                        'bbox': {
-                            'items': {
-                                'type': 'number',
-                            },
-                            'minItems': 4,
-                            'type': 'array',
-                        },
-                        'geometries': {
-                            'oneOf': [
-                                {
-                                    'properties': {
-                                        'bbox': {
-                                            'items': {
-                                                'type': 'number',
-                                            },
-                                            'minItems': 4,
-                                            'type': 'array',
-                                        },
-                                        'coordinates': {
-                                            'items': {
-                                                'items': {
-                                                    'type': 'number',
-                                                },
-                                                'minItems': 2,
-                                                'type': 'array',
-                                            },
-                                            'minItems': 2,
-                                            'type': 'array',
-                                        },
-                                        'type': {
-                                            'const': 'LineString',
-                                            'type': 'string',
-                                        },
-                                    },
-                                    'required': [
-                                        'type',
-                                        'coordinates',
-                                    ],
-                                    'type': 'object',
-                                },
-                                {
-                                    'properties': {
-                                        'bbox': {
-                                            'items': {
-                                                'type': 'number',
-                                            },
-                                            'minItems': 4,
-                                            'type': 'array',
-                                        },
-                                        'coordinates': {
-                                            'items': {
-                                                'type': 'number',
-                                            },
-                                            'minItems': 2,
-                                            'type': 'array',
-                                        },
-                                        'type': {
-                                            'const': 'Point',
-                                            'type': 'string',
-                                        },
-                                    },
-                                    'required': [
-                                        'type',
-                                        'coordinates',
-                                    ],
-                                    'type': 'object',
-                                },
-                                {
-                                    'properties': {
-                                        'bbox': {
-                                            'items': {
-                                                'type': 'number',
-                                            },
-                                            'minItems': 4,
-                                            'type': 'array',
-                                        },
-                                        'coordinates': {
-                                            'items': {
-                                                'items': {
-                                                    'items': {
-                                                        'type': 'number',
-                                                    },
-                                                    'minItems': 2,
-                                                    'type': 'array',
-                                                },
-                                                'minItems': 4,
-                                                'type': 'array',
-                                            },
-                                            'minItems': 1,
-                                            'type': 'array',
-                                        },
-                                        'type': {
-                                            'const': 'Polygon',
-                                            'type': 'string',
-                                        },
-                                    },
-                                    'required': [
-                                        'type',
-                                        'coordinates',
-                                    ],
-                                    'type': 'object',
-                                },
-                                {
-                                    'properties': {
-                                        'bbox': {
-                                            'items': {
-                                                'type': 'number',
-                                            },
-                                            'minItems': 4,
-                                            'type': 'array',
-                                        },
-                                        'coordinates': {
-                                            'items': {
-                                                'items': {
-                                                    'items': {
-                                                        'type': 'number',
-                                                    },
-                                                    'minItems': 2,
-                                                    'type': 'array',
-                                                },
-                                                'minItems': 2,
-                                                'type': 'array',
-                                            },
-                                            'minItems': 1,
-                                            'type': 'array',
-                                        },
-                                        'type': {
-                                            'const': 'MultiLineString',
-                                            'type': 'string',
-                                        },
-                                    },
-                                    'required': [
-                                        'type',
-                                        'coordinates',
-                                    ],
-                                    'type': 'object',
-                                },
-                                {
-                                    'properties': {
-                                        'bbox': {
-                                            'items': {
-                                                'type': 'number',
-                                            },
-                                            'minItems': 4,
-                                            'type': 'array',
-                                        },
-                                        'coordinates': {
-                                            'items': {
-                                                'items': {
-                                                    'type': 'number',
-                                                },
-                                                'minItems': 2,
-                                                'type': 'array',
-                                            },
-                                            'minItems': 1,
-                                            'type': 'array',
-                                        },
-                                        'type': {
-                                            'const': 'MultiPoint',
-                                            'type': 'string',
-                                        },
-                                    },
-                                    'required': [
-                                        'type',
-                                        'coordinates',
-                                    ],
-                                    'type': 'object',
-                                },
-                                {
-                                    'properties': {
-                                        'bbox': {
-                                            'items': {
-                                                'type': 'number',
-                                            },
-                                            'minItems': 4,
-                                            'type': 'array',
-                                        },
-                                        'coordinates': {
-                                            'items': {
-                                                'items': {
-                                                    'items': {
-                                                        'items': {
-                                                            'type': 'number',
-                                                        },
-                                                        'minItems': 2,
-                                                        'type': 'array',
-                                                    },
-                                                    'minItems': 4,
-                                                    'type': 'array',
-                                                },
-                                                'minItems': 1,
-                                                'type': 'array',
-                                            },
-                                            'minItems': 1,
-                                            'type': 'array',
-                                        },
-                                        'type': {
-                                            'const': 'MultiPolygon',
-                                            'type': 'string',
-                                        },
-                                    },
-                                    'required': [
-                                        'type',
-                                        'coordinates',
-                                    ],
-                                    'type': 'object',
-                                },
-                            ],
-                        },
                         'type': {
                             'const': 'GeometryCollection',
-                            'type': 'string',
+                            'type': 'string'
                         },
-                    },
-                    'required': [
-                        'type',
-                        'geometries',
-                    ],
-                    'type': 'object',
-                },
-                {
-                    'properties': {
                         'bbox': {
                             'items': {
-                                'type': 'number',
+                                'type': 'number'
                             },
                             'minItems': 4,
-                            'type': 'array',
+                            'type': 'array'
                         },
-                        'coordinates': {
-                            'items': {
-                                'items': {
-                                    'type': 'number',
+                        'geometries': {
+                            'oneOf': [{
+                                'properties': {
+                                    'type': {
+                                        'const': 'LineString',
+                                        'type': 'string'
+                                    },
+                                    'bbox': {
+                                        'items': {
+                                            'type': 'number'
+                                        },
+                                        'minItems': 4,
+                                        'type': 'array'
+                                    },
+                                    'coordinates': {
+                                        'items': {
+                                            'items': {
+                                                'type': 'number'
+                                            },
+                                            'maxItems': 3,
+                                            'minItems': 2,
+                                            'type': 'array'
+                                        },
+                                        'minItems': 2,
+                                        'type': 'array'
+                                    }
                                 },
-                                'minItems': 2,
-                                'type': 'array',
-                            },
-                            'minItems': 2,
-                            'type': 'array',
-                        },
+                                'required': ['type', 'coordinates'],
+                                'type': 'object'
+                            }, {
+                                'properties': {
+                                    'type': {
+                                        'const': 'Point',
+                                        'type': 'string'
+                                    },
+                                    'bbox': {
+                                        'items': {
+                                            'type': 'number'
+                                        },
+                                        'minItems': 4,
+                                        'type': 'array'
+                                    },
+                                    'coordinates': {
+                                        'items': {
+                                            'type': 'number'
+                                        },
+                                        'maxItems': 3,
+                                        'minItems': 2,
+                                        'type': 'array'
+                                    }
+                                },
+                                'required': ['type', 'coordinates'],
+                                'type': 'object'
+                            }, {
+                                'properties': {
+                                    'type': {
+                                        'const': 'Polygon',
+                                        'type': 'string'
+                                    },
+                                    'bbox': {
+                                        'items': {
+                                            'type': 'number'
+                                        },
+                                        'minItems': 4,
+                                        'type': 'array'
+                                    },
+                                    'coordinates': {
+                                        'items': {
+                                            'items': {
+                                                'items': {
+                                                    'type': 'number'
+                                                },
+                                                'maxItems': 3,
+                                                'minItems': 2,
+                                                'type': 'array'
+                                            },
+                                            'minItems': 4,
+                                            'type': 'array'
+                                        },
+                                        'minItems': 1,
+                                        'type': 'array'
+                                    }
+                                },
+                                'required': ['type', 'coordinates'],
+                                'type': 'object'
+                            }, {
+                                'properties': {
+                                    'type': {
+                                        'const': 'MultiLineString',
+                                        'type': 'string'
+                                    },
+                                    'bbox': {
+                                        'items': {
+                                            'type': 'number'
+                                        },
+                                        'minItems': 4,
+                                        'type': 'array'
+                                    },
+                                    'coordinates': {
+                                        'items': {
+                                            'items': {
+                                                'items': {
+                                                    'type': 'number'
+                                                },
+                                                'maxItems': 3,
+                                                'minItems': 2,
+                                                'type': 'array'
+                                            },
+                                            'minItems': 2,
+                                            'type': 'array'
+                                        },
+                                        'minItems': 1,
+                                        'type': 'array'
+                                    }
+                                },
+                                'required': ['type', 'coordinates'],
+                                'type': 'object'
+                            }, {
+                                'properties': {
+                                    'type': {
+                                        'const': 'MultiPoint',
+                                        'type': 'string'
+                                    },
+                                    'bbox': {
+                                        'items': {
+                                            'type': 'number'
+                                        },
+                                        'minItems': 4,
+                                        'type': 'array'
+                                    },
+                                    'coordinates': {
+                                        'items': {
+                                            'items': {
+                                                'type': 'number'
+                                            },
+                                            'maxItems': 3,
+                                            'minItems': 2,
+                                            'type': 'array'
+                                        },
+                                        'minItems': 1,
+                                        'type': 'array'
+                                    }
+                                },
+                                'required': ['type', 'coordinates'],
+                                'type': 'object'
+                            }, {
+                                'properties': {
+                                    'type': {
+                                        'const': 'MultiPolygon',
+                                        'type': 'string'
+                                    },
+                                    'bbox': {
+                                        'items': {
+                                            'type': 'number'
+                                        },
+                                        'minItems': 4,
+                                        'type': 'array'
+                                    },
+                                    'coordinates': {
+                                        'items': {
+                                            'items': {
+                                                'items': {
+                                                    'items': {
+                                                        'type': 'number'
+                                                    },
+                                                    'maxItems': 3,
+                                                    'minItems': 2,
+                                                    'type': 'array'
+                                                },
+                                                'minItems': 4,
+                                                'type': 'array'
+                                            },
+                                            'minItems': 1,
+                                            'type': 'array'
+                                        },
+                                        'minItems': 1,
+                                        'type': 'array'
+                                    }
+                                },
+                                'required': ['type', 'coordinates'],
+                                'type': 'object'
+                            }]
+                        }
+                    },
+                    'required': ['type', 'geometries'],
+                    'type': 'object'
+                }, {
+                    'properties': {
                         'type': {
                             'const': 'LineString',
-                            'type': 'string',
+                            'type': 'string'
                         },
-                    },
-                    'required': [
-                        'type',
-                        'coordinates',
-                    ],
-                    'type': 'object',
-                },
-                {
-                    'properties': {
                         'bbox': {
                             'items': {
-                                'type': 'number',
+                                'type': 'number'
                             },
                             'minItems': 4,
-                            'type': 'array',
+                            'type': 'array'
                         },
                         'coordinates': {
                             'items': {
-                                'type': 'number',
+                                'items': {
+                                    'type': 'number'
+                                },
+                                'maxItems': 3,
+                                'minItems': 2,
+                                'type': 'array'
                             },
                             'minItems': 2,
-                            'type': 'array',
-                        },
-                        'type': {
-                            'const': 'Point',
-                            'type': 'string',
-                        },
+                            'type': 'array'
+                        }
                     },
-                    'required': [
-                        'type',
-                        'coordinates',
-                    ],
-                    'type': 'object',
-                },
-                {
+                    'required': ['type', 'coordinates'],
+                    'type': 'object'
+                }, {
                     'properties': {
-                        'bbox': {
-                            'items': {
-                                'type': 'number',
-                            },
-                            'minItems': 4,
-                            'type': 'array',
-                        },
-                        'coordinates': {
-                            'items': {
-                                'items': {
-                                    'items': {
-                                        'type': 'number',
-                                    },
-                                    'minItems': 2,
-                                    'type': 'array',
-                                },
-                                'minItems': 4,
-                                'type': 'array',
-                            },
-                            'minItems': 1,
-                            'type': 'array',
-                        },
-                        'type': {
-                            'const': 'Polygon',
-                            'type': 'string',
-                        },
-                    },
-                    'required': [
-                        'type',
-                        'coordinates',
-                    ],
-                    'type': 'object',
-                },
-                {
-                    'properties': {
-                        'bbox': {
-                            'items': {
-                                'type': 'number',
-                            },
-                            'minItems': 4,
-                            'type': 'array',
-                        },
-                        'coordinates': {
-                            'items': {
-                                'items': {
-                                    'items': {
-                                        'type': 'number',
-                                    },
-                                    'minItems': 2,
-                                    'type': 'array',
-                                },
-                                'minItems': 2,
-                                'type': 'array',
-                            },
-                            'minItems': 1,
-                            'type': 'array',
-                        },
                         'type': {
                             'const': 'MultiLineString',
-                            'type': 'string',
+                            'type': 'string'
                         },
-                    },
-                    'required': [
-                        'type',
-                        'coordinates',
-                    ],
-                    'type': 'object',
-                },
-                {
-                    'properties': {
                         'bbox': {
                             'items': {
-                                'type': 'number',
+                                'type': 'number'
                             },
                             'minItems': 4,
-                            'type': 'array',
+                            'type': 'array'
                         },
                         'coordinates': {
                             'items': {
                                 'items': {
-                                    'type': 'number',
+                                    'items': {
+                                        'type': 'number'
+                                    },
+                                    'maxItems': 3,
+                                    'minItems': 2,
+                                    'type': 'array'
                                 },
                                 'minItems': 2,
-                                'type': 'array',
+                                'type': 'array'
                             },
                             'minItems': 1,
-                            'type': 'array',
-                        },
+                            'type': 'array'
+                        }
+                    },
+                    'required': ['type', 'coordinates'],
+                    'type': 'object'
+                }, {
+                    'properties': {
                         'type': {
                             'const': 'MultiPoint',
-                            'type': 'string',
+                            'type': 'string'
                         },
-                    },
-                    'required': [
-                        'type',
-                        'coordinates',
-                    ],
-                    'type': 'object',
-                },
-                {
-                    'properties': {
                         'bbox': {
                             'items': {
-                                'type': 'number',
+                                'type': 'number'
                             },
                             'minItems': 4,
-                            'type': 'array',
+                            'type': 'array'
+                        },
+                        'coordinates': {
+                            'items': {
+                                'items': {
+                                    'type': 'number'
+                                },
+                                'maxItems': 3,
+                                'minItems': 2,
+                                'type': 'array'
+                            },
+                            'minItems': 1,
+                            'type': 'array'
+                        }
+                    },
+                    'required': ['type', 'coordinates'],
+                    'type': 'object'
+                }, {
+                    'properties': {
+                        'type': {
+                            'const': 'MultiPolygon',
+                            'type': 'string'
+                        },
+                        'bbox': {
+                            'items': {
+                                'type': 'number'
+                            },
+                            'minItems': 4,
+                            'type': 'array'
                         },
                         'coordinates': {
                             'items': {
                                 'items': {
                                     'items': {
                                         'items': {
-                                            'type': 'number',
+                                            'type': 'number'
                                         },
+                                        'maxItems': 3,
                                         'minItems': 2,
-                                        'type': 'array',
+                                        'type': 'array'
                                     },
                                     'minItems': 4,
-                                    'type': 'array',
+                                    'type': 'array'
                                 },
                                 'minItems': 1,
-                                'type': 'array',
+                                'type': 'array'
                             },
                             'minItems': 1,
-                            'type': 'array',
-                        },
-                        'type': {
-                            'const': 'MultiPolygon',
-                            'type': 'string',
-                        },
+                            'type': 'array'
+                        }
                     },
-                    'required': [
-                        'type',
-                        'coordinates',
-                    ],
-                    'type': 'object',
-                },
-            ],
-        },
-        'id': {
-            'minLength': 1,
-            'pattern': '^\\S+$',
-            'type': 'string',
-        },
-        'properties': {
-            'additionalProperties': False,
-            'patternProperties': {
-                '^ext_.*$': {},
+                    'required': ['type', 'coordinates'],
+                    'type': 'object'
+                }, {
+                    'properties': {
+                        'type': {
+                            'const': 'Point',
+                            'type': 'string'
+                        },
+                        'bbox': {
+                            'items': {
+                                'type': 'number'
+                            },
+                            'minItems': 4,
+                            'type': 'array'
+                        },
+                        'coordinates': {
+                            'items': {
+                                'type': 'number'
+                            },
+                            'maxItems': 3,
+                            'minItems': 2,
+                            'type': 'array'
+                        }
+                    },
+                    'required': ['type', 'coordinates'],
+                    'type': 'object'
+                }, {
+                    'properties': {
+                        'type': {
+                            'const': 'Polygon',
+                            'type': 'string'
+                        },
+                        'bbox': {
+                            'items': {
+                                'type': 'number'
+                            },
+                            'minItems': 4,
+                            'type': 'array'
+                        },
+                        'coordinates': {
+                            'items': {
+                                'items': {
+                                    'items': {
+                                        'type': 'number'
+                                    },
+                                    'maxItems': 3,
+                                    'minItems': 2,
+                                    'type': 'array'
+                                },
+                                'minItems': 4,
+                                'type': 'array'
+                            },
+                            'minItems': 1,
+                            'type': 'array'
+                        }
+                    },
+                    'required': ['type', 'coordinates'],
+                    'type': 'object'
+                }],
+            },
+            'bbox': {
+                'anyOf': [{
+                    'items': {
+                        'type': 'number'
+                    },
+                    'maxItems': 4,
+                    'minItems': 4,
+                    'type': 'array'
+                }, {
+                    'type': 'null'
+                }],
+                'default': None,
             },
             'properties': {
-                'sources': {
-                    'anyOf': [
-                        {
+                'type': 'object',
+                'properties': {
+                    'theme': {
+                        'type': 'string'
+                    },
+                    'type': {
+                        'type': 'string'
+                    },
+                    'version': {
+                        'minimum': 0,
+                        'type': 'integer'
+                    },
+                    'sources': {
+                        'anyOf': [{
                             'items': {
-                                '$ref': '#/$defs/SourcePropertyItem',
+                                '$ref': '#/$defs/SourcePropertyItem'
                             },
                             'minItems': 1,
                             'type': 'array',
-                            'uniqueItems': True,
-                        },
-                        {
-                            'type': 'null',
-                        },
-                    ],
-                    'default': None,
+                            'uniqueItems': True
+                        }, {
+                            'type': 'null'
+                        }],
+                        'default': None,
+                    }
                 },
-                'theme': {
-                    'type': 'string',
+                'unevaluatedProperties': False,
+                'required': ['theme', 'type', 'version'],
+                'patternProperties': {
+                    '^ext_.*$': {
+                    }
                 },
-                'type': {
-                    'type': 'string',
-                },
-                'version': {
-                    'minimum': 0,
-                    'type': 'integer',
-                },
+                'additionalProperties': False
             },
-            'required': [
-                'theme',
-                'type',
-                'version',
-            ],
-            'type': 'object',
-            'unevaluatedProperties': False,
+            'type': {
+                'const': 'Feature',
+                'type': 'string'
+            }
         },
-        'type': {
-            'const': 'Feature',
-            'type': 'string',
-        },
-    },
-    'required': [
-        'id',
-        'geometry',
-        'properties',
-        'type',
-    ],
-    'type': 'object',
-}
+        'required': ['id', 'geometry', 'properties', 'type'],
+        'type': 'object',
+    }
 
-    assert actual == expect
+
+    diff = DeepDiff(actual, expect, ignore_order=True)
+
+    assert diff == {}
 
 
 @pytest.mark.parametrize("feature, expect", [

--- a/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
@@ -260,19 +260,24 @@
               "items": {
                 "items": {
                   "items": {
-                    "type": "number"
+                    "items": {
+                      "type": "number"
+                    },
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
                   },
-                  "minItems": 2,
+                  "minItems": 4,
                   "type": "array"
                 },
-                "minItems": 4,
+                "minItems": 1,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "Polygon",
+              "const": "MultiPolygon",
               "type": "string"
             }
           },
@@ -295,23 +300,20 @@
               "items": {
                 "items": {
                   "items": {
-                    "items": {
-                      "type": "number"
-                    },
-                    "minItems": 2,
-                    "type": "array"
+                    "type": "number"
                   },
-                  "minItems": 4,
+                  "maxItems": 3,
+                  "minItems": 2,
                   "type": "array"
                 },
-                "minItems": 1,
+                "minItems": 4,
                 "type": "array"
               },
               "minItems": 1,
               "type": "array"
             },
             "type": {
-              "const": "MultiPolygon",
+              "const": "Polygon",
               "type": "string"
             }
           },

--- a/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
@@ -359,6 +359,7 @@
           "items": {
             "type": "number"
           },
+          "maxItems": 3,
           "minItems": 2,
           "type": "array"
         },

--- a/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
@@ -153,6 +153,7 @@
                 "items": {
                   "type": "number"
                 },
+                "maxItems": 3,
                 "minItems": 2,
                 "type": "array"
               },
@@ -185,6 +186,7 @@
                   "items": {
                     "type": "number"
                   },
+                  "maxItems": 3,
                   "minItems": 2,
                   "type": "array"
                 },

--- a/packages/overture-schema-places-theme/tests/place_baseline_schema.json
+++ b/packages/overture-schema-places-theme/tests/place_baseline_schema.json
@@ -313,6 +313,7 @@
           "items": {
             "type": "number"
           },
+          "maxItems": 3,
           "minItems": 2,
           "type": "array"
         },

--- a/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
@@ -84,6 +84,7 @@
           "items": {
             "type": "number"
           },
+          "maxItems": 3,
           "minItems": 2,
           "type": "array"
         },

--- a/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
@@ -636,6 +636,7 @@
                 "items": {
                   "type": "number"
                 },
+                "maxItems": 3,
                 "minItems": 2,
                 "type": "array"
               },
@@ -906,6 +907,7 @@
                 "items": {
                   "type": "number"
                 },
+                "maxItems": 3,
                 "minItems": 2,
                 "type": "array"
               },
@@ -1572,6 +1574,7 @@
                 "items": {
                   "type": "number"
                 },
+                "maxItems": 3,
                 "minItems": 2,
                 "type": "array"
               },


### PR DESCRIPTION
Omnibus PR to increase the quality of the geometry primitives:

1. Make `Geometry` an immutable class
2. Remove `@dataclass` from `BBox` and just use standard immutability tricks. This is because I discovered when trying to make `Geometry` an `@dataclass` that Pydantic doesn't deserialize a data class correctly.
3. Add docstrings to `Geometry` interface.
4. Increase unit test coverage for `Geometry`.
5. Increase unit test coverage for `BBox`.
6. Fix false positive test failures in the test function `test_feature_json_schema`.
7. Raise `ValueError` in `Geometry` constructor if the Shapely geometry is empty. The rule is that Overture geometry has to have a physical existence somewhere in the world, so empty geometry is not allowed (and was prohibited under the Overture JSON Schema).
8. Limit `Geometry` GeoJSON schema dimensions to 3D.
