### PR TITLE
[ENHANCEMENT] Add shelter class to the buildings schema

### DIFF
--- a/packages/overture-schema-theme-buildings/changelog.d/656.feature.md
+++ b/packages/overture-schema-theme-buildings/changelog.d/656.feature.md
@@ -1,0 +1,1 @@
+Add `shelter` to the building `class` enum so shelter structures (e.g. public transport shelters) can receive a class value.

--- a/packages/overture-schema-theme-buildings/src/overture/schema/buildings/building.py
+++ b/packages/overture-schema-theme-buildings/src/overture/schema/buildings/building.py
@@ -112,6 +112,7 @@ class BuildingClass(str, Enum):
     SEMIDETACHED_HOUSE = "semidetached_house"
     SERVICE = "service"
     SHED = "shed"
+    SHELTER = "shelter"
     SHRINE = "shrine"
     SILO = "silo"
     SLURRY_TANK = "slurry_tank"

--- a/packages/overture-schema-theme-buildings/tests/building_baseline_schema.json
+++ b/packages/overture-schema-theme-buildings/tests/building_baseline_schema.json
@@ -67,6 +67,7 @@
         "semidetached_house",
         "service",
         "shed",
+        "shelter",
         "shrine",
         "silo",
         "slurry_tank",

--- a/schema/buildings/building.yaml
+++ b/schema/buildings/building.yaml
@@ -115,6 +115,7 @@ properties:
           - semidetached_house
           - service
           - shed
+          - shelter
           - shrine
           - silo
           - slurry_tank


### PR DESCRIPTION
## Summary

Adds a `shelter` value to the `class` enum of `buildings/building` so that shelter structures — e.g. public transport (bus stop) shelters mapped in OSM as `amenity=shelter` + `building=*` — can receive a `class` instead of being left null.

Fixes #326

## Changes

- `schema/buildings/building.yaml`: add `shelter` to the `class` enum (alphabetical order)
- `packages/overture-schema-theme-buildings/src/overture/schema/buildings/building.py`: add `SHELTER = "shelter"` to `BuildingClass`
- `packages/overture-schema-theme-buildings/tests/building_baseline_schema.json`: add `"shelter"` to the baseline enum

Non-breaking enum addition; no migration needed.

Note: a follow-up change in the data pipeline is required to actually map OSM `amenity=shelter` / `building=shelter` features to `class=shelter`.

## Testing

- `pytest packages/overture-schema-theme-buildings/` — baseline JSON-schema tests pass (2 passed)
- Verified `schema/buildings/building.yaml` parses and the `class` enum remains alphabetically sorted