### PR TITLE
Fix up overture-schema-sources

### DIFF
--- a/packages/overture-schema-sources/src/overture/schema/sources/__main__.py
+++ b/packages/overture-schema-sources/src/overture/schema/sources/__main__.py
@@ -55,7 +55,7 @@ def main() -> None:
         if isinstance(data, dict):
             datasets = data.get("datasets")
 
-        def source_name_for_error(loc):
+        def source_name_for_error(loc: tuple[int | str, ...]) -> str | None:
             if not loc:
                 return None
             if loc[0] != "datasets" or len(loc) < 2:
@@ -80,7 +80,7 @@ def main() -> None:
 
             return None
 
-        def format_field_path(loc):
+        def format_field_path(loc: tuple[int | str, ...]) -> str:
             if len(loc) <= 2:
                 return ""
 

--- a/packages/overture-schema-sources/src/overture/schema/sources/models.py
+++ b/packages/overture-schema-sources/src/overture/schema/sources/models.py
@@ -7,7 +7,6 @@ from pydantic import Field, HttpUrl
 
 from overture.schema.core.models import StrictBaseModel
 from overture.schema.core.types import CountryCode
-from overture.schema.validation import PatternPropertiesDictConstraint
 
 from .enums import BuildSource, UpdateType
 from .types import LicenseShortname
@@ -44,14 +43,12 @@ class Dataset(StrictBaseModel):
         HttpUrl | Literal[""],
         Field(
             description="A link to this source's data license or page referencing the license associated with the data being imported. This should include explicit license terms.",
-            format="uri",
         ),
     ]
     license_url_archived: Annotated[
         HttpUrl | Literal[""],
         Field(
             description="URL of the source's license page, stored on archive.org, at or near the date the source data was obtained for use within Overture.",
-            format="uri",
         ),
     ]
     license_type: Annotated[
@@ -175,9 +172,9 @@ class Sources(StrictBaseModel):
         Field(description="List of data source entries used by Overture."),
     ]
     license_priority: Annotated[
-        dict[LicenseShortname, Annotated[int, Field(min=0)]],
+        dict[LicenseShortname, Annotated[int, Field(ge=0)]],
         Field(
             description="Map of license shortnames to their priority (lower number indicates higher priority)."
         ),
-        PatternPropertiesDictConstraint(),  # TODO see if this is necessary now that `LicenseShortname` is annotated with a pattern
+        Field(json_schema_extra={"additionalProperties": False}),
     ]

