### PR TITLE
Widen transportation, cartography, confidence types to match data

### DIFF
--- a/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
@@ -27,8 +27,8 @@
         },
         "sort_key": {
           "description": "Integer indicating the recommended order in which to draw features.\n\nFeatures with a lower number should be drawn \"in front\" of features with a higher\nnumber.",
-          "maximum": 255,
-          "minimum": 0,
+          "maximum": 2147483647,
+          "minimum": -2147483648,
           "title": "Sort Key",
           "type": "integer"
         }

--- a/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
@@ -624,8 +624,8 @@
         "level": {
           "default": 0,
           "description": "Z-order of the feature where 0 is visual level",
-          "maximum": 32767,
-          "minimum": -32768,
+          "maximum": 2147483647,
+          "minimum": -2147483648,
           "title": "Level",
           "type": "integer"
         },

--- a/packages/overture-schema-base-theme/tests/land_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_baseline_schema.json
@@ -499,8 +499,8 @@
         "level": {
           "default": 0,
           "description": "Z-order of the feature where 0 is visual level",
-          "maximum": 32767,
-          "minimum": -32768,
+          "maximum": 2147483647,
+          "minimum": -2147483648,
           "title": "Level",
           "type": "integer"
         },

--- a/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
@@ -27,8 +27,8 @@
         },
         "sort_key": {
           "description": "Integer indicating the recommended order in which to draw features.\n\nFeatures with a lower number should be drawn \"in front\" of features with a higher\nnumber.",
-          "maximum": 255,
-          "minimum": 0,
+          "maximum": 2147483647,
+          "minimum": -2147483648,
           "title": "Sort Key",
           "type": "integer"
         }

--- a/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
@@ -576,8 +576,8 @@
         "level": {
           "default": 0,
           "description": "Z-order of the feature where 0 is visual level",
-          "maximum": 32767,
-          "minimum": -32768,
+          "maximum": 2147483647,
+          "minimum": -2147483648,
           "title": "Level",
           "type": "integer"
         },

--- a/packages/overture-schema-base-theme/tests/water_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/water_baseline_schema.json
@@ -463,8 +463,8 @@
         "level": {
           "default": 0,
           "description": "Z-order of the feature where 0 is visual level",
-          "maximum": 32767,
-          "minimum": -32768,
+          "maximum": 2147483647,
+          "minimum": -2147483648,
           "title": "Level",
           "type": "integer"
         },

--- a/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
@@ -541,8 +541,8 @@
         "level": {
           "default": 0,
           "description": "Z-order of the feature where 0 is visual level",
-          "maximum": 32767,
-          "minimum": -32768,
+          "maximum": 2147483647,
+          "minimum": -2147483648,
           "title": "Level",
           "type": "integer"
         },

--- a/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
@@ -425,8 +425,8 @@
         "level": {
           "default": 0,
           "description": "Z-order of the feature where 0 is visual level",
-          "maximum": 32767,
-          "minimum": -32768,
+          "maximum": 2147483647,
+          "minimum": -2147483648,
           "title": "Level",
           "type": "integer"
         },

--- a/packages/overture-schema-core/src/overture/schema/core/cartography.py
+++ b/packages/overture-schema-core/src/overture/schema/core/cartography.py
@@ -8,12 +8,12 @@ from typing import Annotated, NewType
 from pydantic import BaseModel, Field
 
 from overture.schema.system.model_constraint import no_extra_fields
