### PR TITLE
[CHORE] Configure uv dependency cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ name = "overture-schema-workspace"
 requires-python = ">=3.10"
 version = "0.0.0"
 
+[tool.uv]
+exclude-newer = "1 week"
+
 [tool.uv.workspace]
 members = ["packages/*"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-03-24T16:30:43.874957Z"
+exclude-newer-span = "P1W"
+
 [manifest]
 members = [
     "overture-schema",


### PR DESCRIPTION
Adds a one-week dependency cooldown via uv's `exclude-newer` setting. Newly released packages won't be considered as upgrade candidates until they've been available for at least a week, reducing exposure to regressions and supply chain attacks.

See https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns

Closes #486