### PR TITLE
[ENHANCEMENT] Added provider, resource, and version parameters to sources

### DIFF
--- a/counterexamples/buildings/bad-sources-empty-provider.yaml
+++ b/counterexamples/buildings/bad-sources-empty-provider.yaml
@@ -1,0 +1,16 @@
+---
+id: overture:buildings:building:1234
+type: Feature
+geometry:
+  type: Polygon
+  coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]
+properties:
+  theme: buildings
+  type: building
+  version: 1
+  sources:
+    - dataset: MyGreatDataset
+      property: "/geometry"
+      provider: ""
+      resource: ""
+      version: ""

--- a/examples/buildings/sources-with-version.yaml
+++ b/examples/buildings/sources-with-version.yaml
@@ -1,0 +1,26 @@
+---
+id: overture:buildings:building:1234
+type: Feature
+geometry:
+  type: Polygon
+  coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]
+properties:
+  theme: buildings
+  type: building
+  version: 1
+  sources:
+    - property: "/geometry"
+      dataset: osm-planet
+      provider: osm
+      resource: planet
+      version: '2078-08-28T14:44:41Z'
+    - property: "/properties/name"
+      dataset: metaML-buildings
+      provider: meta
+      resource: ml-buildings
+      version: 'abcdef'
+    - property: "/properties/height"
+      dataset: microsoft-buildings
+      provider: microsoft
+      resource: buildings
+      version: '352'

--- a/examples/buildings/sources-with-version.yaml
+++ b/examples/buildings/sources-with-version.yaml
@@ -17,7 +17,7 @@ properties:
     - property: "/properties/name"
       dataset: metaML-buildings
       provider: meta
-      resource: ml-buildings
+      resource: ml_buildings
       version: 'abcdef'
     - property: "/properties/height"
       dataset: microsoft-buildings

--- a/packages/overture-schema-addresses-theme/tests/address_baseline_schema.json
+++ b/packages/overture-schema-addresses-theme/tests/address_baseline_schema.json
@@ -54,15 +54,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-addresses-theme/tests/address_baseline_schema.json
+++ b/packages/overture-schema-addresses-theme/tests/address_baseline_schema.json
@@ -55,9 +55,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -67,9 +67,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
@@ -75,15 +75,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/bathymetry_baseline_schema.json
@@ -76,9 +76,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -88,9 +88,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
@@ -384,15 +384,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/infrastructure_baseline_schema.json
@@ -385,9 +385,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -397,9 +397,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-base-theme/tests/land_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_baseline_schema.json
@@ -258,9 +258,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -270,9 +270,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-base-theme/tests/land_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_baseline_schema.json
@@ -257,15 +257,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
@@ -93,9 +93,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -105,9 +105,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_cover_baseline_schema.json
@@ -92,15 +92,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
@@ -335,15 +335,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/land_use_baseline_schema.json
@@ -336,9 +336,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -348,9 +348,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-base-theme/tests/water_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/water_baseline_schema.json
@@ -189,9 +189,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -201,9 +201,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-base-theme/tests/water_baseline_schema.json
+++ b/packages/overture-schema-base-theme/tests/water_baseline_schema.json
@@ -188,15 +188,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
@@ -372,9 +372,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -384,9 +384,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_baseline_schema.json
@@ -371,15 +371,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
@@ -258,9 +258,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -270,9 +270,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
+++ b/packages/overture-schema-buildings-theme/tests/building_part_baseline_schema.json
@@ -257,15 +257,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-common/src/overture/schema/common/sources.py
+++ b/packages/overture-schema-common/src/overture/schema/common/sources.py
@@ -86,6 +86,39 @@ class SourceItem(BaseModel):
             """).strip()
         ),
     ] = None
+    provider: Annotated[
+        str | None,
+        Field(
+            min_length=1,
+            pattern=r"^[a-z0-9][a-z0-9._-]*$",
+            description=textwrap.dedent("""
+                The provider label (lowercase with no white space) for the entity that contributed this data
+                (e.g., osm, meta, esri).
+            """).strip(),
+        ),
+    ] = None
+    resource: Annotated[
+        str | None,
+        Field(
+            min_length=1,
+            pattern=r"^[a-z0-9][a-z0-9._-]*$",
+            description=textwrap.dedent("""
+                The subject or type of data contributed by the provider (lowercase with no white space)
+                (e.g., planet, buildings, division-names).
+            """).strip(),
+        ),
+    ] = None
+    version: Annotated[
+        str | None,
+        Field(
+            min_length=1,
+            pattern=r"^\S+$",
+            description=textwrap.dedent("""
+                A sortable identifier for the specific snapshot of the resource
+                (e.g., 2026-02-13, 5.3, A5692).
+            """).strip(),
+        ),
+    ] = None
 
 
 Sources = NewType(

--- a/packages/overture-schema-common/src/overture/schema/common/sources.py
+++ b/packages/overture-schema-common/src/overture/schema/common/sources.py
@@ -12,7 +12,12 @@ from overture.schema.common.scoping import Scope, scoped
 from overture.schema.common.types import ConfidenceScore
 from overture.schema.system.field_constraint import UniqueItemsConstraint
 from overture.schema.system.model_constraint import no_extra_fields
-from overture.schema.system.string import JsonPointer, StrippedString
+from overture.schema.system.string import (
+    JsonPointer,
+    NoWhitespaceString,
+    SnakeCaseString,
+    StrippedString,
+)
 
 
 @no_extra_fields
@@ -87,32 +92,29 @@ class SourceItem(BaseModel):
         ),
     ] = None
     provider: Annotated[
-        str | None,
+        SnakeCaseString | None,
         Field(
             min_length=1,
-            pattern=r"^[a-z0-9][a-z0-9._-]*$",
             description=textwrap.dedent("""
