### PR TITLE
[BUG] Fix typing_extensions 4.16.0 Sentinel repr break in lowest-direct CI leg

### DIFF
--- a/packages/overture-schema-system/pyproject.toml
+++ b/packages/overture-schema-system/pyproject.toml
@@ -15,6 +15,7 @@ license = "MIT"
 dependencies = [
     "pydantic>=2.12.0",
     "shapely>=2.0.0",
+    "typing-extensions>=4.16",
 ]
 
 [project.urls]

--- a/packages/overture-schema-system/src/overture/schema/system/feature.py
+++ b/packages/overture-schema-system/src/overture/schema/system/feature.py
@@ -170,7 +170,7 @@ class Feature(BaseModel):
     ...         "subtype": "barb_wire_4"
     ...     }
     ... }''')
-    Fence(id=<MISSING>, bbox=<MISSING>, geometry=<<LINESTRING (0 0, 0 0.01)>>, type='fence', subtype='barb_wire_4', height=None)
+    Fence(id=MISSING, bbox=MISSING, geometry=<<LINESTRING (0 0, 0 0.01)>>, type='fence', subtype='barb_wire_4', height=None)
 
     You can model classes that are not `Feature` subclasses in `field_discriminator` to enable
     discriminated unions between features and non-features, as long as at least one model class is

--- a/uv.lock
+++ b/uv.lock
@@ -8,8 +8,9 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-01T14:14:05.273797Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
+
 [manifest]
 members = [
     "overture-schema",
@@ -374,7 +375,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1092,6 +1093,7 @@ source = { editable = "packages/overture-schema-system" }
 dependencies = [
     { name = "pydantic" },
     { name = "shapely" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -1105,6 +1107,7 @@ dev = [
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "shapely", specifier = ">=2.0.0" },
+    { name = "typing-extensions", specifier = ">=4.16" },
 ]
 
 [package.metadata.requires-dev]
@@ -1646,11 +1649,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #554.

typing-extensions 4.16.0 (2026-07-02) changed the repr of its `Sentinel` from `<MISSING>` to `MISSING`. pydantic's experimental `MISSING` sentinel delegates its repr to `typing_extensions.Sentinel`, so the `Feature` doctest in `overture-schema-system` — which pins the rendered repr — breaks against 4.16.0.

The default CI legs install from `uv.lock` (pinned to 4.15.0) and pass; the `lowest-direct` leg re-resolves transitives to latest, picks up 4.16.0, and fails on every branch and PR, independent of the change under test.

**Fix**

- Update the doctest expectation to the current repr (`MISSING`).
- Re-lock `typing-extensions` to 4.16.0 so the default legs agree.
- Floor `typing-extensions>=4.16` as a direct dependency of `overture-schema-system`. The sentinel repr is load-bearing for its doctest, so flooring it makes the `lowest-direct` resolution deterministic at 4.16.0 rather than floating to whatever transitive is newest.

Verified locally: the doctest passes under both the committed lock (4.16.0) and a `lowest-direct` re-resolution (which now floors `typing-extensions` to 4.16.0). Independent of #551 — lands cleanly before it; once merged, #551 needs a rebase onto `main` to turn its `lowest-direct` leg green.
