### PR TITLE
[FEATURE] Added provider, resource, and version as required fields.

### DIFF
--- a/counterexamples/base/bathymetry/bad-depth.yaml
+++ b/counterexamples/base/bathymetry/bad-depth.yaml
@@ -13,5 +13,8 @@ properties:
     - record_id: x123
       property: ""
       dataset: some source
+      provider: some_provider
+      resource: some_resource
+      version: "2087-08-23"
   ext_expected_errors:
     - "depth/minimum]: minimum: got -1, want 0"

--- a/counterexamples/buildings/bad-confidence-in-source.yaml
+++ b/counterexamples/buildings/bad-confidence-in-source.yaml
@@ -14,8 +14,14 @@ properties:
   height: 21.34
   sources:
   - property: ""
-    dataset: microsoftMLBuildings,
+    dataset: microsoftMLBuildings
+    provider: microsoft
+    resource: ml-buildings
+    version: abc
     confidence: 100
   - property: /properties/height
-    dataset:  metaLidarExtractions,
+    dataset:  metaLidarExtractions
+    provider: meta
+    resource: lidar-extractions
+    version: "2087-08-23"
     confidence: -1

--- a/counterexamples/buildings/bad-license.yaml
+++ b/counterexamples/buildings/bad-license.yaml
@@ -11,6 +11,9 @@ properties:
   version: 1
   sources:
     - dataset: MyGreatDataset
+      provider: overture
+      resource: soccer-stadiums
+      version: "2087-08-23"
       property: "/geometry"
       update_time: '2024-04-26T23:55:01-08:00'
       confidence: 0.3

--- a/counterexamples/buildings/bad-time.yaml
+++ b/counterexamples/buildings/bad-time.yaml
@@ -12,5 +12,8 @@ properties:
   version: 1
   sources:
     - dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       property: "/blah"
       update_time: abc2023-02-22T23:55:01-08:00

--- a/counterexamples/buildings/building-part-bad-name.yaml
+++ b/counterexamples/buildings/building-part-bad-name.yaml
@@ -30,3 +30,6 @@ properties:
   sources:
   - property: ""
     dataset: OpenStreetMap
+    provider: osm
+    resource: planet
+    version: "2099-05-18T10:30:00Z"

--- a/counterexamples/places/bad-empty-emails.yaml
+++ b/counterexamples/places/bad-empty-emails.yaml
@@ -33,9 +33,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: "2087-08-23"
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: abc
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/counterexamples/places/bad-empty-phones.yaml
+++ b/counterexamples/places/bad-empty-phones.yaml
@@ -33,9 +33,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: "2087-08-23"
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: abc
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/counterexamples/places/bad-empty-socials.yaml
+++ b/counterexamples/places/bad-empty-socials.yaml
@@ -33,9 +33,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: "2087-08-23"
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: abc
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/counterexamples/places/bad-empty-websites.yaml
+++ b/counterexamples/places/bad-empty-websites.yaml
@@ -33,9 +33,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: "2087-08-23"
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: abc
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/counterexamples/places/bad-operating-status.yaml
+++ b/counterexamples/places/bad-operating-status.yaml
@@ -33,9 +33,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: "2087-08-23"
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: abc
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/counterexamples/transportation/segment/bad-source-between.yaml
+++ b/counterexamples/transportation/segment/bad-source-between.yaml
@@ -21,4 +21,7 @@ properties:
     - record_id: w123
       property: ""
       dataset: some source
+      provider: some_provider
+      resource: some_resource
+      version: "2087-08-23"
       between: []

