### PR TITLE
Fix mypy errors in test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ mypy: uv-sync
 		| tr - . \
 		| sed 's|^packages/|-p |' \
 		| xargs uv run mypy --no-error-summary
-	@uv run mypy --no-error-summary packages/*/tests/*.py
+	@for d in packages/*/tests; do find "$$d" -name "*.py" | sort | xargs uv run mypy --no-error-summary || exit 1; done
 
 reset-baseline-schemas:
 	@find . -name \*_baseline_schema.json -delete

--- a/packages/overture-schema-core/tests/scoping/test_scoped.py
+++ b/packages/overture-schema-core/tests/scoping/test_scoped.py
@@ -181,7 +181,7 @@ class TestScoped:
         when_field_info = SingleScoped.model_fields["when"]
         assert when_field_info.is_required() == required
 
-        when_class = SingleScoped.When
+        when_class = SingleScoped.When  # type: ignore[attr-defined]
         assert issubclass(when_class, BaseModel)
         assert len(when_class.model_fields) == 1
 
@@ -200,7 +200,7 @@ class TestScoped:
         when_field_info = MultiScopedWhenAllFieldsOptional.model_fields["when"]
         assert not when_field_info.is_required()
 
-        when_class = MultiScopedWhenAllFieldsOptional.When
+        when_class = MultiScopedWhenAllFieldsOptional.When  # type: ignore[attr-defined]
         assert issubclass(when_class, BaseModel)
         assert len(when_class.model_fields) == 2
 
@@ -229,7 +229,7 @@ class TestScoped:
         when_field_info = MultiScopedWhenSomeFieldsRequired.model_fields["when"]
         assert when_field_info.is_required()
 
-        when_class = MultiScopedWhenSomeFieldsRequired.When
+        when_class = MultiScopedWhenSomeFieldsRequired.When  # type: ignore[attr-defined]
         assert issubclass(when_class, BaseModel)
         assert len(when_class.model_fields) == 3
 
@@ -270,7 +270,7 @@ class TestScoped:
         when_field_info = Complex.model_fields["when"]
         assert when_field_info.is_required()
 
-        when_class = Complex.When
+        when_class = Complex.When  # type: ignore[attr-defined]
         assert issubclass(when_class, BaseModel)
         assert len(when_class.model_fields) == 3
 

