### PR TITLE
[BUG](ci) Vnext rebase workflow needs broader permissions

### DIFF
--- a/.github/workflows/rebase-vnext.yaml
+++ b/.github/workflows/rebase-vnext.yaml
@@ -36,9 +36,10 @@ jobs:
           client-id: Iv23liiN80WEARreTV7m
           private-key: ${{ secrets.OVERTURE_PULL_REQUESTER_APP_PEM }} # zizmor: ignore[secrets-outside-env]
           # Explicitly scope the app token instead of inheriting all installation permissions.
-          permission-contents: write
-          permission-issues: write
-          permission-pull-requests: read
+          permission-contents: write        # force-push the rebased vnext; clone/fetch
+          permission-issues: write          # open a failure issue on rebase conflict
+          permission-pull-requests: read    # read PR on merge commit to detect vnext→main release
+          permission-workflows: write       # vnext commits may touch .github/workflows/**
 
       # Detect whether this push was a vnext→main release merge.
       # The GitHub API returns the PR(s) associated with the merge commit.


### PR DESCRIPTION
# Description

The [`Rebase vnext onto main`](https://github.com/OvertureMaps/schema/actions/workflows/rebase-vnext.yaml) had been failing until the GitHub app permissions were updated, and is now working. 

This pull request makes additional workflow-level permission changes to ensure that all code paths are accounted for, whereas before there may have been latent permission errors lurking.


# Reference
N/A

# Testing

The workflow has been [successfully re-run](https://github.com/OvertureMaps/schema/actions/runs/26953977727) post updating of the App permissions, confirming it is fixed.


