### PR TITLE
[CHORE] Add Overture issue template, skillset selector, and field sync workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/overture.yaml
+++ b/.github/ISSUE_TEMPLATE/overture.yaml
@@ -38,8 +38,6 @@ body:
         - data science
         - dev ops
         - engineering
-    validations:
-      required: true
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/overture.yaml
+++ b/.github/ISSUE_TEMPLATE/overture.yaml
@@ -1,0 +1,49 @@
+name: Overture
+description: General issue for work tracked in the Overture project.
+projects: ["OvertureMaps/84"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: What kind of work is this? Used to populate the organization-level `Type` field during triage.
+      options:
+        - Task
+        - Bug
+        - Agenda
+    validations:
+      required: true
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Primary theme or platform impacted. Used to populate the organization-level `Scope` field during triage.
+      options:
+        - Addresses
+        - Base
+        - Buildings
+        - Divisions
+        - Places
+        - Transportation
+        - Multi-theme or Platform
+    validations:
+      required: true
+  - type: dropdown
+    id: skillset
+    attributes:
+      label: Skillset
+      description: Primary skill needed to complete this task. Used to populate the organization-level `Skillset` field during triage.
+      options:
+        - data analysis
+        - data science
+        - dev ops
+        - engineering
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      placeholder: Describe what this issue is trying to accomplish (what), context (why), constraints, acceptance criteria, design details (how), and testing
+    validations:
+      required: true

--- a/.github/workflows/check-python-code.yaml
+++ b/.github/workflows/check-python-code.yaml
@@ -1,13 +1,10 @@
 name: Check Python package code
 
 on:
-  pull_request:
-    paths:
-      - 'packages/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - 'Makefile'
-      - '.github/workflows/check-python-code.yaml'
+  # No path filter on pull_request: "All Python checks pass" is a required
+  # status check (see schema.yml in omf-github-terraform), and GitHub never
+  # satisfies a required check that a path filter prevents from running.
+  pull_request: {}
   push:
     branches: [main, dev]
     paths:

--- a/.github/workflows/check-python-package-versions.yaml
+++ b/.github/workflows/check-python-package-versions.yaml
@@ -1,9 +1,10 @@
 name: Check Python package version numbers
 
 on:
-  pull_request:
-    paths:
-      - '**/pyproject.toml'
+  # No path filter: "check / Check Python package versions" is a required
+  # status check (see schema.yml in omf-github-terraform), and GitHub never
+  # satisfies a required check that a path filter prevents from running.
+  pull_request: {}
 permissions:
   contents: read
 

--- a/.github/workflows/sync-issue-type-and-scope.yml
+++ b/.github/workflows/sync-issue-type-and-scope.yml
@@ -1,0 +1,24 @@
+name: Sync issue Type and Scope
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+# One sync run per issue at a time; drop duplicate triggers.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync-fields:
+    name: Sync fields
+    runs-on: ubuntu-slim
+    permissions:
+      issues: write # Read the issue body and set the org-level Type, Scope, and Skillset fields.
+    steps:
+      - name: Sync Type and Scope from form answers
+        uses: OvertureMaps/workflows/.github/actions/sync-issue-fields@main # zizmor: ignore[unpinned-uses] intentionally track main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-schema.yaml
+++ b/.github/workflows/test-schema.yaml
@@ -9,11 +9,10 @@ on:
       - 'schema/**'
       - 'examples/**'
       - 'counterexamples/**'
-  pull_request:
-    paths:
-      - 'schema/**'
-      - 'examples/**'
-      - 'counterexamples/**'
+  # No path filter on pull_request: "Build" is a required status check (see
+  # schema.yml in omf-github-terraform), and GitHub never satisfies a
+  # required check that a path filter prevents from running.
+  pull_request: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
# Description

*Brief description of the business purpose and effect of the pull request.*

Adds the standard Overture issue-template setup to this repo, which previously had no `.github/ISSUE_TEMPLATE/` directory — every issue was opened blank and triaged by hand. This ports the setup from `tf-data-platform` (the reference implementation) so `schema` issues land in the master `Overture` project and carry the org-level `Type`, `Scope`, and `Skillset` fields from the moment they're opened.

Three new files:

- **`.github/ISSUE_TEMPLATE/overture.yaml`** — the single template this repo needs. Files into the `Overture` project (`OvertureMaps/84`) and prompts for `Type`, `Scope`, and an optional `Skillset`, then a required free-form `Description`.
- **`.github/ISSUE_TEMPLATE/config.yml`** — `blank_issues_enabled: false`, so every issue uses the template.
- **`.github/workflows/sync-issue-type-and-scope.yml`** — on `issues: opened`, populates the org-level fields from the form answers.

Field options, per the request:

| Field | Options | Default | Required |
| --- | --- | --- | --- |
| `Type` | Task, Bug, Agenda | none | yes |
| `Scope` | Addresses, Base, Buildings, Divisions, Places, Transportation, Multi-theme or Platform | none | yes |
| `Skillset` | data analysis, data science, dev ops, engineering | none | no |

No field carries a `default:`, so the submitter picks every value explicitly rather than accepting a pre-selected one. `Type` and `Scope` are required. `Skillset` is optional — it's often not obvious to the reporter at filing time, and forcing a choice invites a wrong one, so it can be left blank and set during triage. `Feature` is deliberately absent from `Type` — that work is filed as `Task`.

Notes on details that matter:

- Option strings match the org-level field options exactly (including the lowercase skillset values). A mismatch would 422 the sync action.
- The template does not prepend a bracketed type to the issue title.
- The workflow tracks `sync-issue-fields@main` rather than pinning a SHA, matching both tf-data-platform and this repo's existing convention for internal `OvertureMaps/workflows` actions (see `schema-pr-preview.yml`), with the same `zizmor: ignore[unpinned-uses]` comment.
- The workflow was adapted to this repo's local conventions rather than copied verbatim: top-level `permissions: {}`, a named job, an inline comment on `issues: write`, and a `${{ github.workflow }}`-based concurrency group like the other workflows here.

# Reference

*List of relevant links to GitHub issues, PRs, and other documentation.*

1. Closes #651
2. OvertureMaps/tf-data-platform#4623 — original issue-template work
3. OvertureMaps/tf-data-platform#4728 — added the `Skillset` dropdown and dropped `Feature`
4. [GitHub usage operating procedures](https://github.com/OvertureMaps/operating-procedures/blob/main/development/github-usage.md)

# Testing

*Brief description of the testing done for this change showing why you are confident it works as expected and does not introduce regressions. Provide sample output data where appropriate.*

- All three files confirmed to parse as valid YAML.
- `uvx zizmor --persona=pedantic .github/workflows/sync-issue-type-and-scope.yml` → **No findings to report** (1 ignored: the intentional `unpinned-uses`). Pedantic is stricter than the default persona, and the rest of `.github/workflows/` is clean at that level too, so this file doesn't introduce a new baseline finding regardless of which persona CI uses.
- Still to verify after merge: that the template renders in the "New issue" chooser without errors, that required fields validate, and that a test issue lands in the `Overture` project with `Type`, `Scope`, and `Skillset` set by the workflow.

# Checklist

*Checklist of tasks commonly-associated with schema pull requests.*

Not applicable — this PR touches only repo administration files under `.github/`. No schema, examples, counterexamples, or documentation changes.

# Documentation website

Not applicable — no documentation changes in this PR.
