### PR TITLE
[BUG](system) Fix missing return in BBox dict validator

### DIFF
--- a/packages/overture-schema-system/src/overture/schema/system/primitive/bbox.py
+++ b/packages/overture-schema-system/src/overture/schema/system/primitive/bbox.py
@@ -237,7 +237,7 @@ class BBox:
                 elif isinstance(value, tuple | list):
                     return cls.from_geo_json(value)
                 elif isinstance(value, dict):
-                    BBox(**value)
+                    return BBox(**value)
                 else:
                     raise TypeError(
                         f"expected `BBox` or `tuple` or `list`; got `{type(value).__name__}` with value {repr(value)}"

--- a/packages/overture-schema-system/tests/primitive/test_bbox.py
+++ b/packages/overture-schema-system/tests/primitive/test_bbox.py
@@ -195,6 +195,7 @@ def test_pydantic_json() -> None:
     [
         ((1, 2, 3, 4), BBox(xmin=1, ymin=2, xmax=3, ymax=4)),
         (BBox(0, -1, -2, 3), BBox(0, -1, -2, 3)),
+        ({"xmin": -1, "ymin": -2, "xmax": 1, "ymax": 2}, BBox(-1, -2, 1, 2)),
     ],
 )
 def test_pydantic_validation_success(input: Any, expect: BBox) -> None:


### PR DESCRIPTION
The dict branch of the Pydantic validator in `BBox.__get_pydantic_core_schema__` constructed a `BBox` from the dict but didn't return it, silently producing `None`. Add the missing `return` statement.

The test parametrize case for dict input covers this path.