--- a/docs/schema/0-Schema.mdx
+++ b/docs/schema/0-Schema.mdx
@@ -49,7 +49,7 @@ In the Overture schema, all features have a unique `id` called a [GERS ID](https
 | **theme** | *string* | one of six Overture data themes |
 | **type** | *string* | one of 14 Overture feature types | 
 | **version** | *int32* | version number of the feature, incremented in each Overture release where the geometry or attributes of this feature changed |
-| **sources** | *list\<element: struct\<property: string, dataset: string, record_id: string, update_time: string, confidence: double, between: list\<double\>\>\>* | array of source information for the properties of a given feature |
+| **sources** | *list\<element: struct\<property: string, dataset: string, provider: string, resource: string, version: string, record_id: string, update_time: string, confidence: double, between: list\<double\>\>\>* | array of source information for the properties of a given feature |
 </details>
 
 ### Other key schema properties

--- a/examples/base/bathymetry-example.yaml
+++ b/examples/base/bathymetry-example.yaml
@@ -16,4 +16,7 @@ properties:
     - record_id: x123
       property: ""
       dataset: some source
+      provider: some_provider
+      resource: some_resource
+      version: "2087-08-23"
   version: 0

--- a/examples/base/infrastructure-example.yaml
+++ b/examples/base/infrastructure-example.yaml
@@ -18,4 +18,7 @@ properties:
     - property: ""
       record_id: w556368546@3
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   version: 0

--- a/examples/base/infrastructure-height-example.yaml
+++ b/examples/base/infrastructure-height-example.yaml
@@ -16,4 +16,7 @@ properties:
     - property: ""
       record_id: n10707323715@5
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   version: 0

--- a/examples/base/land-cover-example.yaml
+++ b/examples/base/land-cover-example.yaml
@@ -16,4 +16,7 @@ properties:
     - record_id: x123
       property: ""
       dataset: some source
+      provider: some_provider
+      resource: some_resource
+      version: "2087-08-23"
   version: 0

--- a/examples/base/land-sand-example.yaml
+++ b/examples/base/land-sand-example.yaml
@@ -18,4 +18,7 @@ properties:
     - record_id: w407753930@3
       property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   version: 0

--- a/examples/base/land-use-example.yaml
+++ b/examples/base/land-use-example.yaml
@@ -19,4 +19,7 @@ properties:
     - record_id: w509487233@1
       property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   version: 0

--- a/examples/base/water-body-disputed.yaml
+++ b/examples/base/water-body-disputed.yaml
@@ -31,6 +31,9 @@ properties:
     - record_id: w1234567
       property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   is_salt: false
   is_intermittent: false
   version: 0

--- a/examples/base/water-river-example.yaml
+++ b/examples/base/water-river-example.yaml
@@ -17,6 +17,9 @@ properties:
     - record_id: w54320702@1
       property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   is_salt: false
   is_intermittent: false
   version: 0

--- a/examples/base/water-river-with-wikidata.yaml
+++ b/examples/base/water-river-with-wikidata.yaml
@@ -17,5 +17,8 @@ properties:
     - record_id: w353912370@4
       property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   wikidata: Q7420045
   version: 0

--- a/examples/buildings/basic-sources.yaml
+++ b/examples/buildings/basic-sources.yaml
@@ -14,6 +14,9 @@ properties:
   version: 1
   sources:
     - dataset: MyGreatDataset
+      provider: overture
+      resource: soccer-stadiums
+      version: "2087-08-23"
       property: "/geometry"
       update_time: '2024-04-26T23:55:01-08:00'
       confidence: 0.3

--- a/examples/buildings/building-part-basic.yaml
+++ b/examples/buildings/building-part-basic.yaml
@@ -31,5 +31,11 @@ properties:
   sources:
   - property: ""
     dataset: microsoftMLBuildings
+    provider: microsoft
+    resource: ml-buildings
+    version: abc
   - property: /properties/height
     dataset:  metaLidarExtractions
+    provider: meta
+    resource: lidar-extractions
+    version: "2087-08-23"

--- a/examples/buildings/building-part-name.yaml
+++ b/examples/buildings/building-part-name.yaml
@@ -30,3 +30,6 @@ properties:
   sources:
   - property: ""
     dataset: OpenStreetMap
+    provider: osm
+    resource: planet
+    version: "2099-05-18T10:30:00Z"

--- a/examples/buildings/building-polygon.yaml
+++ b/examples/buildings/building-polygon.yaml
@@ -27,8 +27,14 @@ properties:
   is_underground: false
   sources:
   - property: ""
-    dataset: microsoftMLBuildings,
+    dataset: microsoftMLBuildings
+    provider: microsoft
+    resource: ml-buildings
+    version: abc
     confidence: 1
   - property: /properties/height
-    dataset:  metaLidarExtractions,
+    dataset:  metaLidarExtractions
+    provider: meta
+    resource: lidar-extractions
+    version: "2087-08-23"
     confidence: 0.95

--- a/examples/buildings/empire-state-building.json
+++ b/examples/buildings/empire-state-building.json
@@ -20,6 +20,9 @@
       {
         "property": "",
         "dataset": "OpenStreetMap",
+        "provider": "osm",
+        "resource": "planet",
+        "version": "2099-05-18T10:30:00Z",
         "record_id": "w34633854@71"
       }
     ],

--- a/examples/buildings/license-basic.yaml
+++ b/examples/buildings/license-basic.yaml
@@ -11,6 +11,9 @@ properties:
   version: 1
   sources:
     - dataset: MyGreatDataset
+      provider: overture
+      resource: soccer-stadiums
+      version: "2087-08-23"
       property: "/geometry"
       update_time: '2024-04-26T23:55:01-08:00'
       confidence: 0.3

--- a/examples/buildings/osm/outline.yaml
+++ b/examples/buildings/osm/outline.yaml
@@ -29,3 +29,6 @@ properties:
   sources:
   - property: ''
     dataset: OpenStreetMap
+    provider: osm
+    resource: planet
+    version: "2099-05-18T10:30:00Z"

--- a/examples/buildings/osm/part1.yaml
+++ b/examples/buildings/osm/part1.yaml
@@ -27,3 +27,6 @@ properties:
   sources:
   - property: ''
     dataset: OpenStreetMap
+    provider: osm
+    resource: planet
+    version: "2099-05-18T10:30:00Z"

--- a/examples/buildings/osm/part2.yaml
+++ b/examples/buildings/osm/part2.yaml
@@ -27,3 +27,6 @@ properties:
   sources:
   - property: ''
     dataset: OpenStreetMap
+    provider: osm
+    resource: planet
+    version: "2099-05-18T10:30:00Z"

--- a/examples/divisions/division/capital_of.yaml
+++ b/examples/divisions/division/capital_of.yaml
@@ -16,6 +16,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: N6968827.V76
   country: SI
   hierarchies:

--- a/examples/divisions/division/class.yaml
+++ b/examples/divisions/division/class.yaml
@@ -16,6 +16,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: N21040334
   country: DK
   hierarchies:

--- a/examples/divisions/division/dependency.yaml
+++ b/examples/divisions/division/dependency.yaml
@@ -25,6 +25,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: R4422604.V41
   country: PR
   region: US-PR

--- a/examples/divisions/division/multiple_capital_division.yaml
+++ b/examples/divisions/division/multiple_capital_division.yaml
@@ -16,6 +16,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: R223407.V254
   country: PL
   region: PL-04

--- a/examples/divisions/division/population.yaml
+++ b/examples/divisions/division/population.yaml
@@ -16,6 +16,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: R68841.V267
   country: CA
   region: CA-ON

--- a/examples/divisions/division/prominence.yaml
+++ b/examples/divisions/division/prominence.yaml
@@ -16,6 +16,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: N21040334
   country: DK
   hierarchies:

--- a/examples/divisions/division/region.yaml
+++ b/examples/divisions/division/region.yaml
@@ -16,6 +16,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: R61320.V468
   country: US
   region: US-NY

--- a/examples/places/place-no-emails-phones-socials-websites.yaml
+++ b/examples/places/place-no-emails-phones-socials-websites.yaml
@@ -26,9 +26,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: abc
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: "2087-08-23"
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/examples/places/place-with-operating-status.yaml
+++ b/examples/places/place-with-operating-status.yaml
@@ -34,9 +34,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: abc
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: "2087-08-23"
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/examples/places/place.yaml
+++ b/examples/places/place.yaml
@@ -35,9 +35,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: abc
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: "2087-08-23"
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/examples/transportation/segment/road/road-with-lr-sources.yaml
+++ b/examples/transportation/segment/road/road-with-lr-sources.yaml
@@ -20,12 +20,18 @@ properties:
   sources:
     - property: "/names/primary"
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: w12345@1
       between:
         - 0
         - 0.5
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2097-12-19T08:24:00Z"
       record_id: w67890@1
       between:
         - 0.5