-                The provider label (lowercase with no white space) for the entity that contributed this data
+                The provider label for the entity that contributed this data
                 (e.g., osm, meta, esri).
             """).strip(),
         ),
     ] = None
     resource: Annotated[
-        str | None,
+        SnakeCaseString | None,
         Field(
             min_length=1,
-            pattern=r"^[a-z0-9][a-z0-9._-]*$",
             description=textwrap.dedent("""
-                The subject or type of data contributed by the provider (lowercase with no white space)
-                (e.g., planet, buildings, division-names).
+                The subject or type of data contributed by the provider
+                (e.g., planet, buildings, division_names).
             """).strip(),
         ),
     ] = None
     version: Annotated[
-        str | None,
+        NoWhitespaceString | None,
         Field(
             min_length=1,
-            pattern=r"^\S+$",
             description=textwrap.dedent("""
                 A sortable identifier for the specific snapshot of the resource
                 (e.g., 2026-02-13, 5.3, A5692).

--- a/packages/overture-schema-common/tests/test_models.py
+++ b/packages/overture-schema-common/tests/test_models.py
@@ -61,12 +61,12 @@ def test_feature_json_schema() -> None:
                     "dataset": {"type": "string"},
                     "provider": {
                         "minLength": 1,
-                        "pattern": "^[a-z0-9][a-z0-9._-]*$",
+                        "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
                         "type": "string",
                     },
                     "resource": {
                         "minLength": 1,
-                        "pattern": "^[a-z0-9][a-z0-9._-]*$",
+                        "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
                         "type": "string",
                     },
                     "version": {

--- a/packages/overture-schema-common/tests/test_models.py
+++ b/packages/overture-schema-common/tests/test_models.py
@@ -6,12 +6,12 @@ import pytest
 from deepdiff import DeepDiff
 from overture.schema.common.models import OvertureFeature
 from overture.schema.common.sources import SourceItem
-from pydantic import ValidationError
 from overture.schema.system.json_schema import GenerateOmitNullableOptionalJsonSchema
 from overture.schema.system.primitive import (
     BBox,
     Geometry,
 )
+from pydantic import ValidationError
 from shapely.geometry import LineString, Point
 
 

--- a/packages/overture-schema-common/tests/test_models.py
+++ b/packages/overture-schema-common/tests/test_models.py
@@ -5,6 +5,8 @@ from typing import Any
 import pytest
 from deepdiff import DeepDiff
 from overture.schema.common.models import OvertureFeature
+from overture.schema.common.sources import SourceItem
+from pydantic import ValidationError
 from overture.schema.system.json_schema import GenerateOmitNullableOptionalJsonSchema
 from overture.schema.system.primitive import (
     BBox,
@@ -57,6 +59,21 @@ def test_feature_json_schema() -> None:
                     },
                     "property": {"type": "string"},
                     "dataset": {"type": "string"},
+                    "provider": {
+                        "minLength": 1,
+                        "pattern": "^[a-z0-9][a-z0-9._-]*$",
+                        "type": "string",
+                    },
+                    "resource": {
+                        "minLength": 1,
+                        "pattern": "^[a-z0-9][a-z0-9._-]*$",
+                        "type": "string",
+                    },
+                    "version": {
+                        "minLength": 1,
+                        "pattern": "^\\S+$",
+                        "type": "string",
+                    },
                     "license": {
                         "pattern": "^(\\S(.*\\S)?)?$",
                         "type": "string",
@@ -510,3 +527,33 @@ def test_feature_validate_json(
     )
 
     assert feature == validated
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["provider", "resource", "version"],
+)
+def test_source_item_rejects_embedded_whitespace(field_name: str) -> None:
+    payload = {
+        "property": "",
+        "dataset": "osm-planet",
+        field_name: "with space",
+    }
+
+    with pytest.raises(ValidationError):
+        SourceItem.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["provider", "resource"],
+)
+def test_source_item_rejects_uppercase_in_provider_resource(field_name: str) -> None:
+    payload = {
+        "property": "",
+        "dataset": "osm-planet",
+        field_name: "ContainsUpper",
+    }
+
+    with pytest.raises(ValidationError):
+        SourceItem.model_validate(payload)

