### PR TITLE
Pydantic housekeeping

### DIFF
--- a/.github/workflows/github-actions-check-pydantic.yaml
+++ b/.github/workflows/github-actions-check-pydantic.yaml
@@ -27,8 +27,5 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install dependencies
-        run: uv sync --all-packages
-
       - name: Run make check
         run: make check

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,23 @@
-.PHONY: check test test-all mypy
+.PHONY: default uv-sync check test-all test mypy reset-baseline-schemas
 
 default: test-all
 
-check: test
+uv-sync:
+	@uv sync --all-packages
+
+check: test uv-sync
 	@uv run ruff check -q packages/
 	@$(MAKE) mypy
 	@uv run ruff format --check packages/
 
-test-all:
+test-all: uv-sync
 	@uv run pytest packages/
 
-test:
+test: uv-sync
 	@uv run pytest packages/ -x
 
 # mypy type checking with namespace package support
-mypy:
+mypy: uv-sync
 	@cd packages && uv run mypy --no-error-summary --namespace-packages \
 		-p overture.schema \
 		-p overture.schema.addresses \

--- a/packages/overture-schema-addresses-theme/pyproject.toml
+++ b/packages/overture-schema-addresses-theme/pyproject.toml
@@ -1,35 +1,28 @@
 [project]
-name = "overture-schema-addresses-theme"
-dynamic = ["version"]
-description = "Overture Maps addresses theme models and structures"
-readme = "README.md"
-requires-python = ">=3.10"
-license = "MIT"
 dependencies = [
     "overture-schema-core",
     "pydantic>=2.0",
 ]
+description = "Overture Maps addresses theme models and structures"
+dynamic = ["version"]
+license = "MIT"
+name = "overture-schema-addresses-theme"
+readme = "README.md"
+requires-python = ">=3.10"
 
 [tool.uv.sources]
 overture-schema-core = { workspace = true }
 
 
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = ["hatchling"]
 
 [tool.hatch.version]
 path = "src/overture/schema/addresses/__about__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/overture"]
-
-[dependency-groups]
-dev = [
-    "pytest>=7.0",
-    "ruff",
-    "mypy",
-]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/packages/overture-schema-base-theme/pyproject.toml
+++ b/packages/overture-schema-base-theme/pyproject.toml
@@ -1,29 +1,22 @@
 [project]
-name = "overture-schema-base-theme"
-dynamic = ["version"]
-description = "Overture Maps base theme shared structures and models (bathymetry, infrastructure, land, land_cover, land_use, water)"
-readme = "README.md"
-requires-python = ">=3.10"
-license = "MIT"
 dependencies = [
     "overture-schema-core",
     "pydantic>=2.0",
 ]
-
-[dependency-groups]
-dev = [
-    "pytest>=7.0",
-    "ruff",
-    "mypy",
-]
+description = "Overture Maps base theme shared structures and models (bathymetry, infrastructure, land, land_cover, land_use, water)"
+dynamic = ["version"]
+license = "MIT"
+name = "overture-schema-base-theme"
+readme = "README.md"
+requires-python = ">=3.10"
 
 [tool.uv.sources]
 overture-schema-core = { workspace = true }
 
 
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = ["hatchling"]
 
 [tool.hatch.version]
 path = "src/overture/schema/base/__about__.py"

--- a/packages/overture-schema-buildings-theme/pyproject.toml
+++ b/packages/overture-schema-buildings-theme/pyproject.toml
@@ -1,22 +1,22 @@
 [project]
-name = "overture-schema-buildings-theme"
-dynamic = ["version"]
-description = "Overture Maps buildings theme shared structures, building types, and building part types"
-readme = "README.md"
-requires-python = ">=3.10"
-license = "MIT"
 dependencies = [
     "overture-schema-core",
     "pydantic>=2.0",
 ]
+description = "Overture Maps buildings theme shared structures, building types, and building part types"
+dynamic = ["version"]
+license = "MIT"
+name = "overture-schema-buildings-theme"
+readme = "README.md"
+requires-python = ">=3.10"
 
 [tool.uv.sources]
 overture-schema-core = { workspace = true }
 
 
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = ["hatchling"]
 
 [tool.hatch.version]
 path = "src/overture/schema/buildings/__about__.py"