--- a/packages/overture-schema-addresses-theme/pyproject.toml
+++ b/packages/overture-schema-addresses-theme/pyproject.toml
@@ -69,3 +69,6 @@ value = "Chatham Island"
 [[examples.Address.sources]]
 property = ""
 dataset = "OpenAddresses/LINZ"
+provider = "open-addresses"
+resource = "linz"
+version = "2024-01-01"

--- a/packages/overture-schema-addresses-theme/tests/address_baseline_schema.json
+++ b/packages/overture-schema-addresses-theme/tests/address_baseline_schema.json
@@ -55,7 +55,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -66,7 +66,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -78,7 +78,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -86,10 +86,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-addresses-theme/tests/address_baseline_schema.json
+++ b/packages/overture-schema-addresses-theme/tests/address_baseline_schema.json
@@ -39,7 +39,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -54,9 +54,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -64,11 +76,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-base-theme/pyproject.toml
+++ b/packages/overture-schema-base-theme/pyproject.toml
@@ -62,6 +62,9 @@ ymax = -75.64299774169922
 [[examples.Bathymetry.sources]]
 property = ""
 dataset = "ETOPO/GLOBathy"
+provider = "etopo"
+resource = "globathy"
+version = "2024-12-09"
 record_id = "2024-12-09T00:00:00.000Z"
 
 [examples.Bathymetry.cartography]
@@ -86,6 +89,9 @@ ymax = -82.42407989501953
 [[examples.Infrastructure.sources]]
 property = ""
 dataset = "OpenStreetMap"
+provider = "osm"
+resource = "planet"
+version = "2023-04-07"
 record_id = "n7674174803@2"
 update_time = "2023-04-07T17:37:48.000Z"
 
@@ -119,6 +125,9 @@ ymax = -85.44999694824219
 [[examples.Land.sources]]
 property = ""
 dataset = "OpenStreetMap"
+provider = "osm"
+resource = "planet"
+version = "2024-03-05"
 record_id = "n11693475112@1"
 update_time = "2024-03-05T09:23:39.000Z"
 
@@ -147,6 +156,9 @@ ymax = 65.96218872070312
 [[examples.LandCover.sources]]
 property = ""
 dataset = "ESA WorldCover"
+provider = "esa"
+resource = "worldcover"
+version = "2024-11-07"
 update_time = "2024-11-07T00:00:00.000Z"
 
 [examples.LandCover.cartography]
@@ -172,6 +184,9 @@ ymax = -43.95420837402344
 [[examples.LandUse.sources]]
 property = ""
 dataset = "OpenStreetMap"
+provider = "osm"
+resource = "planet"
+version = "2010-04-24"
 record_id = "w56117029@3"
 update_time = "2010-04-24T22:35:13.000Z"
 
@@ -203,6 +218,9 @@ ymax = -84.9347915649414
 [[examples.Water.sources]]
 property = ""
 dataset = "OpenStreetMap"
+provider = "osm"
+resource = "planet"
+version = "2024-02-11"
 record_id = "n11109190647@2"
 update_time = "2024-02-11T05:52:05.000Z"
 

--- a/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
@@ -76,7 +76,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -87,7 +87,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -99,7 +99,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -107,10 +107,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
@@ -60,7 +60,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -75,9 +75,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -85,11 +97,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
@@ -385,7 +385,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -396,7 +396,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -408,7 +408,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -416,10 +416,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
@@ -369,7 +369,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -384,9 +384,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -394,11 +406,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-base-theme/tests/land_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_baseline_schema.json
@@ -258,7 +258,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -269,7 +269,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -281,7 +281,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -289,10 +289,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-base-theme/tests/land_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_baseline_schema.json
@@ -242,7 +242,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -257,9 +257,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -267,11 +279,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
@@ -93,7 +93,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -104,7 +104,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -116,7 +116,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -124,10 +124,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
@@ -77,7 +77,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -92,9 +92,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -102,11 +114,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
@@ -320,7 +320,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -335,9 +335,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -345,11 +357,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
@@ -336,7 +336,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -347,7 +347,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -359,7 +359,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -367,10 +367,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-base-theme/tests/water_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/water_baseline_schema.json
@@ -173,7 +173,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -188,9 +188,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -198,11 +210,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-base-theme/tests/water_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/water_baseline_schema.json
@@ -189,7 +189,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -200,7 +200,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -212,7 +212,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -220,10 +220,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-buildings-theme/pyproject.toml
+++ b/packages/overture-schema-buildings-theme/pyproject.toml
@@ -59,6 +59,9 @@ ymax = -43.993709564208984
 [[examples.Building.sources]]
 property = ""
 dataset = "OpenStreetMap"
+provider = "osm"
+resource = "planet"
+version = "2017-08-27"
 record_id = "w519166507@1"
 update_time = "2017-08-27T21:39:50.000Z"
 
@@ -81,5 +84,8 @@ ymax = -39.81088638305664
 [[examples.BuildingPart.sources]]
 property = ""
 dataset = "OpenStreetMap"
+provider = "osm"
+resource = "planet"
+version = "2014-10-31"
 record_id = "w223076787@2"
 update_time = "2014-10-31T22:55:36.000Z"

--- a/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
@@ -372,7 +372,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -383,7 +383,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -395,7 +395,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -403,10 +403,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
@@ -356,7 +356,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -371,9 +371,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -381,11 +393,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
@@ -258,7 +258,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -269,7 +269,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -281,7 +281,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -289,10 +289,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
@@ -242,7 +242,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -257,9 +257,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -267,11 +279,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-common/README.md
+++ b/packages/overture-schema-common/README.md
@@ -73,16 +73,16 @@ Name rules support geometric range and side scoping for cases like a street whos
 
 ## Sources
 
