### PR TITLE
[BUG](ci) Tolerate no-package diff in the changelog fragment check

### DIFF
--- a/.github/workflows/require-changelog-fragment.yaml
+++ b/.github/workflows/require-changelog-fragment.yaml
@@ -42,6 +42,10 @@ jobs:
           changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
 
           # Packages with changes outside their own changelog artifacts.
+          # `|| true`: on a PR that touches no package, grep -oE finds no match
+          # and exits 1, which under `set -euo pipefail` would abort the job
+          # with a bare exit 1 and no output -- the same guard the has_* greps
+          # below already use.
           touched=$(echo "$changed" \
             | grep -oE '^packages/[^/]+/' \
             | sort -u \
@@ -52,7 +56,7 @@ jobs:
                   | grep -q .; then
                   echo "$pkg"
                 fi
-              done)
+              done || true)
 
           missing=""
           for pkg in $touched; do


### PR DESCRIPTION
Fixes #635.

## Problem

The `Require changelog on package change` job aborts with a bare `exit 1` on any PR whose diff touches no file under `packages/` (a workflow-only, docs-only, or root-only change). The `touched` pipeline runs `grep -oE "^packages/[^/]+/"` under `set -euo pipefail`; with no `packages/` path in the diff the grep matches nothing and exits 1, the command substitution inherits that status, and `set -e` kills the job before any output. The result is indistinguishable from a real missing-fragment failure: no `::error::`, no package list, just exit 1.

The sibling `has_fragment` / `has_changelog` substitutions already guard their `grep -c` with `|| true`; the `touched` pipeline was missed.

Observed on #626, a workflow-only publish fix, which was forced to carry a fragment to go green.

## Change

Append `|| true` to the `touched` pipeline, matching the existing guard. Real detection is unaffected — a package changed without a fragment still fails.

## Verification

Ran the job logic against four diffs:

| Diff | Before | After |
|---|---|---|
| workflow only (no package) | abort exit 1 (false fail) | pass |
| package changed, no fragment | fail | fail |
| package changed + fragment | pass | pass |
| fragment only | pass | pass |

This PR is itself workflow-only. Because the check is `on: pull_request`, it runs this PR's fixed workflow, so the job exercises the fix on its own diff.