### PR TITLE
[ENHANCEMENT] make operating_status optional

### DIFF
--- a/packages/overture-schema-places-theme/src/overture/schema/places/place.py
+++ b/packages/overture-schema-places-theme/src/overture/schema/places/place.py
@@ -205,10 +205,10 @@ class Place(OvertureFeature[Literal["places"], Literal["place"]], Named):
         ),
     ]
 
-    # Required
+    # Optional
 
     operating_status: Annotated[
-        OperatingStatus,
+        OperatingStatus | None,
         Field(
             description=textwrap.dedent("""
                 An indication of whether a place is: in continued operation, in a temporary
@@ -221,9 +221,7 @@ class Place(OvertureFeature[Literal["places"], Literal["place"]], Named):
                 set to 0.
             """).strip(),
         ),
-    ]
-
-    # Optional
+    ] = None
 
     categories: Categories | None = None
     basic_category: Annotated[

--- a/packages/overture-schema-places-theme/tests/place_baseline_schema.json
+++ b/packages/overture-schema-places-theme/tests/place_baseline_schema.json
@@ -530,8 +530,7 @@
       "required": [
         "theme",
         "type",
-        "version",
-        "operating_status"
+        "version"
       ],
       "type": "object"
     },

--- a/schema/places/place.yaml
+++ b/schema/places/place.yaml
@@ -137,4 +137,3 @@ properties:
           This is not an indication of 'opening hours' or that the place is open/closed at the current time-of-day or day-of-week.
         type: string
         enum: ["open", "permanently_closed", "temporarily_closed"]
-    required: [operating_status]


### PR DESCRIPTION
## B. Related MINOR change steps

- Remove required for operating_status

# Description

Changes operating_status to an optional field to allow for null values when signals are not present. This will allow the field to contain only meaningful data.

# Reference

https://github.com/OvertureMaps/tf-place-data/issues/451

# Documentation website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/513)
