### PR TITLE
[CHORE] Fix PLC0415 (import-outside-toplevel) violations in overture-schema-cli

### DIFF
--- a/packages/overture-schema-cli/src/overture/schema/cli/commands.py
+++ b/packages/overture-schema-cli/src/overture/schema/cli/commands.py
@@ -1,6 +1,7 @@
 """Click-based CLI for overture-schema package."""
 
 import builtins
+import io
 import json
 import sys
 from collections import Counter, defaultdict
@@ -322,8 +323,6 @@ def load_input(filename: Path) -> tuple[dict | list, str]:
                 pass
 
         # Parse as single YAML/JSON document
-        import io
-
         data = yaml.load(io.StringIO(content), Loader=CoreLoader)
         return data, "<stdin>"
 

--- a/packages/overture-schema-cli/src/overture/schema/cli/data_display.py
+++ b/packages/overture-schema-cli/src/overture/schema/cli/data_display.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from rich import box
 from rich.panel import Panel
 from rich.table import Table
 
@@ -670,8 +671,6 @@ def create_feature_display(
             table.add_row(field_name_styled, value_styled, "", "")
 
     # Wrap table in a Panel with rounded borders
-    from rich import box
-
     # Add title: "Validation Failed" for single features, or item info for collections
     if item_index is not None:
         if item_type:

--- a/packages/overture-schema-cli/tests/test_cli_functions.py
+++ b/packages/overture-schema-cli/tests/test_cli_functions.py
@@ -1,5 +1,6 @@
 """Tests for CLI helper functions (load_input, perform_validation)."""
 
+import io
 import json
 from pathlib import Path
 
@@ -175,8 +176,6 @@ class TestLoadInput:
         JSONL format is commonly used for streaming GeoJSON features where each line
         is a complete JSON object/feature.
         """
-        import io
-
         feature1 = build_feature(id="test1")
         feature2 = build_feature(id="test2")
         jsonl_input = f"{json.dumps(feature1)}\n{json.dumps(feature2)}\n"

--- a/packages/overture-schema-cli/tests/test_data_display.py
+++ b/packages/overture-schema-cli/tests/test_data_display.py
@@ -10,6 +10,7 @@ from overture.schema.cli.data_display import (
     select_context_fields,
 )
 from rich.console import Console
+from rich.panel import Panel
 
 
 class TestExtractFeatureData:
@@ -291,8 +292,6 @@ class TestCreateFeatureDisplay:
         result = create_feature_display(fields, errors)
 
         # Verify result is a Panel
-        from rich.panel import Panel
-
         assert isinstance(result, Panel)
 
     def test_includes_error_annotation(self) -> None:

--- a/packages/overture-schema-cli/tests/test_resolve_types.py
+++ b/packages/overture-schema-cli/tests/test_resolve_types.py
@@ -2,6 +2,7 @@
 
 import pytest
 from overture.schema.cli.commands import resolve_types
+from overture.schema.core.discovery import discover_models
 
 
 class TestResolveTypes:
@@ -124,8 +125,6 @@ class TestResolveTypes:
         expected_themes: set[str],
     ) -> None:
         """Test that resolve_types returns models from expected themes."""
-        from overture.schema.core.discovery import discover_models
-
         models = discover_models(namespace=namespace)
         actual_themes = {key.theme for key in models.keys()}
 

--- a/packages/overture-schema-cli/tests/test_type_analysis.py
+++ b/packages/overture-schema-cli/tests/test_type_analysis.py
@@ -10,7 +10,7 @@ from overture.schema.cli.type_analysis import (
     get_or_create_structural_tuple,
     introspect_union,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Discriminator, Field
 
 
 class TestStructuralTuples:
@@ -277,7 +277,6 @@ class TestDiscriminatorDiscovery:
 
     def test_callable_discriminator_extracts_field_name(self) -> None:
         """Callable discriminators (Feature.field_discriminator) are supported."""
-        from pydantic import Discriminator
 
         class ModelA(BaseModel):
             kind: Literal["a"]


### PR DESCRIPTION
Moves inline imports to module level in 6 files across `overture-schema-cli`, fixing ruff PLC0415 violations. None of these were deferred intentionally.

Closes #478