### PR TITLE
[SECURITY] Harden GitHub Workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,5 @@ updates:
     commit-message:
       prefix: "[CHORE](deps)"
       include: "scope"
-    review-before-merge: true
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
     commit-message:
       prefix: "[CHORE](deps)"
       include: "scope"
+    review-before-merge: true
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check-python-code.yaml
+++ b/.github/workflows/check-python-code.yaml
@@ -17,16 +17,21 @@ jobs:
   check:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/enforce-change-type-label.yaml
+++ b/.github/workflows/enforce-change-type-label.yaml
@@ -7,9 +7,13 @@ on:
 jobs:
   check-label:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # Required for reading PR labels
+
     steps:
       - name: Require exactly one change type label
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const allChangeTypeLabels = new Set([

--- a/.github/workflows/publish-python-packages.yaml
+++ b/.github/workflows/publish-python-packages.yaml
@@ -31,6 +31,8 @@ jobs:
   check:
     if: github.event.repository.full_name == github.repository
     uses: ./.github/workflows/reusable-check-python-package-versions.yaml
+    permissions:
+      id-token: write # Required for OIDC in reusable workflow to check AWS CodeArtifact
     with:
       before_commit: ${{ github.event.before }}
       after_commit: ${{ github.event.after }}
@@ -40,6 +42,7 @@ jobs:
     if: github.event.repository.full_name == github.repository && needs.check.outputs.num_changed_packages > 0
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write # Required for OIDC authentication to AWS
 
     strategy:

--- a/.github/workflows/publish-python-packages.yaml
+++ b/.github/workflows/publish-python-packages.yaml
@@ -25,7 +25,6 @@ on:
         default: overture
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -40,23 +39,28 @@ jobs:
     needs: [check]
     if: github.event.repository.full_name == github.repository && needs.check.outputs.num_changed_packages > 0
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC authentication to AWS
+
     strategy:
       matrix:
         include: ${{ fromJson(needs.check.outputs.changed_packages) }}
     steps:
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           version: latest
 
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Sync code to make packages visible to Python
         run: uv sync --all-packages
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::505071440022:role/GithubActions_Schema_CodeArtifact_Publish

--- a/.github/workflows/reusable-check-python-package-versions.yaml
+++ b/.github/workflows/reusable-check-python-package-versions.yaml
@@ -56,6 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # Required for OIDC authentication to AWS to check CodeArtifact
 
     outputs:
       changed_packages: ${{ steps.save-changes.outputs.changed_packages }}

--- a/.github/workflows/reusable-check-python-package-versions.yaml
+++ b/.github/workflows/reusable-check-python-package-versions.yaml
@@ -54,6 +54,9 @@ on:
 jobs:
   check-python-package-versions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     outputs:
       changed_packages: ${{ steps.save-changes.outputs.changed_packages }}
       num_changed_packages: ${{ steps.save-changes.outputs.num_changed_packages }}
@@ -62,17 +65,18 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           version: latest
 
       - name: Check out code before change
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.before_commit }}
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: .python-version
 
@@ -83,9 +87,10 @@ jobs:
         run: uv run python ./.github/workflows/scripts/package-versions.py collect > /tmp/package-versions-before.json
 
       - name: Check out code after change
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.after_commit }}
+          persist-credentials: false
 
       - name: Sync code after change to make packages visible to Python
         run: uv sync --all-packages --refresh
@@ -113,7 +118,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: steps.save-changes.outputs.num_changed_packages > 0
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ inputs.aws_region }}
           role-to-assume: arn:aws:iam::${{ inputs.aws_account_id }}:role/${{ inputs.aws_iam_role_name }}
@@ -122,10 +127,15 @@ jobs:
       - name: Get CodeArtifact index URL
         id: get-code-artifact-index-url
         if: steps.save-changes.outputs.num_changed_packages > 0
+        env:
+          AWS_ACCOUNT_ID: ${{ inputs.aws_account_id }}
+          AWS_REGION: ${{ inputs.aws_region }}
+          DOMAIN: ${{ inputs.domain }}
+          REPOSITORY: ${{ inputs.repository }}
         run: |
           index_url=$(./.github/workflows/scripts/code-artifact.sh index-url \
-            "${{ inputs.aws_account_id }}" "${{ inputs.aws_region }}" \
-            "${{ inputs.domain }}" "${{ inputs.repository }}")
+            "$AWS_ACCOUNT_ID" "$AWS_REGION" \
+            "$DOMAIN" "$REPOSITORY")
           echo "::add-mask::${index_url}"
           echo "index_url=${index_url}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/schema-pr-preview-cleanup.yml
+++ b/.github/workflows/schema-pr-preview-cleanup.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/schema-pr-preview.yml
+++ b/.github/workflows/schema-pr-preview.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3.0.3
-        with: |
+        with:
           message: |
             ## 🗺️ Schema reference docs preview is live!
 

--- a/.github/workflows/schema-pr-preview.yml
+++ b/.github/workflows/schema-pr-preview.yml
@@ -13,11 +13,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  STAGING_URL: https://staging.overturemaps.org
-  PREVIEW_PATH: /schema/pr/${{ github.event.number }}
-  SCHEMA_PREVIEW: 'true'
-
 jobs:
   check-fork:
     name: Check fork
@@ -34,21 +29,23 @@ jobs:
     needs: check-fork
     env:
       DOCS_PATH: _docs
