### PR TITLE
Add internal Overture Publish Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,68 @@
-.PHONY: default uv-sync check test-all test docformat doctest mypy reset-baseline-schemas
+.PHONY: default uv-sync check test-all test docformat doctest mypy reset-baseline-schemas \
+       publish publish-all publish-core publish-system publish-annex publish-themes publish-cli publish-meta
 
 default: test-all
+
+# Publish all packages in dependency order
+publish-all: publish-core publish-system publish-annex publish-themes publish-cli publish-meta
+	@echo "All packages published successfully!"
+
+# Level 0: No internal dependencies
+publish-core:
+	@echo "Publishing overture-schema-core..."
+	uv build --package overture-schema-core
+	uv publish --index overture dist/overture_schema_core-*.whl dist/overture_schema_core-*.tar.gz
+	@rm -rf dist/overture_schema_core-*
+
+publish-system:
+	@echo "Publishing overture-schema-system..."
+	uv build --package overture-schema-system
+	uv publish --index overture dist/overture_schema_system-*.whl dist/overture_schema_system-*.tar.gz
+	@rm -rf dist/overture_schema_system-*
+
+# Level 1: Depends on core
+publish-annex: publish-core
+	@echo "Publishing overture-schema-annex..."
+	uv build --package overture-schema-annex
+	uv publish --index overture dist/overture_schema_annex-*.whl dist/overture_schema_annex-*.tar.gz
+	@rm -rf dist/overture_schema_annex-*
+
+publish-themes: publish-core
+	@echo "Publishing theme packages..."
+	uv build --package overture-schema-addresses-theme
+	uv publish --index overture dist/overture_schema_addresses_theme-*.whl dist/overture_schema_addresses_theme-*.tar.gz
+	@rm -rf dist/overture_schema_addresses_theme-*
+	uv build --package overture-schema-base-theme
+	uv publish --index overture dist/overture_schema_base_theme-*.whl dist/overture_schema_base_theme-*.tar.gz
+	@rm -rf dist/overture_schema_base_theme-*
+	uv build --package overture-schema-buildings-theme
+	uv publish --index overture dist/overture_schema_buildings_theme-*.whl dist/overture_schema_buildings_theme-*.tar.gz
+	@rm -rf dist/overture_schema_buildings_theme-*
+	uv build --package overture-schema-divisions-theme
+	uv publish --index overture dist/overture_schema_divisions_theme-*.whl dist/overture_schema_divisions_theme-*.tar.gz
+	@rm -rf dist/overture_schema_divisions_theme-*
+	uv build --package overture-schema-places-theme
+	uv publish --index overture dist/overture_schema_places_theme-*.whl dist/overture_schema_places_theme-*.tar.gz
+	@rm -rf dist/overture_schema_places_theme-*
+	uv build --package overture-schema-transportation-theme
+	uv publish --index overture dist/overture_schema_transportation_theme-*.whl dist/overture_schema_transportation_theme-*.tar.gz
+	@rm -rf dist/overture_schema_transportation_theme-*
+
+publish-cli: publish-core
+	@echo "Publishing overture-schema-cli..."
+	uv build --package overture-schema-cli
+	uv publish --index overture dist/overture_schema_cli-*.whl dist/overture_schema_cli-*.tar.gz
+	@rm -rf dist/overture_schema_cli-*
+
+# Level 2: Meta-package depends on all others
+publish-meta: publish-themes publish-cli
+	@echo "Publishing overture-schema (meta-package)..."
+	uv build --package overture-schema
+	uv publish --index overture dist/overture_schema-*.whl dist/overture_schema-*.tar.gz
+	@rm -rf dist/overture_schema-*
+
+# Convenience alias
+publish: publish-all
 
 uv-sync:
 	@uv sync --all-packages 2> /dev/null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,9 @@ pythonpath = [
     "packages/overture-schema-transportation-theme/tests",
     "packages/overture-schema/tests",
 ]
+
+[[tool.uv.index]]
+name = "overture"
+url = "https://overture-pypi-505071440022.d.codeartifact.us-west-2.amazonaws.com/pypi/overture/simple/"
+publish-url = "https://overture-pypi-505071440022.d.codeartifact.us-west-2.amazonaws.com/pypi/overture/"
+explicit = true


### PR DESCRIPTION
Adds `make publish` command for publishing all packages.

Currently uses Overture's AWS CodeArtifact as target but this should be turned into a public PyPi endpoint when we're ready!