-Source attribution tracking. Each `SourceItem` identifies which dataset a feature or property came from, with optional license, record ID, update time, and confidence score. Source items support geometric range scoping for per-segment attribution.
+Source attribution tracking. Each `SourceItem` includes a backward-compatible `dataset` identifier and the required source triplet (`provider`, `resource`, `version`), with optional license, record ID, update time, and confidence score. Source items support geometric range scoping for per-segment attribution.
 
 ```python
 from overture.schema.common.sources import SourceItem
 
 sources = [
-    SourceItem(property="", dataset="OpenStreetMap"),
-    SourceItem(property="/geometry", dataset="Microsoft ML Buildings"),
+    SourceItem(property="", dataset="OpenStreetMap", provider="osm", resource="planet", version="2026-05-01"),
+    SourceItem(property="/geometry", dataset="Microsoft ML Buildings", provider="microsoft", resource="buildings", version="v3"),
     # first 30% of the segment's geometry came from a different source
-    SourceItem(property="/geometry", dataset="County GIS", between=[0, 0.3]),
+    SourceItem(property="/geometry", dataset="County GIS", provider="county-gis", resource="building-footprints", version="2026-04", between=[0, 0.3]),
 ]
 ```
 

--- a/packages/overture-schema-common/src/overture/schema/common/sources.py
+++ b/packages/overture-schema-common/src/overture/schema/common/sources.py
@@ -12,6 +12,7 @@ from overture.schema.common.scoping import Scope, scoped
 from overture.schema.common.types import ConfidenceScore
 from overture.schema.system.field_constraint import UniqueItemsConstraint
 from overture.schema.system.model_constraint import no_extra_fields
+from overture.schema.system.optionality import Omitable
 from overture.schema.system.string import JsonPointer, StrippedString
 
 
@@ -44,36 +45,25 @@ class SourceItem(BaseModel):
             Dataset identifier retained for backward compatibility.
         """).strip()
     )
-    provider: Annotated[
-        str,
-        Field(
-            min_length=1,
-            description=textwrap.dedent("""
-                Name of the entity that produced the source data.
-            """).strip(),
-        ),
-    ]
-    resource: Annotated[
-        str,
-        Field(
-            min_length=1,
-            description=textwrap.dedent("""
-                Subject or data type produced by the provider.
-            """).strip(),
-        ),
-    ]
-    version: Annotated[
-        str,
-        Field(
-            min_length=1,
-            description=textwrap.dedent("""
-                Sortable source snapshot identifier, such as a date, number, or release label.
-            """).strip(),
-        ),
-    ]
 
-    # Optional
-
+    provider: Omitable[str] = Field(
+        min_length=1,
+        description=textwrap.dedent("""
+            Optional name of the entity that produced the source data.
+        """).strip(),
+    )
+    resource: Omitable[str] = Field(
+        min_length=1,
+        description=textwrap.dedent("""
+            Optional subject or data type produced by the provider.
+        """).strip(),
+    )
+    version: Omitable[str] = Field(
+        min_length=1,
+        description=textwrap.dedent("""
+            Optional sortable source snapshot identifier, such as a date, number, or release label.
+        """).strip(),
+    )
     license: Annotated[
         StrippedString | None,
         Field(

--- a/packages/overture-schema-common/src/overture/schema/common/sources.py
+++ b/packages/overture-schema-common/src/overture/schema/common/sources.py
@@ -41,9 +41,36 @@ class SourceItem(BaseModel):
     )
     dataset: str = Field(
         description=textwrap.dedent("""