--- a/packages/overture-schema-sources/tests/sources_baseline_schema.json
+++ b/packages/overture-schema-sources/tests/sources_baseline_schema.json
@@ -1,0 +1,297 @@
+{
+  "$defs": {
+    "BuildSource": {
+      "description": "The ingest source for address data.",
+      "enum": [
+        "OpenAddresses",
+        "tf-data-platform"
+      ],
+      "title": "BuildSource",
+      "type": "string"
+    },
+    "Dataset": {
+      "additionalProperties": false,
+      "description": "Dataset definition for Overture Maps data sources.",
+      "properties": {
+        "address_levels": {
+          "description": "Available address level attributes from OpenAddress, if existing.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Address Levels",
+          "type": "array"
+        },
+        "build_source": {
+          "$ref": "#/$defs/BuildSource"
+        },
+        "countries": {
+          "description": "A list of two-character iso country codes that this data source provides data in.",
+          "items": {
+            "anyOf": [
+              {
+                "description": "ISO 3166-1 alpha-2 country code",
+                "maxLength": 2,
+                "minLength": 2,
+                "pattern": "^[A-Z]{2}$",
+                "type": "string"
+              },
+              {
+                "const": "Global",
+                "type": "string"
+              }
+            ]
+          },
+          "title": "Countries",
+          "type": "array"
+        },
+        "coverage_bbox": {
+          "description": "The bounding box, in [xmin, ymin, xmax, ymax] format, of this source's coverage.",
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 4,
+          "minItems": 4,
+          "title": "Coverage Bbox",
+          "type": "array"
+        },
+        "coverage_description": {
+          "description": "A description of the coverage type of the source data - i.e. national, regional, local.",
+          "title": "Coverage Description",
+          "type": "string"
+        },
+        "data_download_url": {
+          "description": "Either a direct download link of data from this source, typically a geo-format or compressed file, or an endpoint from where the data was obtained for use within Overture.",
+          "items": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "maxLength": 2083,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "const": "",
+                "type": "string"
+              }
+            ]
+          },
+          "title": "Data Download Url",
+          "type": "array"
+        },
+        "data_layer_name": {
+          "description": "Name of the data layer used from this source.",
+          "title": "Data Layer Name",
+          "type": "string"
+        },
+        "data_url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "maxLength": 2083,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "const": "",
+              "type": "string"
+            }
+          ],
+          "description": "The data page or data portal of this source, typically includes links to data downloads and license links.",
+          "title": "Data Url"
+        },
+        "data_url_archived": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "maxLength": 2083,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "const": "",
+              "type": "string"
+            }
+          ],
+          "description": "URL of the source's data page, stored on archive.org, at or near the date the source data was obtained for use within Overture.",
+          "title": "Data Url Archived"
+        },
+        "file_format": {
+          "description": "Format of the file used from this source.",
+          "title": "File Format",
+          "type": "string"
+        },
+        "inception_date": {
+          "description": "The first date this source was used in the Overture addresses theme, in YYYY-MM-DD format.",
+          "format": "date",
+          "title": "Inception Date",
+          "type": "string"
+        },
+        "known_issues": {
+          "description": "A description of any issues with the data that are known - i.e. data is incomplete, coverage is incomplete, or issues with character encoding.",
+          "title": "Known Issues",
+          "type": "string"
+        },
+        "license_attribution": {
+          "description": "Any attribution required by this source.",
+          "title": "License Attribution",
+          "type": "string"
+        },
+        "license_text": {
+          "description": "Any relevant license text, direct from the source's license page.",
+          "title": "License Text",
+          "type": "string"
+        },
+        "license_type": {
+          "description": "The license that is associated with the data being used from this source. This should be a valid SPDX license identifier when available.",
+          "title": "License Type",
+          "type": "string"
+        },
+        "license_url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "maxLength": 2083,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "const": "",
+              "type": "string"
+            }
+          ],
+          "description": "A link to this source's data license or page referencing the license associated with the data being imported. This should include explicit license terms.",
+          "title": "License Url"
+        },
+        "license_url_archived": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "maxLength": 2083,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "const": "",
+              "type": "string"
+            }
+          ],
+          "description": "URL of the source's license page, stored on archive.org, at or near the date the source data was obtained for use within Overture.",
+          "title": "License Url Archived"
+        },
+        "notes": {
+          "description": "Freeform notes about this data source, including notes on any pre-processing requirements.",
+          "title": "Notes",
+          "type": "string"
+        },
+        "oa_path": {
+          "description": "File path and name in OpenAddresses, if existing.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Oa Path",
+          "type": "array"
+        },
+        "requires_attribution": {
+          "description": "Whether this source requires attribution to be used in Overture Maps.",
+          "title": "Requires Attribution",
+          "type": "string"
+        },
+        "source_dataset_name": {
+          "description": "The name of the dataset being used from the source. This should match the 'dataset' value found in a record's sources column.",
+          "title": "Source Dataset Name",
+          "type": "string"
+        },
+        "source_name": {
+          "description": "The name of the source.",
+          "title": "Source Name",
+          "type": "string"
+        },
+        "update_frequency": {
+          "description": "How frequently the source data is updated upstream.",
+          "title": "Update Frequency",
+          "type": "string"
+        },
+        "update_schedule": {
+          "description": "The month or months in which the data is to be re-ingested by the Overture theme using this data source.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Update Schedule",
+          "type": "array"
+        },
+        "update_type": {
+          "$ref": "#/$defs/UpdateType"
+        },
+        "url": {
+          "description": "The home page of this source.",
+          "format": "uri",
+          "maxLength": 2083,
+          "minLength": 1,
+          "title": "Url",
+          "type": "string"
+        },
+        "url_archived": {
+          "description": "URL of the source's home page, stored on archive.org, at or near the date the source data was obtained for use within Overture.",
+          "format": "uri",
+          "maxLength": 2083,
+          "minLength": 1,
+          "title": "Url Archived",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_name",
+        "source_dataset_name",
+        "data_url",
+        "data_url_archived",
+        "license_url",
+        "license_url_archived",
+        "license_type",
+        "license_text",
+        "license_attribution",
+        "coverage_bbox"
+      ],
+      "title": "Dataset",
+      "type": "object"
+    },
+    "UpdateType": {
+      "description": "Whether the data is continuously updated upstream or needs manual intervention.",
+      "enum": [
+        "continuous",
+        "manual"
+      ],
+      "title": "UpdateType",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Common schema definitions for data sources.",
+  "properties": {
+    "datasets": {
+      "description": "List of data source entries used by Overture.",
+      "items": {
+        "$ref": "#/$defs/Dataset"
+      },
+      "title": "Datasets",
+      "type": "array"
+    },
+    "license_priority": {
+      "additionalProperties": false,
+      "description": "Map of license shortnames to their priority (lower number indicates higher priority).",
+      "patternProperties": {
+        "^[A-Za-z0-9._+\\-]+$": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "title": "License Priority",
+      "type": "object"
+    }
+  },
+  "required": [
+    "datasets",
+    "license_priority"
+  ],
+  "title": "Sources",
+  "type": "object"
+}

--- a/packages/overture-schema/tests/test_schema_validation.py
+++ b/packages/overture-schema/tests/test_schema_validation.py
@@ -225,7 +225,12 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
 def test_example_validation_geojson(example_file: str) -> None:
     """Test that examples pass validation with GeoJSON input format."""
-    test_feature = convert_to_geojson_format(load_feature(example_file))
+    feature = load_feature(example_file)
+
+    if "geometry" not in feature:
+        pytest.skip("Example does not have a geometry field")
+
+    test_feature = convert_to_geojson_format(feature)
 
     is_valid = False
     error_msg = None
@@ -267,7 +272,7 @@ def test_example_validation_flat(example_file: str) -> None:
     )
 
     # If validation passed and we have a parsed feature, compare with GeoJSON format
