### PR TITLE
[CHORE](ci) Skip changelog fragment check for bot-labeled PRs

### DIFF
--- a/.github/workflows/require-changelog-fragment.yaml
+++ b/.github/workflows/require-changelog-fragment.yaml
@@ -9,6 +9,9 @@ name: Changelog fragment verification
 # package's own changelog artifacts (changelog.d/ and CHANGELOG.md). Every
 # user-facing change gets a fragment, regardless of whether it bumps the
 # version (see docs/versioning.md).
+#
+# PRs labeled `bot` (e.g. Dependabot) skip this check: automated dependency
+# bumps don't carry user-facing changes worth a fragment.
 
 on:
   pull_request:
@@ -25,6 +28,7 @@ jobs:
   check-fragment:
     name: Require changelog on package change
     runs-on: ubuntu-slim
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'bot') }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/require-changelog-fragment.yaml
+++ b/.github/workflows/require-changelog-fragment.yaml
@@ -80,3 +80,19 @@ jobs:
             exit 1
           fi
           echo "Changelog fragment check passed."
+
+  # check-fragment skips for bot-labeled PRs, and branch protection can't
+  # require a job that sometimes doesn't run. This gate always runs and
+  # passes on either a real success or an accepted skip, so it's the check
+  # to require in branch protection instead of check-fragment directly.
+  changelog-fragment-status:
+    name: Changelog fragment check status
+    runs-on: ubuntu-slim
+    needs: [check-fragment]
+    if: always()
+    permissions:
+      contents: read
+    steps:
+      - uses: lowlydba/are-we-good@f506ed6324f55ec5e4ff5d92204a72c7f1c2b4f8 # v1.0.5
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/require-changelog-fragment.yaml
+++ b/.github/workflows/require-changelog-fragment.yaml
@@ -10,8 +10,9 @@ name: Changelog fragment verification
 # user-facing change gets a fragment, regardless of whether it bumps the
 # version (see docs/versioning.md).
 #
-# PRs labeled `bot` (e.g. Dependabot) skip this check: automated dependency
-# bumps don't carry user-facing changes worth a fragment.
+# PRs labeled `bot` skip this check. Dependabot is the only source of that
+# label, and it's scoped to uv.lock and GitHub Actions version bumps, neither
+# of which touches consumer-facing behavior.
 
 on:
   pull_request:

--- a/.github/workflows/require-changelog-fragment.yaml
+++ b/.github/workflows/require-changelog-fragment.yaml
@@ -14,9 +14,9 @@ name: Changelog fragment verification
 # label, and it's scoped to uv.lock and GitHub Actions version bumps, neither
 # of which touches consumer-facing behavior.
 #
-# PRs that only touch .github/ also skip: workflow and CI config aren't
-# packages, so detect-scope's tj-actions/changed-files check (ignoring
-# .github/**) reports no changes and check-fragment never runs.
+# PRs that don't touch packages/ at all also skip: docs, CI config, and
+# other root-level changes were never going to need a fragment, since
+# check-fragment only ever looks at packages/<package>/ paths.
 
 on:
   pull_request:
@@ -31,12 +31,12 @@ concurrency:
 
 jobs:
   detect-scope:
-    name: Detect non-.github changes
+    name: Detect package changes
     runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