--- a/packages/overture-schema-divisions-theme/pyproject.toml
+++ b/packages/overture-schema-divisions-theme/pyproject.toml
@@ -1,30 +1,23 @@
 [project]
-name = "overture-schema-divisions-theme"
-dynamic = ["version"]
-description = "Overture Maps divisions theme shared structures, division, division area and division boundary types"
-readme = "README.md"
-requires-python = ">=3.10"
-license = "MIT"
 dependencies = [
     "overture-schema-core",
     "overture-schema-validation",
     "pydantic>=2.0",
 ]
-
-[dependency-groups]
-dev = [
-    "pytest>=7.0",
-    "ruff",
-    "mypy",
-]
+description = "Overture Maps divisions theme shared structures, division, division area and division boundary types"
+dynamic = ["version"]
+license = "MIT"
+name = "overture-schema-divisions-theme"
+readme = "README.md"
+requires-python = ">=3.10"
 
 [tool.uv.sources]
 overture-schema-core = { workspace = true }
 overture-schema-validation = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = ["hatchling"]
 
 [tool.hatch.version]
 path = "src/overture/schema/divisions/__about__.py"

--- a/packages/overture-schema-places-theme/pyproject.toml
+++ b/packages/overture-schema-places-theme/pyproject.toml
@@ -1,31 +1,24 @@
 [project]
-name = "overture-schema-places-theme"
-dynamic = ["version"]
-description = "Overture Maps places theme with place type models"
-readme = "README.md"
-requires-python = ">=3.10"
-license = "MIT"
 dependencies = [
     "overture-schema-core",
     "overture-schema-validation",
     "pydantic>=2.0",
     "pydantic[email]",
 ]
+description = "Overture Maps places theme with place type models"
+dynamic = ["version"]
+license = "MIT"
+name = "overture-schema-places-theme"
+readme = "README.md"
+requires-python = ">=3.10"
 
 [tool.uv.sources]
 overture-schema-core = { workspace = true }
 overture-schema-validation = { workspace = true }
 
-[dependency-groups]
-dev = [
-    "pytest>=7.0",
-    "ruff",
-    "mypy",
-]
-
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = ["hatchling"]
 
 [tool.hatch.version]
 path = "src/overture/schema/places/__about__.py"

--- a/packages/overture-schema-sources/pyproject.toml
+++ b/packages/overture-schema-sources/pyproject.toml
@@ -1,28 +1,21 @@
 [project]
-name = "overture-schema-sources"
-dynamic = ["version"]
-description = "Add your description here"
-readme = "README.md"
-requires-python = ">=3.10"
-license = "MIT"
 dependencies = [
     "overture-schema-core",
     "pydantic>=2.0",
 ]
+description = "Add your description here"
+dynamic = ["version"]
+license = "MIT"
+name = "overture-schema-sources"
+readme = "README.md"
+requires-python = ">=3.10"
 
 [tool.uv.sources]
 overture-schema-core = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[dependency-groups]
-dev = [
-    "pytest>=7.0",
-    "ruff",
-    "mypy",
-]
+requires = ["hatchling"]
 
 [tool.hatch.version]
 path = "src/overture/schema/__about__.py"

--- a/packages/overture-schema-transportation-theme/pyproject.toml
+++ b/packages/overture-schema-transportation-theme/pyproject.toml
@@ -1,22 +1,22 @@
 [project]
-name = "overture-schema-transportation-theme"
-dynamic = ["version"]
-description = "Overture Maps transportation theme with shared structures and connector and segment types"
-readme = "README.md"
-requires-python = ">=3.10"
-license = "MIT"
 dependencies = [
     "overture-schema-core",
     "pydantic>=2.0",
 ]
+description = "Overture Maps transportation theme with shared structures and connector and segment types"
+dynamic = ["version"]
+license = "MIT"
+name = "overture-schema-transportation-theme"
+readme = "README.md"
+requires-python = ">=3.10"
 
 [tool.uv.sources]
 overture-schema-core = { workspace = true }
 
 
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = ["hatchling"]
 
 [tool.hatch.version]
 path = "src/overture/schema/transportation/__about__.py"

