### PR TITLE
[Pydantic] Remove sys.path manipulation from tests in favor of pytest configuration

### DIFF
--- a/packages/overture-schema-system/tests/model_constraint/test_forbid_if.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_forbid_if.py
@@ -1,10 +1,9 @@
-import sys
-from pathlib import Path
 from typing import cast
 
 import pytest
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.json_schema import JsonDict
+from util import assert_subset
 
 from overture.schema.system import create_model
 from overture.schema.system.model_constraint import (
@@ -14,10 +13,6 @@ from overture.schema.system.model_constraint import (
     ModelConstraint,
     forbid_if,
 )
-
-sys.path.insert(0, str(Path(__file__).parent.parent))  # Needed to import `util` module.
-
-from util import assert_subset
 
 
 @pytest.mark.parametrize("field_names", [[], ()])

--- a/packages/overture-schema-system/tests/model_constraint/test_min_fields_set.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_min_fields_set.py
@@ -1,20 +1,15 @@
-import sys
 from collections.abc import Callable
-from pathlib import Path
 from typing import cast
 
 import pytest
 from pydantic import BaseModel, ConfigDict
+from util import assert_subset
 
 from overture.schema.system import create_model
 from overture.schema.system.model_constraint import (
     MinFieldsSetConstraint,
     min_fields_set,
 )
-
-sys.path.insert(0, str(Path(__file__).parent.parent))  # Needed to import `util` module.
-
-from util import assert_subset
 
 
 def test_error_invalid_count_type() -> None:

--- a/packages/overture-schema-system/tests/model_constraint/test_multi_constraint.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_multi_constraint.py
@@ -1,7 +1,5 @@
-import sys
-from pathlib import Path
-
 from pydantic import BaseModel
+from util import assert_subset
 
 from overture.schema.system.model_constraint import (
     FieldEqCondition,
@@ -19,10 +17,6 @@ from overture.schema.system.model_constraint import (
     require_any_of,
     require_if,
 )
-
-sys.path.insert(0, str(Path(__file__).parent.parent))  # Needed to import `util` module.
-
-from util import assert_subset
 
 
 def test_many_constraints():

--- a/packages/overture-schema-system/tests/model_constraint/test_no_extra_fields.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_no_extra_fields.py
@@ -1,17 +1,11 @@
-import sys
-from pathlib import Path
-
 import pytest
 from pydantic import BaseModel, ConfigDict, create_model
+from util import assert_subset
 
 from overture.schema.system.model_constraint import (
     NoExtraFieldsConstraint,
     no_extra_fields,
 )
-
-sys.path.insert(0, str(Path(__file__).parent.parent))  # Needed to import `util` module.
-
-from util import assert_subset
 
 
 def test_error_invalid_model_class() -> None:

--- a/packages/overture-schema-system/tests/model_constraint/test_radio_group.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_radio_group.py
@@ -1,10 +1,9 @@
-import sys
-from pathlib import Path
 from typing import Annotated, Union
 
 import pytest
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.json_schema import JsonDict
+from util import assert_subset
 
 from overture.schema.system import create_model
 from overture.schema.system.model_constraint import (
@@ -12,10 +11,6 @@ from overture.schema.system.model_constraint import (
     RadioGroupConstraint,
     radio_group,
 )
-
-sys.path.insert(0, str(Path(__file__).parent.parent))  # Needed to import `util` module.
-
-from util import assert_subset
 
 
 @pytest.mark.parametrize("field_names", [[], (), ["foo"], ("bar",)])

--- a/packages/overture-schema-system/tests/model_constraint/test_require_any_of.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_require_any_of.py
@@ -1,19 +1,13 @@
-import sys
-from pathlib import Path
-
 import pytest
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from pydantic.json_schema import JsonDict
+from util import assert_subset
 
 from overture.schema.system.model_constraint import (
     ModelConstraint,
     RequireAnyOfConstraint,
     require_any_of,
 )
-
-sys.path.insert(0, str(Path(__file__).parent.parent))  # Needed to import `util` module.
-
-from util import assert_subset
 
 
 @pytest.mark.parametrize("field_names", [[], ["foo"]])

--- a/packages/overture-schema-system/tests/model_constraint/test_require_if.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_require_if.py
@@ -1,10 +1,9 @@
-import sys
-from pathlib import Path
 from typing import cast
 
 import pytest
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.json_schema import JsonDict
+from util import assert_subset
 
 from overture.schema.system import create_model
 from overture.schema.system.model_constraint import (
@@ -14,10 +13,6 @@ from overture.schema.system.model_constraint import (
     RequireIfConstraint,
     require_if,
 )
-
-sys.path.insert(0, str(Path(__file__).parent.parent))  # Needed to import `util` module.
-
-from util import assert_subset
 
 
 @pytest.mark.parametrize("field_names", [[], ()])

--- a/packages/overture-schema-system/tests/test_feature.py
+++ b/packages/overture-schema-system/tests/test_feature.py
@@ -1,13 +1,12 @@
 import json
 import re
-import sys
 from copy import deepcopy
-from pathlib import Path
 from typing import Annotated, cast
 
 import pytest
 from pydantic import ConfigDict, ValidationError, create_model
 from pydantic.json_schema import JsonSchemaValue, JsonValue
+from util import assert_subset
 
 from overture.schema.system.feature import Feature, _FieldLevel, _maybe_refactor_schema
 from overture.schema.system.model_constraint import (
@@ -24,10 +23,6 @@ from overture.schema.system.primitive import (
     GeometryType,
     GeometryTypeConstraint,
 )
-
-sys.path.insert(0, str(Path(__file__).parent.parent))  # Needed to import `util` module.
-
-from util import assert_subset
 
 
 class TestSerializeModel:

--- a/packages/overture-schema-system/tests/test_optionality.py
+++ b/packages/overture-schema-system/tests/test_optionality.py
@@ -1,18 +1,13 @@
 import json
-import sys
-from pathlib import Path
 from types import NoneType
 from typing import Annotated, Any, cast
 
 import pytest
 from pydantic import BaseModel, create_model
 from pydantic.json_schema import JsonDict
+from util import assert_subset
 
 from overture.schema.system.optionality import Omitable
-
-sys.path.insert(0, str(Path(__file__).parent.parent))  # Needed to import `util` module.
-
-from util import assert_subset
 
 
 @pytest.mark.parametrize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,5 +56,19 @@ dev = [
     "ruff>=0.12.4",
 ]
 
+[tool.pytest.ini_options]
+pythonpath = [
+    "packages/overture-schema-addresses-theme/tests",
+    "packages/overture-schema-annex/tests",
+    "packages/overture-schema-base-theme/tests",
+    "packages/overture-schema-buildings-theme/tests",
+    "packages/overture-schema-core/tests",
+    "packages/overture-schema-divisions-theme/tests",
+    "packages/overture-schema-places-theme/tests",
+    "packages/overture-schema-system/tests",
+    "packages/overture-schema-transportation-theme/tests",
+    "packages/overture-schema/tests",
+]
+
 [tool.docformatter]
 black = true


### PR DESCRIPTION
Replace `sys.path.insert()` hacks with `pytest.ini` configuration across all packages in the workspace. Tests now use standard Python imports via pytest's `pythonpath` setting.

There's no way to use wildcards that I can find.