### PR TITLE
[CHORE] Drop unused __about__.py files from Python packages

### DIFF
--- a/packages/overture-schema-addresses-theme/src/overture/schema/addresses/__about__.py
+++ b/packages/overture-schema-addresses-theme/src/overture/schema/addresses/__about__.py
@@ -1,6 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("overture-schema-addresses-theme")
-except PackageNotFoundError:
-    __version__ = "unknown"

--- a/packages/overture-schema-annex/src/overture/schema/__about__.py
+++ b/packages/overture-schema-annex/src/overture/schema/__about__.py
@@ -1,6 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("overture-schema-annex")
-except PackageNotFoundError:
-    __version__ = "unknown"

--- a/packages/overture-schema-base-theme/src/overture/schema/base/__about__.py
+++ b/packages/overture-schema-base-theme/src/overture/schema/base/__about__.py
@@ -1,6 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("overture-schema-base-theme")
-except PackageNotFoundError:
-    __version__ = "unknown"

--- a/packages/overture-schema-buildings-theme/src/overture/schema/buildings/__about__.py
+++ b/packages/overture-schema-buildings-theme/src/overture/schema/buildings/__about__.py
@@ -1,6 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("overture-schema-buildings-theme")
-except PackageNotFoundError:
-    __version__ = "unknown"

--- a/packages/overture-schema-cli/src/overture/schema/cli/__about__.py
+++ b/packages/overture-schema-cli/src/overture/schema/cli/__about__.py
@@ -1,6 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("overture-schema-cli")
-except PackageNotFoundError:
-    __version__ = "unknown"

--- a/packages/overture-schema-codegen/src/overture/schema/codegen/__about__.py
+++ b/packages/overture-schema-codegen/src/overture/schema/codegen/__about__.py
@@ -1,6 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("overture-schema-codegen")
-except PackageNotFoundError:
-    __version__ = "unknown"

--- a/packages/overture-schema-common/src/overture/schema/common/__about__.py
+++ b/packages/overture-schema-common/src/overture/schema/common/__about__.py
@@ -1,6 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("overture-schema-common")
-except PackageNotFoundError:
-    __version__ = "unknown"

--- a/packages/overture-schema-divisions-theme/src/overture/schema/divisions/__about__.py
+++ b/packages/overture-schema-divisions-theme/src/overture/schema/divisions/__about__.py
@@ -1,6 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("overture-schema-divisions-theme")
-except PackageNotFoundError:
-    __version__ = "unknown"

--- a/packages/overture-schema-places-theme/src/overture/schema/places/__about__.py
+++ b/packages/overture-schema-places-theme/src/overture/schema/places/__about__.py
@@ -1,6 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("overture-schema-places-theme")
-except PackageNotFoundError:
-    __version__ = "unknown"

--- a/packages/overture-schema-system/src/overture/schema/system/__about__.py
+++ b/packages/overture-schema-system/src/overture/schema/system/__about__.py
@@ -1,6 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("overture-schema-system")
-except PackageNotFoundError:
-    __version__ = "unknown"

--- a/packages/overture-schema-transportation-theme/src/overture/schema/transportation/__about__.py
+++ b/packages/overture-schema-transportation-theme/src/overture/schema/transportation/__about__.py
@@ -1,6 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("overture-schema-transportation-theme")
-except PackageNotFoundError:
-    __version__ = "unknown"

--- a/packages/overture-schema/src/overture/schema/__about__.py
+++ b/packages/overture-schema/src/overture/schema/__about__.py
@@ -1,6 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("overture-schema")
-except PackageNotFoundError:
-    __version__ = "unknown"


### PR DESCRIPTION
Closes #549.

Deletes the 12 `__about__.py` version shims. #534 moved every package to a static `version` in `pyproject.toml` and rewrote the shims to read `importlib.metadata`; nothing references `__about__` or `__version__` anywhere in the tree (verified across `packages/`, `.github/`, and the `Makefile` on current `main`).

#534 has merged, so this PR now targets `main` and drops the shims as dead code.
