### PR TITLE
Declare overture-schema-system dependency

### DIFF
--- a/packages/overture-schema-base-theme/pyproject.toml
+++ b/packages/overture-schema-base-theme/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 dependencies = [
     "overture-schema-core",
+    "overture-schema-system",
     "pydantic>=2.0",
 ]
 description = "Overture Maps base theme shared structures and models (bathymetry, infrastructure, land, land_cover, land_use, water)"
@@ -12,6 +13,7 @@ requires-python = ">=3.10"
 
 [tool.uv.sources]
 overture-schema-core = { workspace = true }
+overture-schema-system = { workspace = true }
 
 
 [build-system]

--- a/packages/overture-schema-buildings-theme/pyproject.toml
+++ b/packages/overture-schema-buildings-theme/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 dependencies = [
     "overture-schema-core",
+    "overture-schema-system",
     "pydantic>=2.0",
 ]
 description = "Overture Maps buildings theme shared structures, building types, and building part types"
@@ -12,6 +13,7 @@ requires-python = ">=3.10"
 
 [tool.uv.sources]
 overture-schema-core = { workspace = true }
+overture-schema-system = { workspace = true }
 
 
 [build-system]

--- a/packages/overture-schema-cli/pyproject.toml
+++ b/packages/overture-schema-cli/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 dependencies = [
     "overture-schema-core",
+    "overture-schema-system",
     "pydantic>=2.0",
     "pyyaml>=6.0.2",
     "click>=8.0",
@@ -16,6 +17,7 @@ requires-python = ">=3.10"
 
 [tool.uv.sources]
 overture-schema-core = { workspace = true }
+overture-schema-system = { workspace = true }
 
 [build-system]
 build-backend = "hatchling.build"

--- a/packages/overture-schema-core/pyproject.toml
+++ b/packages/overture-schema-core/pyproject.toml
@@ -8,9 +8,13 @@ dynamic = ["version"]
 description = "Core schemas for Overture Maps"
 license = "MIT"
 dependencies = [
+    "overture-schema-system",
     "pydantic>=2.0",
     "shapely>=2.1.1",
 ]
+
+[tool.uv.sources]
+overture-schema-system = { workspace = true }
 
 [tool.hatch.version]
 path = "src/overture/schema/core/__about__.py"

--- a/packages/overture-schema-transportation-theme/pyproject.toml
+++ b/packages/overture-schema-transportation-theme/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 dependencies = [
     "overture-schema-core",
+    "overture-schema-system",
     "pydantic>=2.0",
 ]
 description = "Overture Maps transportation theme with shared structures and connector and segment types"
@@ -12,6 +13,7 @@ requires-python = ">=3.10"
 
 [tool.uv.sources]
 overture-schema-core = { workspace = true }
+overture-schema-system = { workspace = true }
 
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -648,12 +648,14 @@ name = "overture-schema-base-theme"
 source = { editable = "packages/overture-schema-base-theme" }
 dependencies = [
     { name = "overture-schema-core" },
+    { name = "overture-schema-system" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "overture-schema-core", editable = "packages/overture-schema-core" },
+    { name = "overture-schema-system", editable = "packages/overture-schema-system" },
     { name = "pydantic", specifier = ">=2.0" },
 ]
 
@@ -662,12 +664,14 @@ name = "overture-schema-buildings-theme"
 source = { editable = "packages/overture-schema-buildings-theme" }
 dependencies = [
     { name = "overture-schema-core" },
+    { name = "overture-schema-system" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "overture-schema-core", editable = "packages/overture-schema-core" },
+    { name = "overture-schema-system", editable = "packages/overture-schema-system" },
     { name = "pydantic", specifier = ">=2.0" },
 ]
 
@@ -677,6 +681,7 @@ source = { editable = "packages/overture-schema-cli" }
 dependencies = [
     { name = "click" },
     { name = "overture-schema-core" },
+    { name = "overture-schema-system" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -694,6 +699,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.0" },
     { name = "overture-schema-core", editable = "packages/overture-schema-core" },
+    { name = "overture-schema-system", editable = "packages/overture-schema-system" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "rich", specifier = ">=13.0" },
@@ -711,6 +717,7 @@ dev = [
 name = "overture-schema-core"
 source = { editable = "packages/overture-schema-core" }
 dependencies = [
+    { name = "overture-schema-system" },
     { name = "pydantic" },
     { name = "shapely" },
 ]
@@ -725,6 +732,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "overture-schema-system", editable = "packages/overture-schema-system" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "shapely", specifier = ">=2.1.1" },
 ]
@@ -803,12 +811,14 @@ name = "overture-schema-transportation-theme"
 source = { editable = "packages/overture-schema-transportation-theme" }
 dependencies = [
     { name = "overture-schema-core" },
+    { name = "overture-schema-system" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "overture-schema-core", editable = "packages/overture-schema-core" },
+    { name = "overture-schema-system", editable = "packages/overture-schema-system" },
     { name = "pydantic", specifier = ">=2.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Add `overture-schema-system` to `[project.dependencies]` and `[tool.uv.sources]` for packages that import from `overture.schema.system` without declaring the dependency: `overture-schema-core`, `overture-schema-cli`, `overture-schema-base-theme`, `overture-schema-buildings-theme`, `overture-schema-transportation-theme`
- These imports resolve in the uv workspace but break isolated installs

## Test plan

- [x] `uv sync --all-packages --all-extras` resolves cleanly
- [x] Full test suite passes