### PR TITLE
[BUG](pyspark) Honor string min_length in base-row generation

### DIFF
--- a/packages/overture-schema-codegen/src/overture/schema/codegen/pyspark/test_data/base_row.py
+++ b/packages/overture-schema-codegen/src/overture/schema/codegen/pyspark/test_data/base_row.py
@@ -683,10 +683,16 @@ def _value_from_check_enum(
 
 
 def _value_from_check_string_min_length(
-    _desc: ExpressionDescriptor, _scalar: Primitive, _cs: ConstraintSource
+    desc: ExpressionDescriptor, _scalar: Primitive, _cs: ConstraintSource
 ) -> str:
-    """Return any single character; satisfies `min_length>=1` for every schema today."""
-    return "a"
+    """Return a filler string of exactly `min_length` characters.
+
+    The descriptor's sole arg is the `min_length` bound. A shorter string
+    (a single character against `min_length > 1`) would violate the
+    constraint, making the generated conformance ::valid row invalid.
+    """
+    min_length: int = desc.args[0]  # type: ignore[assignment]
+    return "a" * min_length
 
 
 def _value_from_check_pattern(

--- a/packages/overture-schema-codegen/tests/test_pyspark_base_row.py
+++ b/packages/overture-schema-codegen/tests/test_pyspark_base_row.py
@@ -21,6 +21,7 @@ from overture.schema.codegen.extraction.field import (
     Primitive,
 )
 from overture.schema.codegen.extraction.field_walk import terminal_of
+from overture.schema.codegen.extraction.length_constraints import ScalarMinLen
 from overture.schema.codegen.extraction.model_extraction import extract_model
 from overture.schema.codegen.extraction.specs import (
     FieldSpec,
@@ -361,6 +362,37 @@ class TestRawPatternFailsLoud:
         )
         with pytest.raises(ValueError, match="check_pattern"):
             value_for_field(field, "Foo")
+
+
+class TestStringMinLengthBaseRow:
+    """A string field with `min_length > 1` gets a value long enough to pass.
+
+    The synthesizer must emit a string of at least `min_length` characters:
+    a single character satisfies `min_length == 1` but violates any larger
+    bound, which would make the generated conformance ::valid row invalid.
+    """
+
+    def test_scalar_constraints_honor_min_length(self) -> None:
+        scalar = Primitive(
+            base_type="str",
+            constraints=(
+                ConstraintSource(
+                    source_ref=None,
+                    source_name=None,
+                    constraint=ScalarMinLen(min_length=3),
+                ),
+            ),
+        )
+        val = _value_from_scalar_constraints(scalar)
+        assert isinstance(val, str)
+        assert len(val) >= 3
+
+    def test_base_row_string_min_length_passes_pydantic(self) -> None:
+        class StringMinLengthModel(BaseModel):
+            code: str = Field(min_length=3)
+
+        row = generate_base_row(spec_for_model(StringMinLengthModel))
+        StringMinLengthModel(**row)
 
 
 class TestValueForShapeScalarVariants:


### PR DESCRIPTION
## Summary

`_value_from_check_string_min_length` (base-row test-data synthesis) ignored the descriptor's `min_length` and always returned a single character. For any string field with `min_length > 1`, the synthesized base/valid row value (`'a'`, length 1) already violates the constraint -- so the generated conformance `::valid` row would be invalid and the `::invalid` scenario's baseline wrong.

The fix reads the `min_length` bound from the descriptor and emits a filler of that length (`'a' * min_length`).

## Scope

Latent on `main` today: no live schema field declares a string `min_length > 1`, so the conformance suite stays green and generated output is unchanged. The defect surfaced while working the generalize-field-path branch, where a mixed-shape test had to use `min_length=1` rather than `3` to keep its valid row valid. Genuinely orthogonal to that branch -- it does not mask a defect in #570.

The analogous array min-length synthesizer (`_min_length_from_shape_constraints`) already reads `min_length` correctly and generates that many elements; string max-length and array max-length are not lower bounds and need no base-row value. The string min-length synthesizer was the sole offender.

Part of and partly closes #517.
