### PR TITLE
[CHORE](devops) Keep Dependabot uv updates in uv.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # lockfile-only updates uv.lock only -- never pyproject.toml -- and covers
+    # the direct deps declared in the manifests. It does not refresh
+    # transitive-only entries in uv.lock (dependabot-core#14073); the weekly
+    # uv-lock-refresh.yml workflow runs `uv lock --upgrade` for those.
+    versioning-strategy: lockfile-only
     groups:
       # uv doesn't yet support dependency-type filters in groups
       # (dependabot-core#13202), so dev and production deps aren't split here.

--- a/.github/workflows/uv-lock-refresh.yml
+++ b/.github/workflows/uv-lock-refresh.yml
@@ -1,0 +1,54 @@
+name: Refresh uv.lock (transitive deps)
+
+# Dependabot's uv ecosystem runs lockfile-only (see .github/dependabot.yml) and
+# does not refresh transitive-only entries (dependabot-core#14073). This job does
+# that: `uv lock --upgrade` re-resolves every dependency to the newest version
+# each pyproject.toml already allows, touching only uv.lock.
+#
+# Remove this workflow once dependabot-core#14073 is fixed -- tracked in #614.
+
+on:
+  schedule:
+    - cron: "0 8 * * 4" # Thursdays -- offset from Dependabot's Monday run
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: uv-lock-refresh
+  cancel-in-progress: false
+
+jobs:
+  lock:
+    name: Refresh uv.lock
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write # create-pull-request pushes the refresh branch
+      pull-requests: write # create-pull-request opens/updates the PR
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      - run: uv lock --upgrade
+
+      # NOTE: PRs opened with the default GITHUB_TOKEN do not trigger other
+      # workflows, so CI won't run on this PR. Provide a PAT/App token via
+      # `token:` if the lockfile refresh needs to be gated on CI before merge.
+      # create-pull-request stages the diff, commits, pushes a branch, and
+      # opens/updates the PR idempotently; a gh pr create script would
+      # re-implement that and need persisted checkout credentials to push.
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with: # zizmor: ignore[superfluous-actions]
+          commit-message: |
+            [CHORE](deps) refresh uv.lock
+
+            Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          branch: uv-lock-refresh
+          title: "[CHORE](deps) weekly uv.lock refresh"
+          labels: "bot,automation 🦾"
+          body: "Automated `uv lock --upgrade` at the workspace root. Resolves transitive deps that Dependabot's uv ecosystem does not touch. pyproject.toml files are unchanged."


### PR DESCRIPTION
Closes #612.

Restrict Dependabot's uv ecosystem to uv.lock and never edit pyproject.toml, then cover the transitive deps Dependabot leaves behind with a scheduled refresh.

## Changes

- `.github/dependabot.yml`: add `versioning-strategy: lockfile-only` to the uv ecosystem. Dependabot now updates uv.lock only, for the direct deps declared in the manifests.
- `.github/workflows/uv-lock-refresh.yml`: weekly `uv lock --upgrade` job that opens a PR refreshing transitive-only entries in uv.lock. lockfile-only does not touch these (dependabot/dependabot-core#14073). pyproject.toml files stay unchanged.

## Notes

- The refresh workflow's actions are pinned to full SHAs to match the repo convention, and its commit carries a Signed-off-by trailer for the DCO check (github-actions[bot] is not allowlisted the way dependabot[bot] is).
- PRs opened by the default `GITHUB_TOKEN` do not trigger other workflows, so CI will not gate the refresh PR. An in-file NOTE flags this; wiring a PAT/App token via `token:` is the fix if CI gating is wanted.
- lockfile-only opens no PR for a dependency capped in pyproject.toml whose only update exceeds the cap, since it refuses to widen the manifest. `uv lock --upgrade` respects the same caps. Both are inherent to the no-manifest-edits requirement.