--- a/packages/overture-schema-validation/pyproject.toml
+++ b/packages/overture-schema-validation/pyproject.toml
@@ -1,26 +1,18 @@
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = ["hatchling"]
 
 [project]
-name = "overture-schema-validation"
-dynamic = ["version"]
-description = "Constraint-based validation utilities for Overture Maps schemas"
-readme = "README.md"
-requires-python = ">=3.10"
-license = "MIT"
 dependencies = [
     "pydantic>=2.0.0",
     "shapely>=2.0.0",
 ]
-
-[dependency-groups]
-dev = [
-    "pytest>=7.0",
-    "ruff",
-    "mypy",
-]
-
+description = "Constraint-based validation utilities for Overture Maps schemas"
+dynamic = ["version"]
+license = "MIT"
+name = "overture-schema-validation"
+readme = "README.md"
+requires-python = ">=3.10"
 
 [tool.hatch.version]
 path = "src/overture/schema/validation/__about__.py"
@@ -29,10 +21,16 @@ path = "src/overture/schema/validation/__about__.py"
 packages = ["src/overture"]
 
 [tool.ruff]
-target-version = "py310"
 line-length = 88
+target-version = "py310"
 
 [tool.ruff.lint]
+ignore = [
+    "E501", # line too long
+    "B008", # do not perform function calls in argument defaults
+    "C901", # too complex
+]
+per-file-ignores = { "__init__.py" = ["F401"] }
 select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
@@ -42,9 +40,3 @@ select = [
     "C4", # flake8-comprehensions
     "UP", # pyupgrade
 ]
-ignore = [
-    "E501",  # line too long
-    "B008",  # do not perform function calls in argument defaults
-    "C901",  # too complex
-]
-per-file-ignores = {"__init__.py" = ["F401"]}

--- a/packages/overture-schema/pyproject.toml
+++ b/packages/overture-schema/pyproject.toml
@@ -1,10 +1,4 @@
 [project]
-name = "overture-schema"
-dynamic = ["version"]
-description = "Complete Overture Maps schema collection with all themes and types"
-readme = "README.md"
-requires-python = ">=3.10"
-license = "MIT"
 dependencies = [
     "overture-schema-addresses-theme",
     "overture-schema-base-theme",
@@ -16,28 +10,30 @@ dependencies = [
     "pydantic>=2.0",
     "pyyaml>=6.0.2",
 ]
+description = "Complete Overture Maps schema collection with all themes and types"
+dynamic = ["version"]
+license = "MIT"
+name = "overture-schema"
+readme = "README.md"
+requires-python = ">=3.10"
 
 [tool.uv.sources]
 overture-schema-addresses-theme = { workspace = true }
 overture-schema-base-theme = { workspace = true }
 overture-schema-buildings-theme = { workspace = true }
+overture-schema-core = { workspace = true }
 overture-schema-divisions-theme = { workspace = true }
 overture-schema-places-theme = { workspace = true }
 overture-schema-transportation-theme = { workspace = true }
-overture-schema-core = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = ["hatchling"]
 
 [dependency-groups]
 dev = [
-    "pytest>=7.0",
-    "pytest-cov",
     "pyyaml",
     "deepdiff",
-    "ruff",
-    "mypy",
     "yamlcore>=0.0.4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 # uv workspace configuration
 
 [project]
-name = "overture-schema-workspace"
-version = "0.0.0"
-requires-python = ">=3.10"
 license = "MIT"
+name = "overture-schema-workspace"
+requires-python = ">=3.10"
+version = "0.0.0"
 
 [tool.uv.workspace]
 members = ["packages/*"]
@@ -15,6 +15,11 @@ line-length = 88
 target-version = "py310"
 
 [tool.ruff.lint]
+ignore = [
+    "E501", # line too long
+    "B008", # do not perform function calls in argument defaults
+    "C901", # too complex
+]
 select = [
     "E",   # pycodestyle errors
     "W",   # pycodestyle warnings
@@ -25,29 +30,28 @@ select = [
     "UP",  # pyupgrade,
     "ANN", # flake8-annotations
 ]
-ignore = [
-    "E501", # line too long
-    "B008", # do not perform function calls in argument defaults
-    "C901", # too complex
-]
 
 [tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F401"]
 "**/tests/*.py" = ["ANN401"]
+"__init__.py" = ["F401"]
 
 [tool.mypy]
-python_version = "3.10"
-plugins = ["pydantic.mypy"]
-warn_return_any = true
-warn_unused_configs = true
 disallow_untyped_defs = true
-namespace_packages = true
 explicit_package_bases = true
 files = "packages/**/*.py"
+namespace_packages = true
+plugins = ["pydantic.mypy"]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
 
 [dependency-groups]
 dev = [
     "docformatter>=1.7.7",
+    "mypy",
+    "pytest>=7.0",
+    "pytest-cov",
+    "ruff",
 ]
 
 [tool.docformatter]

--- a/uv.lock
+++ b/uv.lock
@@ -491,11 +491,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "deepdiff" },
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
     { name = "pyyaml" },
-    { name = "ruff" },
     { name = "yamlcore" },
 ]
 
@@ -515,11 +511,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "deepdiff" },
-    { name = "mypy" },
-    { name = "pytest", specifier = ">=7.0" },
-    { name = "pytest-cov" },
     { name = "pyyaml" },
-    { name = "ruff" },
     { name = "yamlcore", specifier = ">=0.0.4" },
 ]
 
