### PR TITLE
[BUG] make install does not regenerate overture-schema-pyspark's codegen output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TESTMON ?= --testmon
 
 default: test-all
 
-install: uv-sync
+install: uv-sync generate-pyspark
 
 uv-sync:
 	@output=$$(uv sync --all-packages --all-extras 2>&1) || { echo "$$output" >&2; exit 1; }


### PR DESCRIPTION
## Summary

- `make install` only ran `uv-sync`, never `generate-pyspark`. The generated PySpark expressions and conformance tests aren't tracked in git, so a fresh worktree following the documented check out -> `make install` flow ended up with neither.
- A plain `pytest` run afterward silently collected thousands fewer tests than the full suite, with no error to signal the gap -- discovered while verifying rebases of several other PRs against fresh worktrees.
- `install` now depends on `generate-pyspark`, matching what `check` and `test-all` already do.

Closes #579.

## Test plan

- [x] Fresh worktree, `make install`, confirm `expressions/generated` and `tests/generated` are populated
- [x] Full test suite passes with freshly generated code (6307 passed)