### PR TITLE
[SECURITY] Harden GitHub Workflows Pt. 2

### DIFF
--- a/.github/workflows/check-python-code.yaml
+++ b/.github/workflows/check-python-code.yaml
@@ -13,8 +13,16 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
+    name: Check
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/check-python-package-versions.yaml
+++ b/.github/workflows/check-python-package-versions.yaml
@@ -7,12 +7,18 @@ on:
       - 'packages/**/__about__.py'
 
 permissions:
-  id-token: write
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:
     uses: ./.github/workflows/reusable-check-python-package-versions.yaml
+    permissions:
+      id-token: write # Required for AWS CodeArtifact OIDC authentication
+      contents: read
     with:
       before_commit: ${{ github.event.pull_request.base.sha }}
       after_commit: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/enforce-change-type-label.yaml
+++ b/.github/workflows/enforce-change-type-label.yaml
@@ -4,8 +4,16 @@ on:
   pull_request:
     types: [opened, edited, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check-label:
+    name: Check label
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/publish-python-packages.yaml
+++ b/.github/workflows/publish-python-packages.yaml
@@ -27,8 +27,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
+    name: Check for changes
     if: github.event.repository.full_name == github.repository
     uses: ./.github/workflows/reusable-check-python-package-versions.yaml
     permissions:
@@ -38,6 +43,7 @@ jobs:
       after_commit: ${{ github.event.after }}
 
   publish:
+    name: Publish
     needs: [check]
     if: github.event.repository.full_name == github.repository && needs.check.outputs.num_changed_packages > 0
     runs-on: ubuntu-latest
@@ -84,18 +90,18 @@ jobs:
         env:
           CA_TOKEN: ${{ steps.get-code-artifact-params.outputs.token }}
           CA_PUBLISH_URL: ${{ steps.get-code-artifact-params.outputs.publish_url }}
+          PACKAGE: ${{ matrix.package }} # zizmor: ignore[template-injection]
+          BEFORE: ${{ matrix.before }} # zizmor: ignore[template-injection]
+          AFTER: ${{ matrix.after }} # zizmor: ignore[template-injection]
         run: |
-          package="${{ matrix.package }}"
-          before="${{ matrix.before }}"
-          after="${{ matrix.after }}"
-          printf 'Publishing package %s version %s to PyPI (previous version %s)...\n' "$package" "$after" "$before"
-          uv build --package "$package"
-          wheel="dist/${package//-/_}-${after}-py3-none-any.whl"
+          printf 'Publishing package %s version %s to PyPI (previous version %s)...\n' "$PACKAGE" "$AFTER" "$BEFORE"
+          uv build --package "$PACKAGE"
+          wheel="dist/${PACKAGE//-/_}-${AFTER}-py3-none-any.whl"
           if [ ! -f "$wheel" ]; then
             echo "    Wheel file [$wheel] not found. Aborting!"
             exit 1
           fi
-          tarball="dist/${package//-/_}-${after}.tar.gz"
+          tarball="dist/${PACKAGE//-/_}-${AFTER}.tar.gz"
           if [ ! -f "$tarball" ]; then
             echo "    Source tarball file [$tarball] not found. Aborting!"
             exit 1

--- a/.github/workflows/reusable-check-python-package-versions.yaml
+++ b/.github/workflows/reusable-check-python-package-versions.yaml
@@ -51,8 +51,13 @@ on:
         value: ${{ jobs.check-python-package-versions.outputs.num_changed_packages }}
 
 
+permissions:
+  contents: read
+
+
 jobs:
   check-python-package-versions:
+    name: Check Python package versions
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -144,6 +149,7 @@ jobs:
         if: steps.save-changes.outputs.num_changed_packages > 0
         env:
           INDEX_URL: ${{ steps.get-code-artifact-index-url.outputs.index_url }}
+          # zizmor: ignore[template-injection]
         run: |
           jq -c '.[]' /tmp/package-version-diff.json | while read -r entry; do
             package=$(echo "$entry" | jq -r '.package')

--- a/.github/workflows/schema-pr-preview-cleanup.yml
+++ b/.github/workflows/schema-pr-preview-cleanup.yml
@@ -9,13 +9,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: schema-pr-preview-${{ github.event.number }}
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     name: Cleanup
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      id-token: write # Required for OIDC authentication to AWS
     env:
       AWS_ROLE_ARN: arn:aws:iam::763944545891:role/pages-staging-oidc-overturemaps
       AWS_REGION: us-west-2
@@ -31,10 +35,14 @@ jobs:
       - name: Delete from S3
         run: |
           aws s3 rm --recursive --quiet \
-            s3://overture-managed-staging-usw2/gh-pages/schema/pr/${{ github.event.number }}/ || true
+            s3://overture-managed-staging-usw2/gh-pages/schema/pr/$PR_NUMBER/ || true
+        env:
+          PR_NUMBER: ${{ github.event.number }}  # zizmor: ignore[template-injection]
 
       - name: Bust the cache
         run: |
           aws cloudfront create-invalidation \
             --distribution-id E1KP2IN0H2RGGT \
-            --paths "/schema/pr/${{ github.event.number }}/*" || true
+            --paths "/schema/pr/$PR_NUMBER/*" || true
+        env:
+          PR_NUMBER: ${{ github.event.number }}  # zizmor: ignore[template-injection]

--- a/.github/workflows/schema-pr-preview.yml
+++ b/.github/workflows/schema-pr-preview.yml
@@ -82,8 +82,8 @@ jobs:
     runs-on: ubuntu-slim
     needs: [check-fork, build]
     permissions:
-      id-token: write
-      pull-requests: write
+      id-token: write # Required for OIDC authentication to AWS
+      pull-requests: write # Required for commenting on PRs
     env:
       AWS_ROLE_ARN: arn:aws:iam::763944545891:role/pages-staging-oidc-overturemaps
       AWS_REGION: us-west-2
@@ -108,19 +108,25 @@ jobs:
       - name: Copy to S3
         run: |
           aws s3 sync --delete --quiet build \
-            s3://overture-managed-staging-usw2/gh-pages/schema/pr/${{ github.event.number }}/
+            s3://overture-managed-staging-usw2/gh-pages/schema/pr/$PR_NUMBER/
+        env:
+          PR_NUMBER: ${{ github.event.number }}  # zizmor: ignore[template-injection]
 
       - name: Bust the cache
         run: |
           aws cloudfront create-invalidation \
             --distribution-id E1KP2IN0H2RGGT \
-            --paths "/schema/pr/${{ github.event.number }}/*"
+            --paths "/schema/pr/$PR_NUMBER/*"
+        env:
+          PR_NUMBER: ${{ github.event.number }}  # zizmor: ignore[template-injection]
 
       - name: Gather metadata for PR comment
         id: deploy-metadata
         run: |
           echo "time=$(date -u +'%b %d, %Y %H:%M UTC')" >> $GITHUB_OUTPUT
           echo "short-sha=$(echo '${{ github.event.pull_request.head.sha }}' | cut -c1-7)" >> $GITHUB_OUTPUT
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}  # zizmor: ignore[template-injection]
 
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3.0.3

--- a/.github/workflows/test-schema.yaml
+++ b/.github/workflows/test-schema.yaml
@@ -10,8 +10,16 @@ on:
       - 'examples/**'
       - 'counterexamples/**'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
# Major change release plan

Non-Major change


## B. Related MINOR change steps

Non-minor change

## C. Public documentation and messaging plan

N/A

# Description

The original PR (https://github.com/OvertureMaps/schema/pull/493) was accidentally targeting fixes only for a subset of the desired risk level. This closes the gap, and we can confirm it now by the temporary, secondary `OMF Security Checks` workflow that is using the desired `pedantic` level.

Prior, due to repo settings it wasn't easily testable until after the workflow had been set as Required.


# Reference

N/A

# Testing

Proof of pedantic passing ([logs](https://github.com/OvertureMaps/schema/actions/runs/24205955283/job/70661710320?pr=496#step:3:89)):

<img width="943" height="254" alt="{6A46B9F6-0621-4CB2-AA6C-457F73F1DE8F}" src="https://github.com/user-attachments/assets/edec0953-765d-4d6d-add4-21c6a572b5d1" />