-from overture.schema.system.primitive import uint8
+from overture.schema.system.primitive import int32
 
 Prominence = NewType(
     "Prominence",
     Annotated[
-        uint8,
+        int32,
         Field(
             ge=1,
             le=100,
@@ -34,7 +34,7 @@ Prominence = NewType(
 MinZoom = NewType(
     "MinZoom",
     Annotated[
-        uint8,
+        int32,
         Field(
             ge=0,
             le=23,
@@ -55,7 +55,7 @@ MinZoom = NewType(
 MaxZoom = NewType(
     "MaxZoom",
     Annotated[
-        uint8,
+        int32,
         Field(
             ge=0,
             le=23,
@@ -76,7 +76,7 @@ MaxZoom = NewType(
 SortKey = NewType(
     "SortKey",
     Annotated[
-        uint8,
+        int32,
         Field(
             description=textwrap.dedent("""
                 Integer indicating the recommended order in which to draw features.

--- a/packages/overture-schema-core/src/overture/schema/core/scoping/vehicle.py
+++ b/packages/overture-schema-core/src/overture/schema/core/scoping/vehicle.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 
 from overture.schema.core.unit import LengthUnit, WeightUnit
 from overture.schema.system.model_constraint import no_extra_fields
-from overture.schema.system.primitive import float32, uint8
+from overture.schema.system.primitive import float64, uint8
 
 
 class VehicleDimension(str, Enum):
@@ -57,7 +57,7 @@ class VehicleHeightSelector(BaseModel):
     dimension: Literal[VehicleDimension.HEIGHT]
     comparison: VehicleRelation
     value: Annotated[
-        float32,
+        float64,
         Field(
             ge=0, description="Vehicle height selection threshold in the given `unit`"
         ),
@@ -74,7 +74,7 @@ class VehicleLengthSelector(BaseModel):
     dimension: Literal[VehicleDimension.LENGTH]
     comparison: VehicleRelation
     value: Annotated[
-        float32,
+        float64,
         Field(
             ge=0, description="Vehicle length selection threshold in the given `unit`"
         ),
@@ -91,7 +91,7 @@ class VehicleWeightSelector(BaseModel):
     dimension: Literal[VehicleDimension.WEIGHT]
     comparison: VehicleRelation
     value: Annotated[
-        float32,
+        float64,
         Field(
             ge=0, description="Vehicle weight selection threshold in the given `unit`"
         ),
@@ -108,7 +108,7 @@ class VehicleWidthSelector(BaseModel):
     dimension: Literal[VehicleDimension.WIDTH]
     comparison: VehicleRelation
     value: Annotated[
-        float32,
+        float64,
         Field(
             ge=0, description="Vehicle width selection threshold in the given `unit`"
         ),

--- a/packages/overture-schema-core/src/overture/schema/core/types.py
+++ b/packages/overture-schema-core/src/overture/schema/core/types.py
@@ -4,12 +4,12 @@ from pydantic import (
     Field,
 )
 
-from overture.schema.system.primitive import float32, int32
+from overture.schema.system.primitive import float64, int32
 
 ConfidenceScore = NewType(
     "ConfidenceScore",
     Annotated[
-        float32,
+        float64,
         Field(description="Confidence score between 0.0 and 1.0", ge=0.0, le=1.0),
     ],
 )

--- a/packages/overture-schema-core/src/overture/schema/core/types.py
+++ b/packages/overture-schema-core/src/overture/schema/core/types.py
@@ -4,7 +4,7 @@ from pydantic import (
     Field,
 )
 
-from overture.schema.system.primitive import float32, int16, int32
+from overture.schema.system.primitive import float32, int32
 
 ConfidenceScore = NewType(
     "ConfidenceScore",
@@ -18,7 +18,7 @@ ConfidenceScore = NewType(
 Level = NewType(
     "Level",
     Annotated[
-        int16,
+        int32,
         Field(description="Z-order of the feature where 0 is visual level"),
     ],
 )

--- a/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
@@ -49,8 +49,8 @@
         },
         "sort_key": {
           "description": "Integer indicating the recommended order in which to draw features.\n\nFeatures with a lower number should be drawn \"in front\" of features with a higher\nnumber.",
-          "maximum": 255,
-          "minimum": 0,
+          "maximum": 2147483647,
+          "minimum": -2147483648,
           "title": "Sort Key",
           "type": "integer"
         }

--- a/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
@@ -236,8 +236,8 @@
         },
         "value": {
           "description": "Z-order of the feature where 0 is visual level",
-          "maximum": 32767,
-          "minimum": -32768,
+          "maximum": 2147483647,
+          "minimum": -2147483648,
           "title": "Value",
           "type": "integer"
         }

--- a/uv.lock
+++ b/uv.lock
@@ -825,7 +825,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "semver" },
 ]
 
 [package.metadata]
@@ -838,7 +837,6 @@ dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.12.4" },
-    { name = "semver", specifier = ">=3.0.4" },
 ]
 
 [[package]]
@@ -1192,15 +1190,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/73/e6/03b882225a1b0627e75339b420883dc3c90707a8917d2284abef7a58d317/ruff-0.14.0-py3-none-win32.whl", hash = "sha256:7450a243d7125d1c032cb4b93d9625dea46c8c42b4f06c6b709baac168e10543", size = 12367872, upload-time = "2025-10-07T18:21:46.67Z" },
     { url = "https://files.pythonhosted.org/packages/41/77/56cf9cf01ea0bfcc662de72540812e5ba8e9563f33ef3d37ab2174892c47/ruff-0.14.0-py3-none-win_amd64.whl", hash = "sha256:ea95da28cd874c4d9c922b39381cbd69cb7e7b49c21b8152b014bd4f52acddc2", size = 13464628, upload-time = "2025-10-07T18:21:50.318Z" },
     { url = "https://files.pythonhosted.org/packages/c6/2a/65880dfd0e13f7f13a775998f34703674a4554906167dce02daf7865b954/ruff-0.14.0-py3-none-win_arm64.whl", hash = "sha256:f42c9495f5c13ff841b1da4cb3c2a42075409592825dada7c5885c2c844ac730", size = 12565142, upload-time = "2025-10-07T18:21:53.577Z" },
-]
-
-[[package]]
-name = "semver"
-version = "3.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Vehicle dimension selectors (height, length, weight, width) widened from `float32` to `float64` to match double-precision values in the data platform
- `Level` type widened from `int16` to `int32` for the same reason
- `VehicleAxleCountSelector` stays `uint8` (discrete count)

Closes OvertureMaps/tf-data-platform#2829

## Test plan

- [x] `make check` passes (1612 tests, mypy, ruff)
- [x] Verify generated Parquet schema matches updated types