-      non-github-changed: ${{ steps.changed.outputs.any_changed }}
+      packages-changed: ${{ steps.changed.outputs.any_changed }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -46,14 +46,14 @@ jobs:
       - id: changed
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          files_ignore: .github/**
+          files: packages/**
 
   check-fragment:
     name: Require changelog on package change
     runs-on: ubuntu-slim
     needs: [detect-scope]
     if: >-
-      needs.detect-scope.outputs.non-github-changed == 'true' &&
+      needs.detect-scope.outputs.packages-changed == 'true' &&
       !contains(github.event.pull_request.labels.*.name, 'bot')
     permissions:
       contents: read
@@ -106,11 +106,11 @@ jobs:
           fi
           echo "Changelog fragment check passed."
 
-  # check-fragment skips for bot-labeled and .github-only PRs, and branch
-  # protection can't require a job that sometimes doesn't run. This gate
-  # always runs and passes on either a real success or an accepted skip, so
-  # it's the check to require in branch protection instead of check-fragment
-  # directly.
+  # check-fragment skips for bot-labeled PRs and PRs that don't touch
+  # packages/, and branch protection can't require a job that sometimes
+  # doesn't run. This gate always runs and passes on either a real success
+  # or an accepted skip, so it's the check to require in branch protection
+  # instead of check-fragment directly.
   changelog-fragment-status:
     name: Changelog fragment check status
     runs-on: ubuntu-slim

--- a/.github/workflows/require-changelog-fragment.yaml
+++ b/.github/workflows/require-changelog-fragment.yaml
@@ -13,6 +13,10 @@ name: Changelog fragment verification
 # PRs labeled `bot` skip this check. Dependabot is the only source of that
 # label, and it's scoped to uv.lock and GitHub Actions version bumps, neither
 # of which touches consumer-facing behavior.
+#
+# PRs that only touch .github/ also skip: workflow and CI config aren't
+# packages, so detect-scope's tj-actions/changed-files check (ignoring
+# .github/**) reports no changes and check-fragment never runs.
 
 on:
   pull_request:
@@ -26,10 +30,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-scope:
+    name: Detect non-.github changes
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    outputs:
+      non-github-changed: ${{ steps.changed.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # The merge base with the PR base branch must be reachable
+          persist-credentials: false
+
+      - id: changed
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files_ignore: .github/**
+
   check-fragment:
     name: Require changelog on package change
     runs-on: ubuntu-slim
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'bot') }}
+    needs: [detect-scope]
+    if: >-
+      needs.detect-scope.outputs.non-github-changed == 'true' &&
+      !contains(github.event.pull_request.labels.*.name, 'bot')
     permissions:
       contents: read
     steps:
@@ -81,14 +106,15 @@ jobs:
           fi
           echo "Changelog fragment check passed."
 
-  # check-fragment skips for bot-labeled PRs, and branch protection can't
-  # require a job that sometimes doesn't run. This gate always runs and
-  # passes on either a real success or an accepted skip, so it's the check
-  # to require in branch protection instead of check-fragment directly.
+  # check-fragment skips for bot-labeled and .github-only PRs, and branch
+  # protection can't require a job that sometimes doesn't run. This gate
+  # always runs and passes on either a real success or an accepted skip, so
+  # it's the check to require in branch protection instead of check-fragment
+  # directly.
   changelog-fragment-status:
     name: Changelog fragment check status
     runs-on: ubuntu-slim
-    needs: [check-fragment]
+    needs: [detect-scope, check-fragment]
     if: always()
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

Dependabot PRs fail `require-changelog-fragment.yaml` because dependency bumps don't carry a `changelog.d/` fragment, and shouldn't need one. Every Dependabot PR needs a manual override to merge.

## Fix

Skip `check-fragment` when the PR carries the `bot` label. Dependabot already applies `bot` on both the `github-actions` and `uv` update configs in `.github/dependabot.yml`, so this needs no dependabot.yml changes, just the job's `if` condition.

Also skip it when the PR doesn't touch `packages/` at all: docs, root-level files, and CI config were never going to need a fragment, since `check-fragment` only ever inspects `packages/<package>/` paths. A new `detect-scope` job uses [`tj-actions/changed-files`](https://github.com/tj-actions/changed-files) (matching the convention already used in `detect-affected-packages`) as an allow-list on `packages/**`, so this covers `.github`-only, docs-only, and root-only PRs alike without an ignore entry per top-level directory.

A job that sometimes doesn't run can't be a required status check, so `check-fragment` alone can't stay required. Added `changelog-fragment-status`, a final gate that always runs and uses [`lowlydba/are-we-good`](https://github.com/lowlydba/are-we-good) to roll `detect-scope` and `check-fragment`'s results into a pass on either a real success or an accepted skip.

> [!IMPORTANT]
> Branch protection needs to require `changelog-fragment-status` instead of `check-fragment` for this to take effect.

Fixes #644