### PR TITLE
Add cli tests to workspace pythonpath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ pythonpath = [
     "packages/overture-schema-annex/tests",
     "packages/overture-schema-base-theme/tests",
     "packages/overture-schema-buildings-theme/tests",
+    "packages/overture-schema-cli/tests",
     "packages/overture-schema-core/tests",
     "packages/overture-schema-divisions-theme/tests",
     "packages/overture-schema-places-theme/tests",


### PR DESCRIPTION
## Summary

- Add `packages/overture-schema-cli/tests` to `[tool.pytest.ini_options].pythonpath` in the workspace `pyproject.toml`
- Every other package had its tests directory listed; cli was the only one missing, making its `conftest.py` imports rely on pytest's rootdir discovery rather than explicit path configuration

## Test plan

- [x] `make check` passes