### PR TITLE
[BUG](ci) Generate PySpark expressions before building the published wheel

### DIFF
--- a/.github/workflows/publish-python-packages.yaml
+++ b/.github/workflows/publish-python-packages.yaml
@@ -79,6 +79,16 @@ jobs:
         id: get-code-artifact-params
         uses: ./.github/actions/code-artifact
 
+      # overture-schema-pyspark ships generated validation expressions that are
+      # not committed to git -- they are regenerated on demand from the Pydantic
+      # models. `uv build` packages whatever is on disk under the module root, so
+      # the tree must be generated here before the build, or the published wheel
+      # ships without its `expressions/generated/` modules and validate_model()
+      # discovers nothing to run.
+      - name: Generate PySpark expressions before build
+        if: matrix.package == 'overture-schema-pyspark'
+        run: make generate-pyspark
+
       - name: Publish package ${{ matrix.package }} version ${{ matrix.after }} to PyPI
         env:
           CA_TOKEN: ${{ steps.get-code-artifact-params.outputs.token }}
@@ -92,6 +102,14 @@ jobs:
           wheel="dist/${PACKAGE//-/_}-${AFTER}-py3-none-any.whl"
           if [ ! -f "$wheel" ]; then
             echo "    Wheel file [$wheel] not found. Aborting!"
+            exit 1
+          fi
+          # Guard against a silently empty wheel: if the generate step above ever
+          # regresses, overture-schema-pyspark would publish with no validation
+          # expressions. Fail loudly instead of shipping a hollow package.
+          if [ "$PACKAGE" = "overture-schema-pyspark" ] && \
+             ! unzip -l "$wheel" | grep -q 'expressions/generated/.*\.py'; then
+            echo "    Wheel [$wheel] has no generated expressions -- codegen did not run. Aborting!"
             exit 1
           fi
           tarball="dist/${PACKAGE//-/_}-${AFTER}.tar.gz"

--- a/packages/overture-schema-pyspark/changelog.d/625.bugfix.md
+++ b/packages/overture-schema-pyspark/changelog.d/625.bugfix.md
@@ -1,0 +1,1 @@
+Fixed published wheels and sdists shipping without the generated validation expressions, which left an installed `validate_model()` unable to discover any models.


### PR DESCRIPTION
Fixes #625.

## Problem

`overture-schema-pyspark` ships generated validation expressions that are not present in git; they are regenerated on demand from the Pydantic models. The publish workflow synced the workspace and ran `uv build` with no codegen step, so `expressions/generated/` was absent on disk at build time and the wheel and sdist shipped without it. `_registry.py` walks that namespace at import, so an installed consumer gets an empty `REGISTRY` and `validate_model()` discovers no models. The build produced the empty wheel with no error.

## Change

- Generate the expression tree (`make generate-pyspark`) in the publish workflow before `uv build`, gated to the `overture-schema-pyspark` matrix entry.
- Add a post-build guard: if the pyspark wheel contains no `expressions/generated/*.py`, abort the publish — a silent empty wheel becomes a loud failure.

## Verification

Built the wheel and sdist locally under uv_build:

| Path | generated in wheel | in sdist | guard |
|---|---|---|---|
| no generate step (current CI) | 0 | 0 | fires (aborts) |
| generate step (this PR) | all model modules | all | passes |

The guard checks the wheel; `uv build` builds the wheel from the sdist, so a populated wheel confirms a populated sdist.