--- a/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
@@ -216,15 +216,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_area_baseline_schema.json
@@ -217,9 +217,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -229,9 +229,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
@@ -320,9 +320,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -332,9 +332,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_baseline_schema.json
@@ -319,15 +319,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
@@ -107,9 +107,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -119,9 +119,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
+++ b/packages/overture-schema-divisions-theme/tests/division_boundary_baseline_schema.json
@@ -106,15 +106,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-places-theme/tests/place_baseline_schema.json
+++ b/packages/overture-schema-places-theme/tests/place_baseline_schema.json
@@ -283,15 +283,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-places-theme/tests/place_baseline_schema.json
+++ b/packages/overture-schema-places-theme/tests/place_baseline_schema.json
@@ -284,9 +284,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -296,9 +296,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
@@ -39,15 +39,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/connector_baseline_schema.json
@@ -40,9 +40,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -52,9 +52,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
@@ -1165,15 +1165,36 @@
           "title": "Property",
           "type": "string"
         },
+        "provider": {
+          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Provider",
+          "type": "string"
+        },
         "record_id": {
           "description": "Identifies the specific record within the source dataset where the source data can\nbe found.\n\nThe format of record identifiers is dataset-specific.",
           "title": "Record Id",
+          "type": "string"
+        },
+        "resource": {
+          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "title": "Resource",
           "type": "string"
         },
         "update_time": {
           "description": "Last update time of the source data record.",
           "format": "date-time",
           "title": "Update Time",
+          "type": "string"
+        },
+        "version": {
+          "description": "A sortable identifier for the specific snapshot of the resource\n(e.g., 2026-02-13, 5.3, A5692).",
+          "minLength": 1,
+          "pattern": "^\\S+$",
+          "title": "Version",
           "type": "string"
         }
       },

--- a/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
+++ b/packages/overture-schema-transportation-theme/tests/segment_baseline_schema.json
@@ -1166,9 +1166,9 @@
           "type": "string"
         },
         "provider": {
-          "description": "The provider label (lowercase with no white space) for the entity that contributed this data\n(e.g., osm, meta, esri).",
+          "description": "The provider label for the entity that contributed this data\n(e.g., osm, meta, esri).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Provider",
           "type": "string"
         },
@@ -1178,9 +1178,9 @@
           "type": "string"
         },
         "resource": {
-          "description": "The subject or type of data contributed by the provider (lowercase with no white space)\n(e.g., planet, buildings, division-names).",
+          "description": "The subject or type of data contributed by the provider\n(e.g., planet, buildings, division_names).",
           "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "pattern": "^[a-z0-9]+(_[a-z0-9]+)*$",
           "title": "Resource",
           "type": "string"
         },

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -260,13 +260,14 @@ description: Common schema definitions shared by all themes
       enum: [left, right]
     sourcePropertyItem:
       description: >-
-        An object storing the source for a specificed property. The property
+        An object storing the source for a specified property. The property
         is a reference to the property element within this Feature, and will be
         referenced using JSON Pointer Notation RFC 6901