-            Name of the dataset where the source data can be found.
+            Dataset identifier retained for backward compatibility.
         """).strip()
     )
+    provider: Annotated[
+        str,
+        Field(
+            min_length=1,
+            description=textwrap.dedent("""
+                Name of the entity that produced the source data.
+            """).strip(),
+        ),
+    ]
+    resource: Annotated[
+        str,
+        Field(
+            min_length=1,
+            description=textwrap.dedent("""
+                Subject or data type produced by the provider.
+            """).strip(),
+        ),
+    ]
+    version: Annotated[
+        str,
+        Field(
+            min_length=1,
+            description=textwrap.dedent("""
+                Sortable source snapshot identifier, such as a date, number, or release label.
+            """).strip(),
+        ),
+    ]
 
     # Optional
 

--- a/packages/overture-schema-common/tests/test_models.py
+++ b/packages/overture-schema-common/tests/test_models.py
@@ -5,11 +5,13 @@ from typing import Any
 import pytest
 from deepdiff import DeepDiff
 from overture.schema.common.models import OvertureFeature
+from overture.schema.common.sources import SourceItem
 from overture.schema.system.json_schema import GenerateOmitNullableOptionalJsonSchema
 from overture.schema.system.primitive import (
     BBox,
     Geometry,
 )
+from pydantic import ValidationError
 from shapely.geometry import LineString, Point
 
 
@@ -71,7 +73,7 @@ def test_feature_json_schema() -> None:
                     },
                     "confidence": {"maximum": 1.0, "minimum": 0.0, "type": "number"},
                 },
-                "required": ["property", "dataset", "provider", "resource", "version"],
+                "required": ["property", "dataset"],
                 "type": "object",
             }
         },
@@ -513,3 +515,22 @@ def test_feature_validate_json(
     )
 
     assert feature == validated
+
+
+def test_source_item_provider_resource_version_omittable() -> None:
+    """provider, resource, and version can be omitted; absent fields excluded from JSON."""
+    item = SourceItem(property="", dataset="osm")
+    dumped = json.loads(item.model_dump_json(exclude_unset=True))
+    assert "provider" not in dumped
+    assert "resource" not in dumped
+    assert "version" not in dumped
+
+
+def test_source_item_provider_resource_version_not_nullable() -> None:
+    """provider, resource, and version cannot be set to null."""
+    with pytest.raises(ValidationError):
+        SourceItem(property="", dataset="osm", provider=None)
+    with pytest.raises(ValidationError):
+        SourceItem(property="", dataset="osm", resource=None)
+    with pytest.raises(ValidationError):
+        SourceItem(property="", dataset="osm", version=None)

--- a/packages/overture-schema-common/tests/test_models.py
+++ b/packages/overture-schema-common/tests/test_models.py
@@ -57,6 +57,9 @@ def test_feature_json_schema() -> None:
                     },
                     "property": {"type": "string"},
                     "dataset": {"type": "string"},
+                    "provider": {"minLength": 1, "type": "string"},
+                    "resource": {"minLength": 1, "type": "string"},
+                    "version": {"minLength": 1, "type": "string"},
                     "license": {
                         "pattern": "^(\\S(.*\\S)?)?$",
                         "type": "string",
@@ -68,7 +71,7 @@ def test_feature_json_schema() -> None:
                     },
                     "confidence": {"maximum": 1.0, "minimum": 0.0, "type": "number"},
                 },
-                "required": ["property", "dataset"],
+                "required": ["property", "dataset", "provider", "resource", "version"],
                 "type": "object",
             }
         },

--- a/packages/overture-schema-divisions-theme/pyproject.toml
+++ b/packages/overture-schema-divisions-theme/pyproject.toml
@@ -71,6 +71,9 @@ ymax = -21.13536834716797
 [[examples.Division.sources]]
 property = ""
 dataset = "OpenStreetMap"
+provider = "osm"
+resource = "planet"
+version = "2014-12-18"
 record_id = "n3173231082@4"
 update_time = "2014-12-18T09:17:03Z"
 
@@ -110,6 +113,9 @@ ymax = -21.283489227294922
 [[examples.DivisionArea.sources]]
 property = ""
 dataset = "OpenStreetMap"
+provider = "osm"
+resource = "planet"
+version = "2020-12-30"
 record_id = "r7247527@3"
 update_time = "2020-12-30T18:41:56Z"
 
@@ -142,11 +148,17 @@ ymax = -15.151169776916504
 [[examples.DivisionBoundary.sources]]
 property = ""
 dataset = "OpenStreetMap"
+provider = "osm"
+resource = "planet"
+version = "2023-07-20"
 record_id = "r6063055@9"
 update_time = "2023-07-20T00:28:40Z"
 
 [[examples.DivisionBoundary.sources]]
 property = ""
 dataset = "OpenStreetMap"
+provider = "osm"
+resource = "planet"
+version = "2023-07-20"
 record_id = "r6063063@12"
 update_time = "2023-07-20T00:28:40Z"

--- a/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
@@ -217,7 +217,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -228,7 +228,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -240,7 +240,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -248,10 +248,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
@@ -201,7 +201,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -216,9 +216,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -226,11 +238,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
@@ -304,7 +304,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -319,9 +319,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -329,11 +341,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
@@ -320,7 +320,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -331,7 +331,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -343,7 +343,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -351,10 +351,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
@@ -91,7 +91,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -106,9 +106,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -116,11 +128,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
@@ -107,7 +107,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -118,7 +118,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -130,7 +130,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -138,10 +138,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-places-theme/pyproject.toml
+++ b/packages/overture-schema-places-theme/pyproject.toml
@@ -66,6 +66,9 @@ ymax = -79.17133331298828
 [[examples.Place.sources]]
 property = ""
 dataset = "meta"
+provider = "meta"
+resource = "places"
+version = "2025-06-30"
 record_id = "107663894904826"
 update_time = "2025-06-30T07:00:00.000Z"
 confidence = 0.7337175792507205

--- a/packages/overture-schema-places-theme/tests/place_baseline_schema.json
+++ b/packages/overture-schema-places-theme/tests/place_baseline_schema.json
@@ -284,7 +284,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -295,7 +295,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -307,7 +307,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -315,10 +315,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-places-theme/tests/place_baseline_schema.json
+++ b/packages/overture-schema-places-theme/tests/place_baseline_schema.json
@@ -268,7 +268,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -283,9 +283,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -293,11 +305,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-transportation-theme/pyproject.toml
+++ b/packages/overture-schema-transportation-theme/pyproject.toml
@@ -57,6 +57,9 @@ ymax = -43.96794128417969
 [[examples.Connector.sources]]
 property = ""
 dataset = "OpenStreetMap"
+provider = "osm"
+resource = "planet"
+version = "2024-01-01"
 
 [[examples.Segment]]
 id = "1bc62f3b-08b5-42b8-89fe-36f685f60455"
@@ -76,6 +79,9 @@ ymax = -43.953250885009766
 [[examples.Segment.sources]]
 property = ""
 dataset = "OpenStreetMap"
+provider = "osm"
+resource = "planet"
+version = "2021-05-03"
 record_id = "w53435546@6"
 update_time = "2021-05-03T06:37:03Z"
 

--- a/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
@@ -40,7 +40,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -51,7 +51,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -63,7 +63,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -71,10 +71,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
@@ -24,7 +24,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -39,9 +39,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -49,11 +61,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
@@ -1150,7 +1150,7 @@
           "type": "number"
         },
         "dataset": {
-          "description": "Name of the dataset where the source data can be found.",
+          "description": "Dataset identifier retained for backward compatibility.",
           "title": "Dataset",
           "type": "string"
         },
@@ -1165,9 +1165,21 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "Name of the entity that produced the source data.",
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Subject or data type produced by the provider.",
+          "minLength": 1,
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
@@ -1175,11 +1187,20 @@
           "format": "date-time",
           "title": "Update Time",
           "type": "string"
+        },
+        "version": {
+          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
         }
       },
       "required": [
         "property",
-        "dataset"
+        "dataset",
+        "provider",
+        "resource",
+        "version"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
@@ -1166,7 +1166,7 @@
           "type": "string"
         },
         "provider": {
-          "description": "Name of the entity that produced the source data.",
+          "description": "Optional name of the entity that produced the source data.",
           "minLength": 1,
           "title": "Provider",
           "type": "string"
@@ -1177,7 +1177,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "Subject or data type produced by the provider.",
+          "description": "Optional subject or data type produced by the provider.",
           "minLength": 1,
           "title": "Resource",
           "type": "string"
@@ -1189,7 +1189,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Sortable source snapshot identifier, such as a date, number, or release label.",
+          "description": "Optional sortable source snapshot identifier, such as a date, number, or release label.",
           "minLength": 1,
           "title": "Version",
           "type": "string"
@@ -1197,10 +1197,7 @@
       },
       "required": [
         "property",
-        "dataset",
-        "provider",
-        "resource",
-        "version"
+        "dataset"
       ],
       "title": "SourceItem",
       "type": "object"

--- a/reference/counterexamples/base/bathymetry/bad-depth.yaml
+++ b/reference/counterexamples/base/bathymetry/bad-depth.yaml
@@ -13,5 +13,8 @@ properties:
     - record_id: x123
       property: ""
       dataset: some source
+      provider: some_provider
+      resource: some_resource
+      version: "2087-08-23"
   ext_expected_errors:
     - "depth/minimum]: minimum: got -1, want 0"

--- a/reference/counterexamples/buildings/bad-confidence-in-source.yaml
+++ b/reference/counterexamples/buildings/bad-confidence-in-source.yaml
@@ -14,8 +14,14 @@ properties:
   height: 21.34
   sources:
   - property: ""
-    dataset: microsoftMLBuildings,
+    dataset: microsoftMLBuildings
+    provider: microsoft
+    resource: ml-buildings
+    version: abc
     confidence: 100
   - property: /properties/height
-    dataset:  metaLidarExtractions,
+    dataset:  metaLidarExtractions
+    provider: meta
+    resource: lidar-extractions
+    version: "2087-08-23"
     confidence: -1

--- a/reference/counterexamples/buildings/bad-license.yaml
+++ b/reference/counterexamples/buildings/bad-license.yaml
@@ -11,6 +11,9 @@ properties:
   version: 1
   sources:
     - dataset: MyGreatDataset
+      provider: overture
+      resource: soccer-stadiums
+      version: "2087-08-23"
       property: "/geometry"
       update_time: "2024-04-26T23:55:01-08:00"
       confidence: 0.3

--- a/reference/counterexamples/buildings/bad-time.yaml
+++ b/reference/counterexamples/buildings/bad-time.yaml
@@ -12,5 +12,8 @@ properties:
   version: 1
   sources:
     - dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2026-05-18T10:30:00Z"
       property: "/blah"
       update_time: abc2023-02-22T23:55:01-08:00

--- a/reference/counterexamples/buildings/building-part-bad-name.yaml
+++ b/reference/counterexamples/buildings/building-part-bad-name.yaml
@@ -30,3 +30,6 @@ properties:
   sources:
   - property: ""
     dataset: OpenStreetMap
+    provider: osm
+    resource: planet
+    version: "2099-05-18T10:30:00Z"

--- a/reference/counterexamples/places/bad-empty-emails.yaml
+++ b/reference/counterexamples/places/bad-empty-emails.yaml
@@ -33,9 +33,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: "2087-08-23"
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: abc
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/reference/counterexamples/places/bad-empty-phones.yaml
+++ b/reference/counterexamples/places/bad-empty-phones.yaml
@@ -33,9 +33,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: "2087-08-23"
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: abc
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/reference/counterexamples/places/bad-empty-socials.yaml
+++ b/reference/counterexamples/places/bad-empty-socials.yaml
@@ -33,9 +33,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: "2087-08-23"
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: abc
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/reference/counterexamples/places/bad-empty-websites.yaml
+++ b/reference/counterexamples/places/bad-empty-websites.yaml
@@ -33,9 +33,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: "2087-08-23"
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: abc
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/reference/counterexamples/places/bad-operating-status.yaml
+++ b/reference/counterexamples/places/bad-operating-status.yaml
@@ -33,9 +33,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: "2087-08-23"
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: abc
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/reference/counterexamples/transportation/segment/bad-source-between.yaml
+++ b/reference/counterexamples/transportation/segment/bad-source-between.yaml
@@ -21,4 +21,7 @@ properties:
     - record_id: w123
       property: ""
       dataset: some source
+      provider: some_provider
+      resource: some_resource
+      version: abc
       between: []

--- a/reference/examples/base/bathymetry-example.yaml
+++ b/reference/examples/base/bathymetry-example.yaml
@@ -16,4 +16,7 @@ properties:
     - record_id: x123
       property: ""
       dataset: some source
+      provider: some_provider
+      resource: some_resource
+      version: abc
   version: 0

--- a/reference/examples/base/infrastructure-example.yaml
+++ b/reference/examples/base/infrastructure-example.yaml
@@ -18,4 +18,7 @@ properties:
     - property: ""
       record_id: w556368546@3
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   version: 0

--- a/reference/examples/base/infrastructure-height-example.yaml
+++ b/reference/examples/base/infrastructure-height-example.yaml
@@ -16,4 +16,7 @@ properties:
     - property: ""
       record_id: n10707323715@5
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   version: 0

--- a/reference/examples/base/land-cover-example.yaml
+++ b/reference/examples/base/land-cover-example.yaml
@@ -16,4 +16,7 @@ properties:
     - record_id: x123
       property: ""
       dataset: some source
+      provider: some_provider
+      resource: some_resource
+      version: abc
   version: 0

--- a/reference/examples/base/land-sand-example.yaml
+++ b/reference/examples/base/land-sand-example.yaml
@@ -18,4 +18,7 @@ properties:
     - record_id: w407753930@3
       property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   version: 0

--- a/reference/examples/base/land-use-example.yaml
+++ b/reference/examples/base/land-use-example.yaml
@@ -19,4 +19,7 @@ properties:
     - record_id: w509487233@1
       property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   version: 0

--- a/reference/examples/base/water-body-disputed.yaml
+++ b/reference/examples/base/water-body-disputed.yaml
@@ -31,6 +31,9 @@ properties:
     - record_id: w1234567
       property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   is_salt: false
   is_intermittent: false
   version: 0

--- a/reference/examples/base/water-river-example.yaml
+++ b/reference/examples/base/water-river-example.yaml
@@ -17,6 +17,9 @@ properties:
     - record_id: w54320702@1
       property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   is_salt: false
   is_intermittent: false
   version: 0

--- a/reference/examples/base/water-river-with-wikidata.yaml
+++ b/reference/examples/base/water-river-with-wikidata.yaml
@@ -17,5 +17,8 @@ properties:
     - record_id: w353912370@4
       property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
   wikidata: Q7420045
   version: 0

--- a/reference/examples/buildings/basic-sources.yaml
+++ b/reference/examples/buildings/basic-sources.yaml
@@ -14,6 +14,9 @@ properties:
   version: 1
   sources:
     - dataset: MyGreatDataset
+      provider: overture
+      resource: soccer-stadiums
+      version: "2087-08-23"
       property: "/geometry"
       update_time: '2024-04-26T23:55:01-08:00'
       confidence: 0.3

--- a/reference/examples/buildings/building-part-basic.yaml
+++ b/reference/examples/buildings/building-part-basic.yaml
@@ -31,5 +31,11 @@ properties:
   sources:
   - property: ""
     dataset: microsoftMLBuildings
+    provider: microsoft
+    resource: ml-buildings
+    version: abc
   - property: /properties/height
     dataset:  metaLidarExtractions
+    provider: meta
+    resource: lidar-extractions
+    version: "2087-08-23"

--- a/reference/examples/buildings/building-part-name.yaml
+++ b/reference/examples/buildings/building-part-name.yaml
@@ -30,3 +30,6 @@ properties:
   sources:
   - property: ""
     dataset: OpenStreetMap
+    provider: osm
+    resource: planet
+    version: "2099-05-18T10:30:00Z"

--- a/reference/examples/buildings/building-polygon.yaml
+++ b/reference/examples/buildings/building-polygon.yaml
@@ -27,8 +27,14 @@ properties:
   is_underground: false
   sources:
   - property: ""
-    dataset: microsoftMLBuildings,
+    dataset: microsoftMLBuildings
+    provider: microsoft
+    resource: ml-buildings
+    version: abc
     confidence: 1
   - property: /properties/height
-    dataset:  metaLidarExtractions,
+    dataset:  metaLidarExtractions
+    provider: meta
+    resource: lidar-extractions
+    version: "2087-08-23"
     confidence: 0.95

--- a/reference/examples/buildings/empire-state-building.json
+++ b/reference/examples/buildings/empire-state-building.json
@@ -20,6 +20,9 @@
       {
         "property": "",
         "dataset": "OpenStreetMap",
+        "provider": "osm",
+        "resource": "planet",
+        "version": "2099-05-18T10:30:00Z",
         "record_id": "w34633854@71"
       }
     ],

--- a/reference/examples/buildings/license-basic.yaml
+++ b/reference/examples/buildings/license-basic.yaml
@@ -11,6 +11,9 @@ properties:
   version: 1
   sources:
     - dataset: MyGreatDataset
+      provider: overture
+      resource: soccer-stadiums
+      version: "2087-08-23"
       property: "/geometry"
       update_time: '2024-04-26T23:55:01-08:00'
       confidence: 0.3

--- a/reference/examples/buildings/osm/outline.yaml
+++ b/reference/examples/buildings/osm/outline.yaml
@@ -29,3 +29,6 @@ properties:
   sources:
   - property: ''
     dataset: OpenStreetMap
+    provider: osm
+    resource: planet
+    version: "2099-05-18T10:30:00Z"

--- a/reference/examples/buildings/osm/part1.yaml
+++ b/reference/examples/buildings/osm/part1.yaml
@@ -27,3 +27,6 @@ properties:
   sources:
   - property: ''
     dataset: OpenStreetMap
+    provider: osm
+    resource: planet
+    version: "2099-05-18T10:30:00Z"

--- a/reference/examples/buildings/osm/part2.yaml
+++ b/reference/examples/buildings/osm/part2.yaml
@@ -27,3 +27,6 @@ properties:
   sources:
   - property: ''
     dataset: OpenStreetMap
+    provider: osm
+    resource: planet
+    version: "2099-05-18T10:30:00Z"

--- a/reference/examples/divisions/division/capital_of.yaml
+++ b/reference/examples/divisions/division/capital_of.yaml
@@ -16,6 +16,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: N6968827.V76
   country: SI
   hierarchies:

--- a/reference/examples/divisions/division/class.yaml
+++ b/reference/examples/divisions/division/class.yaml
@@ -16,6 +16,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: N21040334
   country: DK
   hierarchies:

--- a/reference/examples/divisions/division/dependency.yaml
+++ b/reference/examples/divisions/division/dependency.yaml
@@ -25,6 +25,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: R4422604.V41
   country: PR
   region: US-PR

--- a/reference/examples/divisions/division/multiple_capital_division.yaml
+++ b/reference/examples/divisions/division/multiple_capital_division.yaml
@@ -16,6 +16,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: R223407.V254
   country: PL
   region: PL-04

--- a/reference/examples/divisions/division/population.yaml
+++ b/reference/examples/divisions/division/population.yaml
@@ -16,6 +16,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: R68841.V267
   country: CA
   region: CA-ON

--- a/reference/examples/divisions/division/prominence.yaml
+++ b/reference/examples/divisions/division/prominence.yaml
@@ -16,6 +16,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: N21040334
   country: DK
   hierarchies:

--- a/reference/examples/divisions/division/region.yaml
+++ b/reference/examples/divisions/division/region.yaml
@@ -16,6 +16,9 @@ properties:
   sources:
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: R61320.V468
   country: US
   region: US-NY

--- a/reference/examples/places/place-no-emails-phones-socials-websites.yaml
+++ b/reference/examples/places/place-no-emails-phones-socials-websites.yaml
@@ -26,9 +26,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: abc
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: "2087-08-23"
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/reference/examples/places/place-with-operating-status.yaml
+++ b/reference/examples/places/place-with-operating-status.yaml
@@ -34,9 +34,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: abc
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: "2087-08-23"
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/reference/examples/places/place.yaml
+++ b/reference/examples/places/place.yaml
@@ -35,9 +35,15 @@ properties:
   sources:
     - property: ""
       dataset: metaPlaces
+      provider: meta
+      resource: places
+      version: abc
       record_id: "10101"
     - property: "/properties/brand"
       dataset: msftPlaces
+      provider: microsoft
+      resource: places
+      version: "2087-08-23"
       record_id: "10df72b8"
   names:
     primary: My Sweet POI

--- a/reference/examples/transportation/segment/road/road-with-lr-sources.yaml
+++ b/reference/examples/transportation/segment/road/road-with-lr-sources.yaml
@@ -20,12 +20,18 @@ properties:
   sources:
     - property: "/names/primary"
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2099-05-18T10:30:00Z"
       record_id: w12345@1
       between:
         - 0
         - 0.5
     - property: ""
       dataset: OpenStreetMap
+      provider: osm
+      resource: planet
+      version: "2097-08-12T11:20:00Z"
       record_id: w67890@1
       between:
         - 0.5

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -260,15 +260,14 @@ description: Common schema definitions shared by all themes
       enum: [left, right]
     sourcePropertyItem:
       description: >-
-        An object storing the source for a specificed property. The property
+        An object storing the source for a specified property. The property
         is a reference to the property element within this Feature, and will be
         referenced using JSON Pointer Notation RFC 6901
-        (https://datatracker.ietf.org/doc/rfc6901/). The source dataset for
-        that referenced property will be specified in the overture list of
-        approved sources from the Overture Data Working Group that contains
-        the relevant metadata for that dataset including license source organization.
+        (https://datatracker.ietf.org/doc/rfc6901/). Source identity includes
+        a backward-compatible dataset identifier plus provider, resource, and
+        version values that together identify a specific source snapshot.
       type: object
-      required: [property, dataset]
+      required: [property, dataset, provider, resource, version]
       allOf:
         - { "$ref": "#/$defs/propertyContainers/geometricRangeScopeContainer" }
       unevaluatedProperties: false
@@ -277,6 +276,20 @@ description: Common schema definitions shared by all themes
           type: string
         dataset:
           type: string
+          description: >-
+            Dataset identifier retained for backward compatibility.
+        provider:
+          type: string
+          description: The entity that produced the source data, for example meta, esri, microsoft, etc.
+          minLength: 1
+        resource:
+          type: string
+          description: The subject or data type produced by the provider, for example buildings, division-names, planet, etc.
+          minLength: 1
+        version:
+          type: string
+          description: Sortable source snapshot identifier, for example 2026-02-13, 5.3, A5692, etc.
+          minLength: 1
         license:
           type: string
           description: >-
@@ -296,10 +309,10 @@ description: Common schema definitions shared by all themes
       description: >-
         The array of source information for the properties of a
         given feature, with each entry being a source object which
-        lists the property in JSON Pointer notation and the dataset
-        that specific value came from. All features must have a root
-        level source which is the default source if a specific
-        property's source is not specified.
+        lists the property in JSON Pointer notation and source
+        identifiers for where that value came from. All features
+        must have a root level source which is the default source
+        if a specific property's source is not specified.
       type: array
       items: {"$ref" : "#/$defs/propertyDefinitions/sourcePropertyItem"}
       minItems: 1

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -264,10 +264,11 @@ description: Common schema definitions shared by all themes
         is a reference to the property element within this Feature, and will be
         referenced using JSON Pointer Notation RFC 6901
         (https://datatracker.ietf.org/doc/rfc6901/). Source identity includes
-        a backward-compatible dataset identifier plus provider, resource, and
-        version values that together identify a specific source snapshot.
+        a backward-compatible dataset identifier plus optional provider,
+        resource, and version values that together can identify a specific
+        source snapshot.
       type: object
-      required: [property, dataset, provider, resource, version]
+      required: [property, dataset]
       allOf:
         - { "$ref": "#/$defs/propertyContainers/geometricRangeScopeContainer" }
       unevaluatedProperties: false


### PR DESCRIPTION
# Major change release plan

This step alone is not a major change as it is simply adding new fields, but when we remove the deprecated dataset field that will be breaking.

## A. Expected release date for this MAJOR change
The breaking change for this should come 6 to 12 months after the minor change is released. For this change to be rolled out we are going to have to update all data loaders to populate these required fields. That will take some time. While this pull request is out now, we may not actually be able to implement this change until the August timeframe.

## B. Related MINOR change steps

- Release this non-breaking change and announce a deprecation timeline for the `dataset` field.
- Come back later and remove the outdated `dataset` field and make the three new fields non-optional.

## C. Public documentation and messaging plan

Messaging around this change is that the current method of providing provenance is not sufficient to ensure traceability. Besides documenting the deprecation of `dataset` we will want to provide details on how the `provider`, `resource`, and `version` work together to identify a data snapshot.

# Description

The intent of this change is to update our source item field to include the information necessary for data provenance:

```
- provider: The name of the entity that produced the data: meta, esri, microsoft, osm, etc.
- resource: The subject or type of data given by the provider: division-names, buildings, planet, etc.
- version: The sortable identifier such as a date or number: 2026-02-13, 5.3, A5692
```
Together, along with the `version_id` these values allow a user to uniquely identify what raw input data was used to construct Overture data. Our current system, of providing only a `dataset` is lacking dataset version information but is also inconsistently constructed. All three new fields will be omitable which means optional (absent or non-null string) and null rejected at validation time.

# Reference
Closes #530 

# Testing

The unit tests for the schema were run.


 ## Test Results

Added 2 new tests:
- test_source_item_provider_resource_version_omittable (omission works, fields excluded from JSON)
- test_source_item_provider_resource_version_not_nullable (null raises ValidationError)

```
 All 1995 tests passed.

 uv run pytest -W error packages/ -q --tb=short
 1995 passed in 5.18s

 Lint and formatting checks also clean (`ruff check`, `ruff format --check`).
```

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [ ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation website
[Docs preview for this PR.](https://staging.overturemaps.org/schema/pr/532/schema/index.html)
