### PR TITLE
Attach docstrings to NewTypes at runtime

### DIFF
--- a/packages/overture-schema-core/src/overture/schema/core/names.py
+++ b/packages/overture-schema-core/src/overture/schema/core/names.py
@@ -110,7 +110,7 @@ CommonNames = NewType(
         Field(json_schema_extra={"additionalProperties": False}),
     ],
 )
-"""A mapping from language to the most commonly used or recognized name in that language."""
+CommonNames.__doc__ = """A mapping from language to the most commonly used or recognized name in that language."""
 
 
 class NameVariant(str, DocumentedEnum):

--- a/packages/overture-schema-core/src/overture/schema/core/scoping/opening_hours.py
+++ b/packages/overture-schema-core/src/overture/schema/core/scoping/opening_hours.py
@@ -15,7 +15,7 @@ OpeningHours = NewType(
         ),
     ],
 )
-"""
+OpeningHours.__doc__ = """
 Time span or time spans during which something is open or active, specified in the OpenStreetMap
 opening hours specification: https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification.
 """

--- a/packages/overture-schema-system/src/overture/schema/system/primitive/__init__.py
+++ b/packages/overture-schema-system/src/overture/schema/system/primitive/__init__.py
@@ -24,7 +24,7 @@ from .geom import (
 )
 
 uint8 = NewType("uint8", Annotated[int, Field(ge=0, le=255)])  # type: ignore [type-arg]
-"""
+uint8.__doc__ = """
 Portable 8-bit unsigned integer.
 
 This is an `int` at runtime, but using `uint8` for Pydantic model fields instead of `int` makes them
@@ -32,7 +32,7 @@ portable across different serialization and validation platforms.
 """
 
 uint16 = NewType("uint16", Annotated[int, Field(ge=0, le=65535)])  # type: ignore[type-arg]
-"""
+uint16.__doc__ = """
 Portable 16-bit unsigned integer.
 
 This is an `int` at runtime, but using `uint16` for Pydantic model fields instead of `int` makes
@@ -40,7 +40,7 @@ them portable across different serialization and validation platforms.
 """
 
 uint32 = NewType("uint32", Annotated[int, Field(ge=0, le=4294967295)])  # type: ignore[type-arg]
-"""
+uint32.__doc__ = """
 Portable 32-bit unsigned integer.
 
 This is an `int` at runtime, but using `uint32` for Pydantic model fields instead of `int` makes
@@ -48,7 +48,7 @@ them portable across different serialization and validation platforms.
 """
 
 int8 = NewType("int8", Annotated[int, Field(ge=-128, le=127)])  # type: ignore[type-arg]
-"""
+int8.__doc__ = """
 Portable 8-bit signed integer.
 
 This is an `int` at runtime, but using `int8` for Pydantic model fields instead of `int` makes them
@@ -56,7 +56,7 @@ portable across different serialization and validation platforms.
 """
 
 int16 = NewType("int16", Annotated[int, Field(ge=-32768, le=32767)])  # type: ignore[type-arg]
-"""
+int16.__doc__ = """
 Portable 16-bit signed integer.
 
 This is an `int` at runtime, but using `int16` for Pydantic model fields instead of `int` makes them
@@ -64,7 +64,7 @@ portable across different serialization and validation platforms.
 """
 
 int32 = NewType("int32", Annotated[int, Field(ge=-(2**31), le=2**31 - 1)])  # type: ignore[type-arg]
-"""
+int32.__doc__ = """
 Portable 32-bit signed integer.
 
 This is an `int` at runtime, but using `int32` for Pydantic model fields instead of `int` makes them
@@ -72,7 +72,7 @@ portable across different serialization and validation platforms.
 """
 
 int64 = NewType("int64", Annotated[int, Field(ge=-(2**63), le=2**63 - 1)])  # type: ignore[type-arg]
-"""
+int64.__doc__ = """
 Portable 64-bit signed integer.
 
 This is an `int` at runtime, but using `int64` for Pydantic model fields instead of `int` makes them
@@ -80,7 +80,7 @@ portable across different serialization and validation platforms.
 """
 
 float32 = NewType("float32", float)  # type: ignore[type-arg]
-"""
+float32.__doc__ = """
 Portable IEEE 32-bit floating point number.
 
 This is a `float` at runtime, but using `float32` for Pydantic model fields instead of `float` makes