-        (https://datatracker.ietf.org/doc/rfc6901/). The source dataset for
-        that referenced property will be specified in the overture list of
-        approved sources from the Overture Data Working Group that contains
-        the relevant metadata for that dataset including license source organization.
+        (https://datatracker.ietf.org/doc/rfc6901/). The source is currently
+        identified by the dataset field, but will, in the future, be replaced
+        by the combination of provider, resource, and version fields.
+        Additional metadata such as license, record_id, update_time, and
+        confidence may also be provided.
       type: object
       required: [property, dataset]
       allOf:
@@ -292,14 +293,31 @@ description: Common schema definitions shared by all themes
           type: number
           minimum: 0
           maximum: 1
+        provider:
+          type: string
+          description: >-
+            The Provider Label for the entity that produced this data
+            (e.g. osm, meta, esri).
+          minLength: 1
+        resource:
+          type: string
+          description: >-
+            The subject or type of data provided by the provider (e.g. planet,
+            buildings, division-names).
+          minLength: 1
+        version:
+          type: string
+          description: >-
+            A sortable identifier for the specific snapshot of the resource
+            (e.g. 2026-02-13, 5.3, A5692).
+          minLength: 1
     sources:
       description: >-
         The array of source information for the properties of a
         given feature, with each entry being a source object which
-        lists the property in JSON Pointer notation and the dataset
-        that specific value came from. All features must have a root
-        level source which is the default source if a specific
-        property's source is not specified.
+        lists the property in JSON Pointer notation. All features
+        must have a root level source which is the default source
+        if a specific property's source is not specified.
       type: array
       items: {"$ref" : "#/$defs/propertyDefinitions/sourcePropertyItem"}
       minItems: 1

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -294,19 +294,19 @@ description: Common schema definitions shared by all themes
           minimum: 0
           maximum: 1
         provider:
-          type: string
+          type: [string, "null"]
           description: >-
             The Provider Label for the entity that produced this data
             (e.g. osm, meta, esri).
           minLength: 1
         resource:
-          type: string
+          type: [string, "null"]
           description: >-
             The subject or type of data provided by the provider (e.g. planet,
             buildings, division-names).
           minLength: 1
         version:
-          type: string
+          type: [string, "null"]
           description: >-
             A sortable identifier for the specific snapshot of the resource
             (e.g. 2026-02-13, 5.3, A5692).

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -296,13 +296,13 @@ description: Common schema definitions shared by all themes
         provider:
           type: [string, "null"]
           description: >-
-            The Provider Label for the entity that produced this data
+            The Provider Label for the entity that contributed this data
             (e.g. osm, meta, esri).
           minLength: 1
         resource:
           type: [string, "null"]
           description: >-
-            The subject or type of data provided by the provider (e.g. planet,
+            The subject or type of data contributed by the provider (e.g. planet,
             buildings, division-names).
           minLength: 1
         version:

--- a/schema/defs.yaml
+++ b/schema/defs.yaml
@@ -294,19 +294,19 @@ description: Common schema definitions shared by all themes
           minimum: 0
           maximum: 1
         provider:
-          type: [string, "null"]
+          type: string
           description: >-
             The Provider Label for the entity that contributed this data
             (e.g. osm, meta, esri).
           minLength: 1
         resource:
-          type: [string, "null"]
+          type: string
           description: >-
             The subject or type of data contributed by the provider (e.g. planet,
             buildings, division-names).
           minLength: 1
         version:
-          type: [string, "null"]
+          type: string
           description: >-
             A sortable identifier for the specific snapshot of the resource
             (e.g. 2026-02-13, 5.3, A5692).


### PR DESCRIPTION
# Background

The intent of this change is to update our source item field to include the information necessary for data provenance:
```
- provider: The name of the entity that produced the data: meta, esri, microsoft, osm, etc.
- resource: The subject or type of data given by the provider: division-names, buildings, planet, etc.
- version: The sortable identifier such as a date or number: 2026-02-13, 5.3, A5692
```
Together, along with the version_id these values allow a user to uniquely identify what raw input data was used to construct Overture data. Our current system, of providing only a dataset is lacking dataset version information but is also inconsistently constructed. All three new fields will be nullable and optional to start as this is the first step where we are making it so the pipeline can populate these fields.

## Major change release plan
While this change in itself is not a breaking change, it is part of a larger plan with major impact. The rough timeline for these changes is:

- Update the schema to add `provider` + `resource` + `version` details as optional fields (this PR - June / July)
- Non-schema work for pipelines to populate the new fields
- Update the schema to A) make `provider` + `resource` + `version` required fields and B) mark `dataset` as deprecated and make it an optional field. (BREAKING - September)
- Update the schema and code to remove the `dataset` field. (BREAKING - March 2027 or later)

Messaging around this change is that the current method of providing provenance is not sufficient to ensure traceability. Besides documenting the deprecation of `dataset` we will want to provide details on how the `provider`,  `resource`, `version` work together to identify a data snapshot.

Closes #530

# Testing

A couple of new examples / counterexamples have been added. In particular one to check that the length of each of the provided fields is at least 1 and a second which shows what properly populated fields look like.

The tests were then run with the following results:

```
  ## Test Results
  
  | Result | Count |
  |--------|-------|
  | ✅ Passed | 1993 |
  | ❌ Failed | 0 |
  | ⚠️  Errors | 0 |

  **Duration:** 5.21s
```

# Documentation website
[Docs preview for this PR.](https://staging.overturemaps.org/schema/pr/535/schema/index.html)
