### PR TITLE
[Pydantic] Handle None values in UniqueItemsConstraint validation

### DIFF
--- a/packages/overture-schema-system/src/overture/schema/system/field_constraint/collection.py
+++ b/packages/overture-schema-system/src/overture/schema/system/field_constraint/collection.py
@@ -41,7 +41,11 @@ class CollectionConstraint(FieldConstraint):
 class UniqueItemsConstraint(CollectionConstraint):
     """Ensures all items in a collection are unique."""
 
-    def validate(self, value: list[Any], info: ValidationInfo) -> None:
+    def validate(self, value: list[Any] | None, info: ValidationInfo) -> None:
+        # Skip validation for None values (used with optional fields)
+        if value is None:
+            return
+
         # First try the fast path for hashable items
         try:
             if len(value) != len(set(value)):

--- a/packages/overture-schema-system/tests/field_constraint/test_collection_constraints.py
+++ b/packages/overture-schema-system/tests/field_constraint/test_collection_constraints.py
@@ -65,3 +65,22 @@ class TestUniqueItemsConstraint:
         assert props["min_items"].get("minItems") == 2
         assert props["max_items"].get("uniqueItems") is True
         assert props["max_items"].get("maxItems") == 5
+
+    def test_none_values_allowed(self) -> None:
+        """Test UniqueItemsConstraint with None values on optional fields."""
+
+        class TestModel(BaseModel):
+            tags: Annotated[list[str] | None, UniqueItemsConstraint()]
+
+        # None should be valid (constraint should be skipped)
+        model = TestModel(tags=None)
+        assert model.tags is None
+
+        # Non-None values should still be validated
+        model = TestModel(tags=["a", "b"])
+        assert model.tags == ["a", "b"]
+
+        # Duplicates should still fail
+        with pytest.raises(ValidationError) as exc_info:
+            TestModel(tags=["a", "a"])
+        assert "All items must be unique" in str(exc_info.value)


### PR DESCRIPTION
The `UniqueItemsConstraint` now correctly handles `None` values on optional collection fields. Previously, when a field was typed as `list[T] | None` with `UniqueItemsConstraint` applied, passing `None` would cause a `TypeError` when the constraint tried to check uniqueness.

The constraint now skips validation when the value is `None`, which is appropriate since `None` represents the absence of a collection rather than an empty or invalid collection.