@@ -531,24 +523,10 @@ dependencies = [
     { name = "pydantic" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "ruff" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "overture-schema-core", editable = "packages/overture-schema-core" },
     { name = "pydantic", specifier = ">=2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy" },
-    { name = "pytest", specifier = ">=7.0" },
-    { name = "ruff" },
 ]
 
 [[package]]
@@ -559,24 +537,10 @@ dependencies = [
     { name = "pydantic" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "ruff" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "overture-schema-core", editable = "packages/overture-schema-core" },
     { name = "pydantic", specifier = ">=2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy" },
-    { name = "pytest", specifier = ">=7.0" },
-    { name = "ruff" },
 ]
 
 [[package]]
@@ -632,25 +596,11 @@ dependencies = [
     { name = "pydantic" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "ruff" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "overture-schema-core", editable = "packages/overture-schema-core" },
     { name = "overture-schema-validation", editable = "packages/overture-schema-validation" },
     { name = "pydantic", specifier = ">=2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy" },
-    { name = "pytest", specifier = ">=7.0" },
-    { name = "ruff" },
 ]
 
 [[package]]
@@ -662,26 +612,12 @@ dependencies = [
     { name = "pydantic", extra = ["email"] },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "ruff" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "overture-schema-core", editable = "packages/overture-schema-core" },
     { name = "overture-schema-validation", editable = "packages/overture-schema-validation" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic", extras = ["email"] },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy" },
-    { name = "pytest", specifier = ">=7.0" },
-    { name = "ruff" },
 ]
 
 [[package]]
@@ -692,24 +628,10 @@ dependencies = [
     { name = "pydantic" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "ruff" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "overture-schema-core", editable = "packages/overture-schema-core" },
     { name = "pydantic", specifier = ">=2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy" },
-    { name = "pytest", specifier = ">=7.0" },
-    { name = "ruff" },
 ]
 
 [[package]]
@@ -734,24 +656,10 @@ dependencies = [
     { name = "shapely" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "ruff" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "shapely", specifier = ">=2.0.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy" },
-    { name = "pytest", specifier = ">=7.0" },
-    { name = "ruff" },
 ]
 
 [[package]]
@@ -762,12 +670,22 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "docformatter" },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
-dev = [{ name = "docformatter", specifier = ">=1.7.7" }]
+dev = [
+    { name = "docformatter", specifier = ">=1.7.7" },
+    { name = "mypy" },
+    { name = "pytest", specifier = ">=7.0" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
`pyproject.toml` cleanups:

- move common utilities (mypy, pytest, ruff) to workspace dependencies
- format TOML (using `taplo`)

`Makefile` cleanup:

- run `uv sync --all-packages` before each Make target to ensure that the virtual environment is in its intended state