### PR TITLE
Add Python package semantic version check to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default: test-all
 uv-sync:
 	@uv sync --all-packages 2> /dev/null
 
-check: test doctest
+check: test doctest check-versions
 	@uv run ruff check -q packages/
 	@$(MAKE) mypy
 	@uv run ruff format --check packages/
@@ -44,6 +44,13 @@ mypy: uv-sync
 		| sed 's|^packages/|-p |' \
 		| xargs uv run mypy --no-error-summary
 	@uv run mypy --no-error-summary packages/*/tests/*.py
+
+check-versions:
+	@find packages -maxdepth 1 -type d -name "overture-schema*" \
+		| sort \
+		| tr - . \
+		| sed 's|^packages/||' \
+		| xargs uv run python -c 'import semver, sys; from importlib import metadata; [print(m, semver.VersionInfo.parse(metadata.version(m))) for m in sys.argv[1:]]'
 
 reset-baseline-schemas:
 	@find . -name \*_baseline_schema.json -delete

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "pytest>=8.4.1",
     "pytest-cov>=7.0.0",
     "ruff>=0.12.4",
+    "semver>=3.0.4"
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -825,6 +825,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "semver" },
 ]
 
 [package.metadata]
@@ -837,6 +838,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.12.4" },
+    { name = "semver", specifier = ">=3.0.4" },
 ]
 
 [[package]]
@@ -1190,6 +1192,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/73/e6/03b882225a1b0627e75339b420883dc3c90707a8917d2284abef7a58d317/ruff-0.14.0-py3-none-win32.whl", hash = "sha256:7450a243d7125d1c032cb4b93d9625dea46c8c42b4f06c6b709baac168e10543", size = 12367872, upload-time = "2025-10-07T18:21:46.67Z" },
     { url = "https://files.pythonhosted.org/packages/41/77/56cf9cf01ea0bfcc662de72540812e5ba8e9563f33ef3d37ab2174892c47/ruff-0.14.0-py3-none-win_amd64.whl", hash = "sha256:ea95da28cd874c4d9c922b39381cbd69cb7e7b49c21b8152b014bd4f52acddc2", size = 13464628, upload-time = "2025-10-07T18:21:50.318Z" },
     { url = "https://files.pythonhosted.org/packages/c6/2a/65880dfd0e13f7f13a775998f34703674a4554906167dce02daf7865b954/ruff-0.14.0-py3-none-win_arm64.whl", hash = "sha256:f42c9495f5c13ff841b1da4cb3c2a42075409592825dada7c5885c2c844ac730", size = 12565142, upload-time = "2025-10-07T18:21:53.577Z" },
+]
+
+[[package]]
+name = "semver"
+version = "3.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

`$ make check-versions` will verify that the root Python module of each package has a valid semantic version. This is part of the larger effort to build the PyPI package publishing workflow.

See the sequence diagram at https://github.com/OvertureMaps/schema-wg/issues/406, though we changed the plan slightly in the course of the coding session.

# Testing

```
$ make check
```

The GitHub actions tied to this PR should also run `$ make check`, so if the workflows pass, it should be working.