@@ -88,7 +88,7 @@ them portable across different serialization and validation platforms.
 """
 
 float64 = NewType("float64", float)  # type: ignore[type-arg]
-"""
+float64.__doc__ = """
 Portable IEEE 64-bit floating point number.
 
 This is a `float` at runtime, but using `float64` for Pydantic model fields instead of `float` makes

--- a/packages/overture-schema-system/src/overture/schema/system/ref/id.py
+++ b/packages/overture-schema-system/src/overture/schema/system/ref/id.py
@@ -18,7 +18,7 @@ Id = NewType(
         ),
     ],
 )
-"""
+Id.__doc__ = """
 A unique identifier.
 """
 

--- a/packages/overture-schema-system/src/overture/schema/system/string.py
+++ b/packages/overture-schema-system/src/overture/schema/system/string.py
@@ -35,7 +35,7 @@ CountryCodeAlpha2 = NewType(
         Field(description="An ISO 3166-1 alpha-2 country code"),
     ],
 )  # type: ignore [type-arg]
-"""
+CountryCodeAlpha2.__doc__ = """
 An ISO-3166-1 alpha-2 country code.
 """
 
@@ -49,7 +49,7 @@ HexColor = NewType(
         ),
     ],
 )  # type: ignore [type-arg]
-"""
+HexColor.__doc__ = """
 A color represented as an #RRGGBB or #RGB hexadecimal string.
 
 For example:
@@ -67,7 +67,7 @@ JsonPointer = NewType(
         Field(description="A JSON Pointer (as described in RFC-6901)"),
     ],
 )  # type: ignore [type-arg]
-"""
+JsonPointer.__doc__ = """
 A JSON Pointer
 
 As described in `the JSON Pointer specification, RFC-6901`_.
@@ -91,7 +91,7 @@ LanguageTag = NewType(
         ),
     ],
 )  # type: ignore [type-arg]
-"""
+LanguageTag.__doc__ = """
 A BCP-47 language tag.
 
 As described in `Tags for Identifying Languages, BCP-47`_.
@@ -114,7 +114,7 @@ NoWhitespaceString = NewType(
         Field(description="A string that contains no whitespace characters"),
     ],
 )  # type: ignore [type-arg]
-"""
+NoWhitespaceString.__doc__ = """
 A string that contains no whitespace characters.
 """
 
@@ -124,7 +124,7 @@ PhoneNumber = NewType(
         str, PhoneNumberConstraint(), Field(description="An international phone number")
     ],
 )  # type: ignore [type-arg]
-"""
+PhoneNumber.__doc__ = """
 An international phone number.
 """
 
@@ -136,12 +136,12 @@ RegionCode = NewType(
         Field(description="An ISO 3166-2 principal subdivision code"),
     ],
 )  # type: ignore [type-arg]
-"""
+RegionCode.__doc__ = """
 An ISO 3166-2 principal subdivision code.
 """
 
 SnakeCaseString = NewType("SnakeCaseString", Annotated[str, SnakeCaseConstraint()])
-"""
+SnakeCaseString.__doc__ = """
 A string that looks like a snake case identifier, like a Python variable name (*e.g.*, `foo_bar`).
 """
 
@@ -155,7 +155,7 @@ StrippedString = NewType(
         ),
     ],
 )  # type: ignore [type-arg]
-"""
+StrippedString.__doc__ = """
 A string without leading or trailing whitespace.
 """
 
@@ -167,7 +167,7 @@ WikidataId = NewType(
         Field(description="A wikidata ID, as found on https://www.wikidata.org/"),
     ],
 )  # type: ignore [type-arg]
-"""
+WikidataId.__doc__ = """
 A wikidata ID, as found on https://www.wikidata.org/.
 
 - `"Q42"`


### PR DESCRIPTION
## Summary

- Convert bare triple-quoted strings after `NewType` assignments into explicit `__doc__` assignments so docstrings are accessible at runtime
- Python treats post-assignment docstrings as expression statements, never attaching them to the `NewType` object (`__doc__` stays `None`)
- Same pattern `DocumentedEnum` uses for enum member docs

## Affected packages

- `overture-schema-system` (primitives, strings, ref/id)
- `overture-schema-core` (names, opening_hours)