+      STAGING_URL: https://staging.overturemaps.org
+      SCHEMA_PREVIEW: 'true'
     steps:
       - name: Check out schema repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Check out docs repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: OvertureMaps/docs
           path: ${{ env.DOCS_PATH }}
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ${{ env.DOCS_PATH }}/package.json
 
@@ -60,7 +57,7 @@ jobs:
         run: npm ci --omit=dev
 
       - name: Generate schema markdown docs
-        uses: OvertureMaps/workflows/.github/actions/generate-schema-docs@main
+        uses: OvertureMaps/workflows/.github/actions/generate-schema-docs@4fbe12a41eae18e9ac641667074feb65ce478009 # validate-pr-title-v1
         with:
           output-dir: ${{ github.workspace }}/${{ env.DOCS_PATH }}/docs/schema/reference
           schema-path: .
@@ -71,11 +68,11 @@ jobs:
         run: npm run build
         env:
           DOCUSAURUS_URL: ${{ env.STAGING_URL }}/
-          DOCUSAURUS_BASE_URL: ${{ env.PREVIEW_PATH }}/
+          DOCUSAURUS_BASE_URL: /schema/pr/${{ github.event.number }}/
           SCHEMA_PREVIEW: ${{ env.SCHEMA_PREVIEW }}
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: build-artifact
           path: ${{ env.DOCS_PATH }}/build
@@ -90,29 +87,34 @@ jobs:
     env:
       AWS_ROLE_ARN: arn:aws:iam::763944545891:role/pages-staging-oidc-overturemaps
       AWS_REGION: us-west-2
+      STAGING_URL: https://staging.overturemaps.org
     environment:
       name: staging
-      url: ${{ env.STAGING_URL }}${{ env.PREVIEW_PATH }}/schema/index.html
+      url: https://staging.overturemaps.org/schema/pr/${{ github.event.number }}/schema/index.html
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Download build artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-artifact
           path: build
 
       - name: Copy to S3
+        env:
+          PREVIEW_PATH: /schema/pr/${{ github.event.number }}
         run: |
           aws s3 sync --delete --quiet build \
             s3://overture-managed-staging-usw2/gh-pages${{ env.PREVIEW_PATH }}/
 
       - name: Bust the cache
+        env:
+          PREVIEW_PATH: /schema/pr/${{ github.event.number }}
         run: |
           aws cloudfront create-invalidation \
             --distribution-id E1KP2IN0H2RGGT \
@@ -126,16 +128,16 @@ jobs:
 
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3.0.3
-        with:
+        with: |
           message: |
             ## 🗺️ Schema reference docs preview is live!
 
             |                  |                                                                    |
             |------------------|--------------------------------------------------------------------|
-            | 🌍 **Preview**   | ${{ env.STAGING_URL }}${{ env.PREVIEW_PATH }}/schema/index.html |
+            | 🌍 **Preview**   | https://staging.overturemaps.org/schema/pr/${{ github.event.number }}/schema/index.html |
             | 🕐 **Updated**   | ${{ steps.deploy-metadata.outputs.time }} |
             | 📝 **Commit**    | [${{ steps.deploy-metadata.outputs.short-sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}) |
-            | 🔧 **env SCHEMA_PREVIEW** | `${{ env.SCHEMA_PREVIEW }}` |
+            | 🔧 **env SCHEMA_PREVIEW** | `true` |
 
             > [!NOTE]
             > ♻️ This preview updates automatically with each push to this PR.

--- a/.github/workflows/schema-pr-preview.yml
+++ b/.github/workflows/schema-pr-preview.yml
@@ -106,19 +106,15 @@ jobs:
           path: build
 
       - name: Copy to S3
-        env:
-          PREVIEW_PATH: /schema/pr/${{ github.event.number }}
         run: |
           aws s3 sync --delete --quiet build \
-            s3://overture-managed-staging-usw2/gh-pages${{ env.PREVIEW_PATH }}/
+            s3://overture-managed-staging-usw2/gh-pages/schema/pr/${{ github.event.number }}/
 
       - name: Bust the cache
-        env:
-          PREVIEW_PATH: /schema/pr/${{ github.event.number }}
         run: |
           aws cloudfront create-invalidation \
             --distribution-id E1KP2IN0H2RGGT \
-            --paths "${{ env.PREVIEW_PATH }}/*"
+            --paths "/schema/pr/${{ github.event.number }}/*"
 
       - name: Gather metadata for PR comment
         id: deploy-metadata

--- a/.github/workflows/test-schema.yaml
+++ b/.github/workflows/test-schema.yaml
@@ -13,11 +13,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.22
 


### PR DESCRIPTION
# Major change release plan

Non-major change

## B. Related MINOR change steps

Non-minor change

# Description

Resolve all current zizmor security findings:

```
62 findings (26 suppressed, 12 fixable): 0 informational, 7 low, 4 medium, 25 high

warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
error[unpinned-uses]: unpinned action references (25 of these)
warning[excessive-permissions]: overly broad permissions (4 of these)
help[artipacked]: credential persistence through GitHub Actions artifacts (6 of these)
error[template-injection]: code injection via template expansion (8 of these)
```

There should be **no functional changes** to any workflows.

# Reference

* https://zizmor.sh/ - Static analysis for GitHub Actions

# Testing

Once approved and ready to merge, this repo will be included in the GH Org Ruleset that will require `OMF Security Checks`, which runs the zizmor checker, as a required workflow to merge. Similar to `OMF PR Checks`. This will ensure this and all future commits satisfy the security compliance checks.
