### PR TITLE
[DOCS] Fix docformat errors in system package

### DIFF
--- a/packages/overture-schema-system/src/overture/schema/system/optionality.py
+++ b/packages/overture-schema-system/src/overture/schema/system/optionality.py
@@ -1,4 +1,7 @@
-from enum import Enum
+"""
+Optional types.
+"""
+
 from types import NoneType, UnionType
 from typing import Annotated, Any, Generic, TypeVar, Union, get_args, get_origin
 
@@ -69,18 +72,6 @@ class Omitable(Generic[T]):
                 f"`None` not allowed in `{Omitable.__name__}` args, but found `None` in {item}"
             )
         return Annotated[item | MISSING, Field(default=MISSING)]
-
-
-# todo - Vic - finish this
-class Optionality(str, Enum):
-    # This is for implementing the model constraints more cleverly.
-    #       Noneable -> It is allowed to be `null` in JSON Schema.
-    #                   To make it @required, need to take away the right to set `null`.
-    #
-    #
-    OMITABLE = ("omitable",)
-    NONEABLE = ("noneable",)
-    NOT_OPTIONAL = ("not_optional",)
 
 
 def _has_none(value: Any) -> bool:

--- a/packages/overture-schema-system/src/overture/schema/system/ref/ref.py
+++ b/packages/overture-schema-system/src/overture/schema/system/ref/ref.py
@@ -13,7 +13,7 @@ _SNAKE_CASE_RE = re.compile(r"^[a-z][a-z0-9]*(_[a-z0-9]+)*$")
 
 
 class Relationship(str, DocumentedEnum):
-    """
+    r"""
     The kind of relationship that exists between two entities.
 
     Relationships represent connections between different features or models. Think of them as links
@@ -33,9 +33,9 @@ class Relationship(str, DocumentedEnum):
     relationship, is at the bottom.
 
                COMPOSITION
-               /         \\
+               /         \
          AGGREGATION   HIERARCHY
-               \\          /
+               \         /
                ASSOCIATION
 
     Note that the *kind* of a relationship does not say anything about the *directionality* of the


### PR DESCRIPTION
This change eliminates `make docformat` errors in `overture-schema-system`, a prerequisite to enforcing `make docformat` in `make check`, which is a prerequisite of GA-ing the amazing new Pydantic-based schema.

Closes #601, an issue I opened bureaucratically just so I could publish this PR!