### PR TITLE
Fix workflow trigger for Python package version check

### DIFF
--- a/.github/workflows/check-python-package-versions.yaml
+++ b/.github/workflows/check-python-package-versions.yaml
@@ -1,7 +1,7 @@
 name: Check Python package version numbers
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '**/pyproject.toml'
       - 'packages/**/__about__.py'


### PR DESCRIPTION
# Description

This change switches the trigger for the Python package version check GitHub Actions workflow from `pull_request_target` to `pull_request`. This should result in the `paths` filter on the workflow working correctly.

Because `pull_request_target` runs against the base and doesn't work with paths, it's doesn't work for the intended use case. It is more targeted toward protecting workflows from rogue PRs from forks. Such protection isn't needed for this workflow because it doesn't use any secrets, apart from ephemeral ones generated through OIDC flows, and in any event it's protected from fork runs by the `if` check in `check-python-package-versions.yaml` on line 11.

# Testing

Ongoing, via PR #430.