### PR TITLE
[DOCS] Clear pydocstyle errors in codegen and pyspark

### DIFF
--- a/packages/overture-schema-codegen/src/overture/schema/codegen/markdown/type_format.py
+++ b/packages/overture-schema-codegen/src/overture/schema/codegen/markdown/type_format.py
@@ -238,7 +238,7 @@ def _map_side_link(shape: FieldShape, ctx: LinkContext | None) -> str | None:
 
 
 def _bare_map_side_name(shape: FieldShape) -> str:
-    """Bare markdown name for a map key/value, recursing through containers.
+    r"""Bare markdown name for a map key/value, recursing through containers.
 
     Every variant resolves to a real name: `list<...>` / `map<...>`
     wrappers recurse, scalars use their registry name (so `Any` is `Any`,
@@ -248,7 +248,7 @@ def _bare_map_side_name(shape: FieldShape) -> str:
     bug, not a placeholder.
 
     A union-valued map is the one shape left unrendered: no schema field
-    uses one, and its `\\|`-separated members do not compose cleanly into
+    uses one, and its `\|`-separated members do not compose cleanly into
     a bare `map<...>` span. It raises so the gap surfaces loudly when a
     field first needs it, rather than shipping a half-rendered value.
     """

--- a/packages/overture-schema-codegen/src/overture/schema/codegen/pyspark/_render_common.py
+++ b/packages/overture-schema-codegen/src/overture/schema/codegen/pyspark/_render_common.py
@@ -84,7 +84,7 @@ _MAP_RUNTIME_HELPERS: dict[MapProjection, str] = {
 
 
 def map_runtime_helper(projection: MapProjection) -> str:
-    """PySpark column-patterns helper name for a map projection.
+    """Map a projection to its PySpark column-patterns helper name.
 
     `MapProjection.KEY` -> `map_keys_check`;
     `MapProjection.VALUE` -> `map_values_check`. This is a pyspark-layer

--- a/packages/overture-schema-codegen/src/overture/schema/codegen/pyspark/constraint_dispatch.py
+++ b/packages/overture-schema-codegen/src/overture/schema/codegen/pyspark/constraint_dispatch.py
@@ -173,11 +173,11 @@ def compiled_pattern_source(pattern: re.Pattern[str]) -> str:
 
 
 def normalize_anchor(pattern: str) -> str:
-    """Replace trailing `$` with `\\z` for Java/Spark regex compatibility.
+    r"""Replace trailing `$` with `\z` for Java/Spark regex compatibility.
 
     Uses backslash-parity to distinguish a real anchor from an escaped
     literal `$`. Counts the run of backslashes immediately before the
-    final `$`: an even count means `$` is unescaped (convert to `\\z`);
+    final `$`: an even count means `$` is unescaped (convert to `\z`);
     an odd count means it is an escaped literal `$` (leave unchanged).
     """
     if not pattern.endswith("$"):

--- a/packages/overture-schema-codegen/src/overture/schema/codegen/pyspark/test_data/base_row.py
+++ b/packages/overture-schema-codegen/src/overture/schema/codegen/pyspark/test_data/base_row.py
@@ -245,7 +245,7 @@ def _build_arm_rows(
 
 
 def _condition_value(field_eq: FieldEq) -> object:
-    """The condition's comparison value, with an `Enum` unwrapped to its value.
+    """Return the condition's comparison value, with an `Enum` unwrapped to its value.
 
     Row dicts store raw scalar values, so an `Enum`-typed condition value is
     compared and written as its underlying `.value`.

--- a/packages/overture-schema-pyspark/src/overture/schema/pyspark/cli.py
+++ b/packages/overture-schema-pyspark/src/overture/schema/pyspark/cli.py
@@ -34,7 +34,7 @@ class ReadSpec:
 
 
 def absent_column(exc: AnalysisException, columns: Collection[str]) -> str | None:
-    """The top-level column an unresolved-column error names, if absent from data.
+    """Return the top-level column named by an unresolved-column error, if absent.
 
     Returns the column name only when `exc` is an `UNRESOLVED_COLUMN` error
     whose target is genuinely missing from `columns` -- the case a re-run with

--- a/packages/overture-schema-pyspark/src/overture/schema/pyspark/expressions/constraint_expressions.py
+++ b/packages/overture-schema-pyspark/src/overture/schema/pyspark/expressions/constraint_expressions.py
@@ -133,14 +133,14 @@ def check_required(col: Column) -> Column:
 
 
 def check_pattern(col: Column, pattern: str, *, label: str) -> Column:
-    """Regex pattern check via rlike.  Returns error string or null.
+    r"""Regex pattern check via rlike.  Returns error string or null.
 
     Parameters
     ----------
     col
         Column to validate.
     pattern
-        Java regex pattern (use `\\z` for absolute end-of-input).
+        Java regex pattern (use `\z` for absolute end-of-input).
     label
         Human-readable description used in error messages:
         `"invalid {label}: got '...'"`
@@ -150,8 +150,8 @@ def check_pattern(col: Column, pattern: str, *, label: str) -> Column:
     `rlike` runs Java's regex engine against patterns authored for Python's
     `re` (the engine Pydantic validates with).  The dialects coincide on the
     ASCII character ranges the schema patterns use, but diverge on the
-    shorthand classes: Java's `\\d \\s \\w \\S` are ASCII-only while Python's
-    are Unicode, so e.g. `^\\S+$` accepts a non-breaking space here that
+    shorthand classes: Java's `\d \s \w \S` are ASCII-only while Python's
+    are Unicode, so e.g. `^\S+$` accepts a non-breaking space here that
     Pydantic rejects, and `.` excludes a different set of line terminators.
     These divergences are accepted -- the affected inputs (Unicode digits,
     exotic whitespace) do not occur in practice for the constrained fields.
@@ -243,12 +243,12 @@ def check_array_max_length(col: Column, max_len: int) -> Column:
 
 
 def check_string_min_length(col: Column, min_len: int) -> Column:
-    """String minimum character length check.  Returns error string or null."""
+    """Minimum character length check for strings.  Returns error string or null."""
     return _check_length(col, F.length(col), min_len, direction="minimum")
 
 
 def check_string_max_length(col: Column, max_len: int) -> Column:
-    """String maximum character length check.  Returns error string or null."""
+    """Maximum character length check for strings.  Returns error string or null."""
     return _check_length(col, F.length(col), max_len, direction="maximum")
 
 


### PR DESCRIPTION
## Summary

`make docformat` (pydocstyle, numpy convention) flagged eight docstrings across `overture-schema-codegen` and `overture-schema-pyspark`. This clears all of them. Docstring text only, no runtime behavior change.

## Fixes

- **D301 (raw string for backslashes)** — `_bare_map_side_name`, `normalize_anchor`, `check_pattern`: switch to `r"""` and drop the doubled backslashes so the rendered text (`\|`, `\z`, `\d \s \w \S`) is unchanged.
- **D401 (imperative mood)** — `_condition_value`, `absent_column`: reword the summary to lead with a verb.
- **D401 on `check_string_min_length` / `check_string_max_length`** — pydocstyle's stemmer trips on a leading "String"; the summaries now read "Minimum/Maximum character length check for strings", parallel to the sibling `check_array_*` docstrings.
- **D403 on `map_runtime_helper`** — the check lowercases the proper noun "PySpark" to "Pyspark"; reworded so PySpark is no longer the first word.

## Scope

Limited to the two named packages. Other packages (annex, common, system, transportation-theme) have separate missing-docstring errors (D100/D101) not addressed here.

Closes #581
