### PR TITLE
Speed up make check ~5x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default uv-sync check test-all test docformat doctest mypy reset-baseline-schemas
+.PHONY: default uv-sync check test-all test test-only docformat doctest doctest-only mypy mypy-only lint-only reset-baseline-schemas
 
 default: test-all
 
@@ -7,15 +7,16 @@ install: uv-sync
 uv-sync:
 	@uv sync --all-packages 2> /dev/null
 
-check: test doctest
-	@uv run ruff check -q packages/
-	@$(MAKE) mypy
-	@uv run ruff format --check packages/
+check: uv-sync
+	@$(MAKE) -j test-only doctest-only lint-only mypy-only
 
 test-all: uv-sync
 	@uv run pytest -W error packages/
 
 test: uv-sync
+	@uv run pytest -W error packages/ -x
+
+test-only:
 	@uv run pytest -W error packages/ -x
 
 coverage: uv-sync
@@ -25,7 +26,9 @@ docformat:
 	@find packages/*/src -name "*.py" -type f -not -name "__*" \
 		| xargs uv run pydocstyle --convention=numpy --add-ignore=D102,D105,D200,D205,D400
 
-doctest: uv-sync
+doctest: uv-sync doctest-only
+
+doctest-only:
 	@# $$ escapes $ for make - sed needs literal $ for end-of-line anchor
 	@find packages/*/src -name "*.py" -type f \
 		| sed 's|^packages/[^/]*/src/||' \
@@ -37,7 +40,9 @@ doctest: uv-sync
 		| xargs uv run python -c 'import doctest, importlib, sys; sys.exit(any(doctest.testmod(importlib.import_module(m)).failed for m in sys.argv[1:]))'
 
 # mypy type checking with namespace package support
-mypy: uv-sync
+mypy: uv-sync mypy-only
+
+mypy-only:
 	@# $$ escapes $ for make - sed needs literal $ for end-of-line anchor
 	@find packages -maxdepth 1 -type d -name "overture-schema*" \
 		| sort \
@@ -46,6 +51,10 @@ mypy: uv-sync
 		| sed 's|^packages/|-p |' \
 		| xargs uv run mypy --no-error-summary
 	@for d in packages/*/tests; do find "$$d" -name "*.py" | sort | xargs uv run mypy --no-error-summary || exit 1; done
+
+lint-only:
+	@uv run ruff check -q packages/
+	@uv run ruff format --check packages/
 
 reset-baseline-schemas:
 	@find . -name \*_baseline_schema.json -delete

--- a/packages/overture-schema-system/tests/primitive/test_geom.py
+++ b/packages/overture-schema-system/tests/primitive/test_geom.py
@@ -1,7 +1,6 @@
 import re
-from collections.abc import Iterator
 from dataclasses import dataclass
-from itertools import chain, combinations
+from itertools import combinations
 from typing import Annotated, Any
 
 import pytest
@@ -261,16 +260,21 @@ TEST_GEOMETRY_TYPE_CASES: tuple[GeometryTypeCase, ...] = (
 )
 
 
-def powerset(
-    iterable: tuple[GeometryTypeCase, ...],
-) -> Iterator[tuple[GeometryTypeCase, ...]]:
-    s = list(iterable)
-    return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
+def _representative_subsets(
+    cases: tuple[GeometryTypeCase, ...],
+) -> tuple[tuple[GeometryTypeCase, ...], ...]:
+    """Select subsets that cover the constraint behavior without combinatorial explosion.
+
+    Singletons test each type accepted/rejected individually. Pairs test
+    composition. The full set tests unconstrained acceptance.
+    """
+    singletons = [(c,) for c in cases]
+    pairs = list(combinations(cases, 2))
+    full = [cases]
+    return tuple(singletons + pairs + full)
 
 
-TEST_GEOMETRY_TYPE_CASE_SUBSETS = tuple(
-    s for s in powerset(TEST_GEOMETRY_TYPE_CASES) if len(s) > 0
-)
+TEST_GEOMETRY_TYPE_CASE_SUBSETS = _representative_subsets(TEST_GEOMETRY_TYPE_CASES)
 
 
 @pytest.mark.parametrize("geometry_type_case_subset", TEST_GEOMETRY_TYPE_CASE_SUBSETS)


### PR DESCRIPTION
Run test, doctest, lint, and mypy targets in parallel via `make -j`, and replace the geometry type powerset (127 subsets) with representative subsets (singletons + pairs + full = 28 subsets).

## Changes

**Makefile**: Split each check target into a `-only` variant (no `uv-sync` dep) so `make -j` can run them concurrently. `check` does a single `uv-sync` upfront, then fans out.

**test_geom.py**: Replace powerset enumeration with singletons, pairs, and the full set. Covers individual type acceptance/rejection, pairwise composition, and unconstrained acceptance without combinatorial explosion.