-    if parsed_feature is not None:
+    if parsed_feature is not None and "geometry" in flat_feature:
         # Parsed feature should be in GeoJSON format, so compare with GeoJSON variant
         expected_geojson = convert_to_geojson_format(flat_feature)
         is_equal, diff_report = deep_compare_dicts(expected_geojson, parsed_feature)

--- a/reference/counterexamples/sources/coverage-bbox-too-short.yaml
+++ b/reference/counterexamples/sources/coverage-bbox-too-short.yaml
@@ -1,4 +1,3 @@
----
 datasets:
   - source_name: Example City Open Data
     source_dataset_name: address_points

--- a/reference/counterexamples/sources/invalid-data-url.yaml
+++ b/reference/counterexamples/sources/invalid-data-url.yaml
@@ -1,4 +1,3 @@
----
 datasets:
   - source_name: Example Broken URLs
     source_dataset_name: address_points

--- a/reference/examples/sources/basic-sources.yaml
+++ b/reference/examples/sources/basic-sources.yaml
@@ -1,4 +1,3 @@
----
 datasets:
   - source_name: Example City Open Data
     source_dataset_name: address_points

--- a/reference/examples/sources/minimal.yaml
+++ b/reference/examples/sources/minimal.yaml
@@ -1,4 +1,3 @@
----
 datasets:
   - source_name: Address Sample
     source_dataset_name: addresses_sample


### PR DESCRIPTION
- add support for models without a `type` field to the dynamic union generator in `overture.schema:parse`; it now produces `<discriminated union of models with 'type'> | <regular union of models without 'type'>` to maintain performance while adding flexibility for peripheral Overture models
- remove non-existent `PatternPropertiesDictConstraint` in favor of `json_schema_extra=` kwarg
- remove deprecated `format` kwargs (redundant with `HttpUri`)
- avoid transforming non-Features to GeoJSON
- add missing typing information
- align YAML formatting with existing examples
- add missing baseline sources JSON Schema