--- a/packages/overture-schema-system/tests/model_constraint/test_forbid_if.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_forbid_if.py
@@ -16,7 +16,7 @@ from overture.schema.system.model_constraint import (
 
 
 @pytest.mark.parametrize("field_names", [[], ()])
-def test_error_not_enough_field_names(field_names: list[str]):
+def test_error_not_enough_field_names(field_names: list[str]) -> None:
     with pytest.raises(ValueError, match="`field_names` cannot be empty, but it is"):
         forbid_if(field_names, FieldEqCondition("foo", 42))
 

--- a/packages/overture-schema-system/tests/model_constraint/test_min_fields_set.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_min_fields_set.py
@@ -3,6 +3,7 @@ from typing import cast
 
 import pytest
 from pydantic import BaseModel, ConfigDict
+from pydantic.json_schema import JsonDict
 from util import assert_subset
 
 from overture.schema.system import create_model
@@ -195,7 +196,7 @@ def test_model_json_schema_no_model_config() -> None:
 
 
 def test_model_json_schema_already_set_same() -> None:
-    expect = {"minProperties": 3, "hello": "world"}
+    expect: JsonDict = {"minProperties": 3, "hello": "world"}
 
     @min_fields_set(3)
     class TestModel(BaseModel):
@@ -211,7 +212,7 @@ def test_model_json_schema_already_set_same() -> None:
 
 
 def test_model_json_schema_error_already_set_different() -> None:
-    expect = {"minProperties": 1, "hello": "world"}
+    expect: JsonDict = {"minProperties": 1, "hello": "world"}
 
     with pytest.raises(
         RuntimeError,

--- a/packages/overture-schema-system/tests/model_constraint/test_multi_constraint.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_multi_constraint.py
@@ -19,7 +19,7 @@ from overture.schema.system.model_constraint import (
 )
 
 
-def test_many_constraints():
+def test_many_constraints() -> None:
     @forbid_if(["corge", "garply"], FieldEqCondition("qux", "hello"))
     @min_fields_set(3)
     @no_extra_fields

--- a/packages/overture-schema-system/tests/model_constraint/test_no_extra_fields.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_no_extra_fields.py
@@ -9,7 +9,7 @@ from overture.schema.system.model_constraint import (
 
 
 def test_error_invalid_model_class() -> None:
-    expect_pattern = r"can't apply `@?\w+` to model class `TestModel`: existing `model_config\['extra'\]` is already set to '\w+'"
+    expect_pattern = r"can't apply `@?\w+` to model class `\w+`: existing `model_config\['extra'\]` is already set to '\w+'"
 
     with pytest.raises(TypeError, match=expect_pattern):
 
@@ -19,10 +19,10 @@ def test_error_invalid_model_class() -> None:
 
     with pytest.raises(TypeError, match=expect_pattern):
 
-        class TestModel(BaseModel):
+        class TestModelAllow(BaseModel):
             model_config = ConfigDict(extra="allow")
 
-        NoExtraFieldsConstraint().validate_class(TestModel)
+        NoExtraFieldsConstraint().validate_class(TestModelAllow)
 
 
 @pytest.mark.parametrize(

--- a/packages/overture-schema-system/tests/model_constraint/test_radio_group.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_radio_group.py
@@ -14,7 +14,7 @@ from overture.schema.system.model_constraint import (
 
 
 @pytest.mark.parametrize("field_names", [[], (), ["foo"], ("bar",)])
-def test_error_not_enough_field_names(field_names: list[str]):
+def test_error_not_enough_field_names(field_names: list[str]) -> None:
     with pytest.raises(
         ValueError, match="`field_names` must contain at least two items"
     ):
@@ -108,7 +108,7 @@ def test_valid_model_instance(field_names: list[str]) -> None:
 def test_model_json_schema_no_model_config() -> None:
     @radio_group("foo", "baz", "qux")
     class TestModel(BaseModel):
-        foo: bool = Field(default=None, alias="bar")
+        foo: bool | None = Field(default=None, alias="bar")
         baz: bool
         qux: bool = Field(alias="corge")
 

--- a/packages/overture-schema-system/tests/model_constraint/test_require_any_of.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_require_any_of.py
@@ -25,7 +25,9 @@ def test_error_duplicate_field_names(field_names: list[str]) -> None:
 
 
 def test_error_invalid_model_class() -> None:
-    expect = "specifies one or more fields that are not in the model class `TestModel`: foo, bar"
+    expect = (
+        r"specifies one or more fields that are not in the model class `\w+`: foo, bar"
+    )
 
     with pytest.raises(TypeError, match=expect):
 
@@ -35,10 +37,10 @@ def test_error_invalid_model_class() -> None:
 
     with pytest.raises(TypeError, match=expect):
 
-        class TestModel(BaseModel):
+        class TestModel2(BaseModel):
             baz: int
 
-        RequireAnyOfConstraint("foo", "bar").validate_class(TestModel)
+        RequireAnyOfConstraint("foo", "bar").validate_class(TestModel2)
 
 
 def test_error_invalid_model_instance() -> None:

--- a/packages/overture-schema-system/tests/model_constraint/test_require_if.py
+++ b/packages/overture-schema-system/tests/model_constraint/test_require_if.py
@@ -16,7 +16,7 @@ from overture.schema.system.model_constraint import (
 
 
 @pytest.mark.parametrize("field_names", [[], ()])
-def test_error_not_enough_field_names(field_names: list[str]):
+def test_error_not_enough_field_names(field_names: list[str]) -> None:
     with pytest.raises(ValueError, match="`field_names` cannot be empty, but it is"):
         require_if(field_names, FieldEqCondition("foo", 42))
 
@@ -107,7 +107,7 @@ def test_valid_model_instance_condition_true(field_names: list[str]) -> None:
 
 
 @pytest.mark.parametrize("field_names", [["foo"], ["bar"], ["foo", "bar"]])
-def test_valid_model_instance_condition_false(field_names) -> None:
+def test_valid_model_instance_condition_false(field_names: list[str]) -> None:
     class TestModel(BaseModel):
         foo: int | None = None
         bar: int | None = None

--- a/packages/overture-schema-system/tests/ref/test_id.py
+++ b/packages/overture-schema-system/tests/ref/test_id.py
@@ -10,12 +10,12 @@ class TestIdentifiedFeature:
     class IdentifiedFeature(Identified, Feature):
         pass
 
-    def test_id_required_in_model_fields(self):
+    def test_id_required_in_model_fields(self) -> None:
         id_field = TestIdentifiedFeature.IdentifiedFeature.model_fields["id"]
 
         assert id_field.is_required()
 
-    def test_description_same_in_model_fields(self):
+    def test_description_same_in_model_fields(self) -> None:
         base_id_field = Identified.model_fields["id"]
         derived_id_field = TestIdentifiedFeature.IdentifiedFeature.model_fields["id"]
 

--- a/packages/overture-schema-system/tests/util.py
+++ b/packages/overture-schema-system/tests/util.py
@@ -1,7 +1,10 @@
+from collections.abc import Mapping
 from typing import cast
 
 
-def subset_conflicts(a: dict[str, object], b: dict[str, object]) -> dict[str, object]:
+def subset_conflicts(
+    a: Mapping[str, object], b: Mapping[str, object]
+) -> dict[str, object]:
     """
     Returns conflict items that prevent `a` from being a subset of `b`.
 
@@ -44,7 +47,10 @@ def subset_conflicts(a: dict[str, object], b: dict[str, object]) -> dict[str, ob
 
 
 def assert_subset(
-    a: dict[str, object], b: dict[str, object], a_name: str = "a", b_name: str = "b"
+    a: Mapping[str, object],
+    b: Mapping[str, object],
+    a_name: str = "a",
+    b_name: str = "b",
 ) -> None:
     conflicts = subset_conflicts(a, b)
     if conflicts:


### PR DESCRIPTION
## Summary

- Fix mypy errors across test subdirectories in both `overture-schema-core` and `overture-schema-system` packages
- Update `Makefile` mypy target to check test files recursively (`find` instead of glob) so subdirectories like `tests/model_constraint/` and `tests/scoping/` are covered

## Changes

- Add `# type: ignore[attr-defined]` for dynamically-generated `When` inner class access in scoping tests
- Add return type annotations to test functions missing `-> None`
- Fix type annotations: `dict` → `Mapping` for read-only params, `JsonDict` for Pydantic schema dicts, `bool | None` where `None` default was used
- Rename duplicate `TestModel` classes within the same module to satisfy mypy's no-redef rule
- Use regex patterns in `pytest.raises(match=...)` where class names vary across redefined test models
- Replace flat `packages/*/tests/*.py` glob in Makefile with recursive `find` to catch all test files

## Test plan

- [x] `make mypy` passes with no errors
- [x] `make test` still passes