### PR TITLE
[ENHANCEMENT](transportation) Make segment connectors required

### DIFF
--- a/counterexamples/common/names/names-invalid-language.yaml
+++ b/counterexamples/common/names/names-invalid-language.yaml
@@ -10,6 +10,11 @@ properties:
   version: 1
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: Foo
     common:

--- a/counterexamples/common/names/names-invalid-variant.yaml
+++ b/counterexamples/common/names/names-invalid-variant.yaml
@@ -10,6 +10,11 @@ properties:
   version: 1
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: Bar
     rules:

--- a/counterexamples/transportation/segment/bad-geometry-type.json
+++ b/counterexamples/transportation/segment/bad-geometry-type.json
@@ -12,6 +12,10 @@
     "theme": "transportation",
     "type": "segment",
     "subtype": "water",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "version": 15
   }
 }

--- a/counterexamples/transportation/segment/bad-lr-width-missing-items.json
+++ b/counterexamples/transportation/segment/bad-lr-width-missing-items.json
@@ -11,6 +11,10 @@
     "version": 26,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "width_rules": [],
     "ext_expected_errors": [
       "minItems: got 0, want 1"

--- a/counterexamples/transportation/segment/bad-lr-width.json
+++ b/counterexamples/transportation/segment/bad-lr-width.json
@@ -11,6 +11,10 @@
     "version": 26,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "width_rules": [
       {
         "between" : [0, 0.5],

--- a/counterexamples/transportation/segment/missing-subtype.json
+++ b/counterexamples/transportation/segment/missing-subtype.json
@@ -11,6 +11,10 @@
     ],
     "theme": "transportation",
     "type": "segment",
-    "version": 26
+    "version": 26,
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ]
   }
 }

--- a/counterexamples/transportation/segment/missing-version.json
+++ b/counterexamples/transportation/segment/missing-version.json
@@ -11,6 +11,10 @@
     ],
     "theme": "transportation",
     "type": "segment",
-    "subtype": "water"
+    "subtype": "water",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ]
   }
 }

--- a/counterexamples/transportation/segment/property-subtype-mismatch.yaml
+++ b/counterexamples/transportation/segment/property-subtype-mismatch.yaml
@@ -10,6 +10,11 @@ properties:
   version: 1
   # Segment of subtype rail has a road flag (should be disallowed)
   subtype: rail
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   road_flags:
     - values: [is_indoor]
   ext_expected_errors:

--- a/counterexamples/transportation/segment/rail/bad-rail-class.json
+++ b/counterexamples/transportation/segment/rail/bad-rail-class.json
@@ -13,6 +13,10 @@
     "type": "segment",
     "version": 18,
     "subtype": "rail",
-    "class": "foo"
+    "class": "foo",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ]
   }
 }

--- a/counterexamples/transportation/segment/rail/bad-rail-flags-duplicate-flag.json
+++ b/counterexamples/transportation/segment/rail/bad-rail-flags-duplicate-flag.json
@@ -14,6 +14,10 @@
     "version": 19,
     "subtype": "rail",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "rail_flags": [
       {
         "values": ["is_freight", "is_freight"]

--- a/counterexamples/transportation/segment/rail/bad-rail-flags-invalid-flag.json
+++ b/counterexamples/transportation/segment/rail/bad-rail-flags-invalid-flag.json
@@ -14,6 +14,10 @@
     "version": 20,
     "subtype": "rail",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "rail_flags": [
       {
         "values": ["foo"]

--- a/counterexamples/transportation/segment/road/bad-road-class.json
+++ b/counterexamples/transportation/segment/road/bad-road-class.json
@@ -13,6 +13,10 @@
     "type": "segment",
     "version": 18,
     "subtype": "road",
-    "class": "foo"
+    "class": "foo",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ]
   }
 }

--- a/counterexamples/transportation/segment/road/bad-road-flags-duplicate-flag.json
+++ b/counterexamples/transportation/segment/road/bad-road-flags-duplicate-flag.json
@@ -14,6 +14,10 @@
     "version": 19,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "road_flags": [
       {
         "values": ["is_tunnel", "is_tunnel"]

--- a/counterexamples/transportation/segment/road/bad-road-flags-invalid-flag.json
+++ b/counterexamples/transportation/segment/road/bad-road-flags-invalid-flag.json
@@ -14,6 +14,10 @@
     "version": 20,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "road_flags": [
       {
         "values": ["foo"]

--- a/counterexamples/transportation/segment/road/bad-road-flags-invalid-is_private-flag.json
+++ b/counterexamples/transportation/segment/road/bad-road-flags-invalid-is_private-flag.json
@@ -11,6 +11,10 @@
       "version": 20,
       "subtype": "road",
       "class": "primary",
+      "connectors": [
+        { "connector_id": "fooConnector", "at": 0 },
+        { "connector_id": "barConnector", "at": 1 }
+      ],
       "road_flags": [
         {
           "values": ["is_private"]

--- a/counterexamples/transportation/segment/road/bad-road-flags-invalid-string-value.json
+++ b/counterexamples/transportation/segment/road/bad-road-flags-invalid-string-value.json
@@ -14,6 +14,10 @@
       "version": 20,
       "subtype": "road",
       "class": "primary",
+      "connectors": [
+        { "connector_id": "fooConnector", "at": 0 },
+        { "connector_id": "barConnector", "at": 1 }
+      ],
       "road_flags": ["is_tunnel"]
     }
   }

--- a/counterexamples/transportation/segment/road/bad-road-invalid-temporal-scoping.json
+++ b/counterexamples/transportation/segment/road/bad-road-invalid-temporal-scoping.json
@@ -11,6 +11,10 @@
     "version": 20,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "road_flags": [
       {
         "values": ["is_bridge"]

--- a/counterexamples/transportation/segment/road/bad-road-surface-invalid-rule-value.json
+++ b/counterexamples/transportation/segment/road/bad-road-surface-invalid-rule-value.json
@@ -11,6 +11,10 @@
     "version": 23,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "road_surface": [
       {
         "value": "hot mess"

--- a/counterexamples/transportation/segment/road/restrictions/access/bad-access-unsupported-properties.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/access/bad-access-unsupported-properties.yaml
@@ -8,6 +8,11 @@ properties:
   type: segment
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   version: 1
   access_restrictions:
     - foo: bar

--- a/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/unsupported-properties.yaml
+++ b/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/unsupported-properties.yaml
@@ -8,6 +8,11 @@ properties:
   type: segment
   subtype: road
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   version: 1
   prohibited_transitions:
     - sequence:

--- a/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-empty-rule.json
+++ b/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-empty-rule.json
@@ -11,6 +11,10 @@
     "version": 26,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "speed_limits": [
       {}
     ],

--- a/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-invalid-type.json
+++ b/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-invalid-type.json
@@ -11,6 +11,10 @@
     "version": 0,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "speed_limits": {},
     "ext_expected_errors": [
       "'/properties/speed_limits' [S#/$defs/propertyContainers/speedLimitsContainer/type]: got object, want array"

--- a/examples/common/names/names-lexically-valid-language-tag.yaml
+++ b/examples/common/names/names-lexically-valid-language-tag.yaml
@@ -10,6 +10,11 @@ properties:
   version: 1
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: foo
     common:

--- a/examples/common/timestamp/timestamp-leap-second.yaml
+++ b/examples/common/timestamp/timestamp-leap-second.yaml
@@ -9,4 +9,9 @@ properties:
   type: segment
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   version: 1

--- a/examples/transportation/docusaurus/access-restriction-01-blanket.yaml
+++ b/examples/transportation/docusaurus/access-restriction-01-blanket.yaml
@@ -12,5 +12,10 @@ properties:
   version: 1
   subtype: road
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied

--- a/examples/transportation/docusaurus/access-restriction-02-private-with-deliveries.yaml
+++ b/examples/transportation/docusaurus/access-restriction-02-private-with-deliveries.yaml
@@ -12,6 +12,11 @@ properties:
   version: 1
   subtype: road
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
     - access_type: allowed

--- a/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
+++ b/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
@@ -12,6 +12,11 @@ properties:
   version: 1
   subtype: road
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
       when: { mode: [motor_vehicle] }

--- a/examples/transportation/docusaurus/access-restriction-04-axle-limit.yaml
+++ b/examples/transportation/docusaurus/access-restriction-04-axle-limit.yaml
@@ -12,6 +12,11 @@ properties:
   version: 1
   subtype: road
   class: motorway
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
       when:

--- a/examples/transportation/docusaurus/geometric-scoping.yaml
+++ b/examples/transportation/docusaurus/geometric-scoping.yaml
@@ -10,6 +10,11 @@ properties:
   version: 1
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   speed_limits:
     - between: [0, 0.15]
       max_speed:

--- a/examples/transportation/docusaurus/speed-limits-01-simple.yaml
+++ b/examples/transportation/docusaurus/speed-limits-01-simple.yaml
@@ -12,6 +12,11 @@ properties:
   version: 1
   subtype: road
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   speed_limits:
     - max_speed:
         value: 30

--- a/examples/transportation/docusaurus/speed-limits-02-directional.yaml
+++ b/examples/transportation/docusaurus/speed-limits-02-directional.yaml
@@ -12,6 +12,11 @@ properties:
   version: 2
   subtype: road
   class: secondary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   speed_limits:
     - max_speed: {value: 70, unit: "mph"}
     - when:

--- a/examples/transportation/docusaurus/speed-limits-03-variable-max.yaml
+++ b/examples/transportation/docusaurus/speed-limits-03-variable-max.yaml
@@ -14,6 +14,11 @@ properties:
   version: 1
   subtype: road
   class: motorway
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   speed_limits:
     - max_speed:
         value: 100

--- a/examples/transportation/docusaurus/subjective-heading-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-heading-scoping.yaml
@@ -16,6 +16,11 @@ properties:
   version: 2
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
       when: { heading: backward }

--- a/examples/transportation/docusaurus/subjective-status-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-status-scoping.yaml
@@ -13,6 +13,11 @@ properties:
   version: 1
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
     - access_type: allowed

--- a/examples/transportation/docusaurus/subjective-usage-purpose-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-usage-purpose-scoping.yaml
@@ -12,6 +12,11 @@ properties:
   version: 1
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
     - access_type: allowed

--- a/examples/transportation/docusaurus/subjective-vehicle-attributes-scoping.yaml
+++ b/examples/transportation/docusaurus/subjective-vehicle-attributes-scoping.yaml
@@ -13,6 +13,11 @@ properties:
   version: 1
   subtype: road
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
       when:

--- a/examples/transportation/docusaurus/temporal-scoping.yaml
+++ b/examples/transportation/docusaurus/temporal-scoping.yaml
@@ -13,6 +13,11 @@ properties:
   version: 2
   subtype: road
   class: unknown
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
       when:

--- a/examples/transportation/segment/missing-update-time.json
+++ b/examples/transportation/segment/missing-update-time.json
@@ -11,6 +11,10 @@
     "theme": "transportation",
     "type": "segment",
     "version": 27,
-    "subtype": "water"
+    "subtype": "water",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ]
   }
 }

--- a/examples/transportation/segment/rail/rail-freight.yaml
+++ b/examples/transportation/segment/rail/rail-freight.yaml
@@ -12,6 +12,11 @@ properties:
   version: 3
   subtype: rail
   class: standard_gauge
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: Generic Rail Name
   rail_flags:

--- a/examples/transportation/segment/rail/rail-tunnel.yaml
+++ b/examples/transportation/segment/rail/rail-tunnel.yaml
@@ -12,6 +12,11 @@ properties:
   version: 3
   subtype: rail
   class: subway
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: Generic Rail Name
   rail_flags:

--- a/examples/transportation/segment/road/restrictions/road-restrictions-access.yaml
+++ b/examples/transportation/segment/road/restrictions/road-restrictions-access.yaml
@@ -9,6 +9,11 @@ properties:
   type: segment
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   version: 2
   access_restrictions:
     - access_type: denied

--- a/examples/transportation/segment/road/restrictions/road-restrictions-prohibited-transitions.yaml
+++ b/examples/transportation/segment/road/restrictions/road-restrictions-prohibited-transitions.yaml
@@ -9,6 +9,11 @@ properties:
   type: segment
   subtype: road
   class: secondary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   version: 2
   prohibited_transitions:
     - sequence:

--- a/examples/transportation/segment/road/restrictions/road-restrictions-speed-limits.yaml
+++ b/examples/transportation/segment/road/restrictions/road-restrictions-speed-limits.yaml
@@ -9,6 +9,11 @@ properties:
   type: segment
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   version: 3
   speed_limits:
     - max_speed: {value: 20, unit: 'km/h'}

--- a/examples/transportation/segment/road/road-abandoned.yaml
+++ b/examples/transportation/segment/road/road-abandoned.yaml
@@ -11,6 +11,11 @@ properties:
   version: 3
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   road_surface:
     - value: gravel
   road_flags:

--- a/examples/transportation/segment/road/road-acesss-restriction.yaml
+++ b/examples/transportation/segment/road/road-acesss-restriction.yaml
@@ -17,6 +17,11 @@ properties:
   version: 5
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
     - access_type: designated

--- a/examples/transportation/segment/road/road-alley.yaml
+++ b/examples/transportation/segment/road/road-alley.yaml
@@ -10,6 +10,11 @@ properties:
   version: 5
   subtype: road
   class: service
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   subclass_rules:
     - value: alley
       between: [0, 0.5]

--- a/examples/transportation/segment/road/road-covered.yaml
+++ b/examples/transportation/segment/road/road-covered.yaml
@@ -11,6 +11,11 @@ properties:
   version: 3
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   road_surface:
     - value: paved
   road_flags:

--- a/examples/transportation/segment/road/road-indoors.yaml
+++ b/examples/transportation/segment/road/road-indoors.yaml
@@ -11,6 +11,11 @@ properties:
   version: 1
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   road_surface:
     - value: unknown
   road_flags:

--- a/examples/transportation/segment/road/road-level.yaml
+++ b/examples/transportation/segment/road/road-level.yaml
@@ -10,6 +10,11 @@ properties:
   subtype: road
   version: 2
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   level_rules:
     - value: -1
       between: [0, 0.5]

--- a/examples/transportation/segment/road/road-path.yaml
+++ b/examples/transportation/segment/road/road-path.yaml
@@ -10,3 +10,8 @@ properties:
   version: 5
   subtype: road
   class: path
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1

--- a/packages/overture-schema-theme-transportation/changelog.d/669.breaking.md
+++ b/packages/overture-schema-theme-transportation/changelog.d/669.breaking.md
@@ -1,0 +1,1 @@
+Made segment `connectors` a required field. It previously defaulted to an empty list, a value its own `min_length=2` constraint rejected, so a segment without connectors failed re-validation after a dump. Every segment in published Overture data already carries two or more connectors.

--- a/packages/overture-schema-theme-transportation/src/overture/schema/transportation/segment/_common.py
+++ b/packages/overture-schema-theme-transportation/src/overture/schema/transportation/segment/_common.py
@@ -168,12 +168,9 @@ class TransportationSegment(
         SegmentSubtype, Field(description="Broad category of transportation segment.")
     ]
 
-    # Optional
-
-    access_restrictions: AccessRules | None = None
     # Contains the GERS ID and relative position between 0 and 1 of a connector feature along the segment.
     connectors: Annotated[
-        list[ConnectorReference] | None,
+        list[ConnectorReference],
         Field(
             min_length=2,
             description=textwrap.dedent("""
@@ -184,7 +181,11 @@ class TransportationSegment(
             """).strip(),
         ),
         UniqueItemsConstraint(),
-    ] = []
+    ]
+
+    # Optional
+
+    access_restrictions: AccessRules | None = None
     level_rules: LevelRules | None = None
 
 

--- a/packages/overture-schema-theme-transportation/tests/segment_baseline_schema.json
+++ b/packages/overture-schema-theme-transportation/tests/segment_baseline_schema.json
@@ -630,7 +630,6 @@
               "$ref": "#/$defs/RailClass"
             },
             "connectors": {
-              "default": [],
               "description": "List of connectors which this segment is physically connected to and their\nrelative location. Each connector is a possible routing decision point,\nmeaning it defines a place along the segment in which there is possibility to\ntransition to other segments which share the same connector.",
               "items": {
                 "$ref": "#/$defs/ConnectorReference"
@@ -700,6 +699,7 @@
             "type",
             "version",
             "subtype",
+            "connectors",
             "class"
           ],
           "type": "object"
@@ -884,7 +884,6 @@
               "$ref": "#/$defs/RoadClass"
             },
             "connectors": {
-              "default": [],
               "description": "List of connectors which this segment is physically connected to and their\nrelative location. Each connector is a possible routing decision point,\nmeaning it defines a place along the segment in which there is possibility to\ntransition to other segments which share the same connector.",
               "items": {
                 "$ref": "#/$defs/ConnectorReference"
@@ -1019,6 +1018,7 @@
             "type",
             "version",
             "subtype",
+            "connectors",
             "class"
           ],
           "type": "object"
@@ -1618,7 +1618,6 @@
               "uniqueItems": true
             },
             "connectors": {
-              "default": [],
               "description": "List of connectors which this segment is physically connected to and their\nrelative location. Each connector is a possible routing decision point,\nmeaning it defines a place along the segment in which there is possibility to\ntransition to other segments which share the same connector.",
               "items": {
                 "$ref": "#/$defs/ConnectorReference"
@@ -1677,7 +1676,8 @@
             "theme",
             "type",
             "version",
-            "subtype"
+            "subtype",
+            "connectors"
           ],
           "type": "object"
         },

--- a/reference/counterexamples/common/names/names-invalid-language.yaml
+++ b/reference/counterexamples/common/names/names-invalid-language.yaml
@@ -10,6 +10,11 @@ properties:
   version: 1
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: Foo
     common:

--- a/reference/counterexamples/common/names/names-invalid-variant.yaml
+++ b/reference/counterexamples/common/names/names-invalid-variant.yaml
@@ -10,6 +10,11 @@ properties:
   version: 1
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: Bar
     rules:

--- a/reference/counterexamples/transportation/segment/bad-geometry-type.json
+++ b/reference/counterexamples/transportation/segment/bad-geometry-type.json
@@ -12,6 +12,10 @@
     "theme": "transportation",
     "type": "segment",
     "subtype": "water",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "version": 15
   }
 }

--- a/reference/counterexamples/transportation/segment/bad-lr-width-missing-items.json
+++ b/reference/counterexamples/transportation/segment/bad-lr-width-missing-items.json
@@ -11,6 +11,10 @@
     "version": 26,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "width_rules": [],
     "ext_expected_errors": [
       "minItems: got 0, want 1"

--- a/reference/counterexamples/transportation/segment/bad-lr-width.json
+++ b/reference/counterexamples/transportation/segment/bad-lr-width.json
@@ -11,6 +11,10 @@
     "version": 26,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "width_rules": [
       {
         "between" : [0, 0.5],

--- a/reference/counterexamples/transportation/segment/bad-rail-flags-wrong-subtype.yaml
+++ b/reference/counterexamples/transportation/segment/bad-rail-flags-wrong-subtype.yaml
@@ -11,6 +11,11 @@ properties:
   type: segment
   version: 1
   subtype: road  # This is road subtype, but we're using rail_flags
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   rail_flags:
     - values: [is_bridge]
   ext_expected_errors:

--- a/reference/counterexamples/transportation/segment/missing-subtype.json
+++ b/reference/counterexamples/transportation/segment/missing-subtype.json
@@ -11,6 +11,10 @@
     ],
     "theme": "transportation",
     "type": "segment",
-    "version": 26
+    "version": 26,
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ]
   }
 }

--- a/reference/counterexamples/transportation/segment/missing-version.json
+++ b/reference/counterexamples/transportation/segment/missing-version.json
@@ -11,6 +11,10 @@
     ],
     "theme": "transportation",
     "type": "segment",
-    "subtype": "water"
+    "subtype": "water",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ]
   }
 }

--- a/reference/counterexamples/transportation/segment/property-subtype-mismatch.yaml
+++ b/reference/counterexamples/transportation/segment/property-subtype-mismatch.yaml
@@ -10,6 +10,11 @@ properties:
   version: 1
   # Segment of subtype rail has a road flag (should be disallowed)
   subtype: rail
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   road_flags:
     - values: [is_indoor]
   ext_expected_errors:

--- a/reference/counterexamples/transportation/segment/rail/bad-rail-class-invalid.yaml
+++ b/reference/counterexamples/transportation/segment/rail/bad-rail-class-invalid.yaml
@@ -12,5 +12,10 @@ properties:
   version: 1
   subtype: rail
   class: invalid_rail_class  # This should trigger Pydantic validation error
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   ext_expected_errors:
     - "value must be one of 'funicular', 'light_rail', 'monorail', 'narrow_gauge', 'standard_gauge', 'subway', 'tram', 'unknown'"

--- a/reference/counterexamples/transportation/segment/rail/bad-rail-class.json
+++ b/reference/counterexamples/transportation/segment/rail/bad-rail-class.json
@@ -13,6 +13,10 @@
     "type": "segment",
     "version": 18,
     "subtype": "rail",
-    "class": "foo"
+    "class": "foo",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ]
   }
 }

--- a/reference/counterexamples/transportation/segment/rail/bad-rail-flags-duplicate-flag.json
+++ b/reference/counterexamples/transportation/segment/rail/bad-rail-flags-duplicate-flag.json
@@ -14,6 +14,10 @@
     "version": 19,
     "subtype": "rail",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "rail_flags": [
       {
         "values": ["is_freight", "is_freight"]

--- a/reference/counterexamples/transportation/segment/rail/bad-rail-flags-invalid-flag.json
+++ b/reference/counterexamples/transportation/segment/rail/bad-rail-flags-invalid-flag.json
@@ -14,6 +14,10 @@
     "version": 20,
     "subtype": "rail",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "rail_flags": [
       {
         "values": ["foo"]

--- a/reference/counterexamples/transportation/segment/road/bad-road-class-invalid.yaml
+++ b/reference/counterexamples/transportation/segment/road/bad-road-class-invalid.yaml
@@ -12,5 +12,10 @@ properties:
   version: 1
   subtype: road
   class: invalid_road_class  # This should trigger Pydantic validation error
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   ext_expected_errors:
     - "value must be one of 'motorway', 'primary', 'secondary', 'tertiary', 'residential', 'living_street', 'trunk', 'unclassified', 'service', 'pedestrian', 'footway', 'steps', 'path', 'track', 'cycleway', 'bridleway', 'unknown'"

--- a/reference/counterexamples/transportation/segment/road/bad-road-class.json
+++ b/reference/counterexamples/transportation/segment/road/bad-road-class.json
@@ -13,6 +13,10 @@
     "type": "segment",
     "version": 18,
     "subtype": "road",
-    "class": "foo"
+    "class": "foo",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ]
   }
 }

--- a/reference/counterexamples/transportation/segment/road/bad-road-flags-duplicate-flag.json
+++ b/reference/counterexamples/transportation/segment/road/bad-road-flags-duplicate-flag.json
@@ -14,6 +14,10 @@
     "version": 19,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "road_flags": [
       {
         "values": ["is_tunnel", "is_tunnel"]

--- a/reference/counterexamples/transportation/segment/road/bad-road-flags-invalid-flag.json
+++ b/reference/counterexamples/transportation/segment/road/bad-road-flags-invalid-flag.json
@@ -14,6 +14,10 @@
     "version": 20,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "road_flags": [
       {
         "values": ["foo"]

--- a/reference/counterexamples/transportation/segment/road/bad-road-flags-invalid-is_private-flag.json
+++ b/reference/counterexamples/transportation/segment/road/bad-road-flags-invalid-is_private-flag.json
@@ -11,6 +11,10 @@
       "version": 20,
       "subtype": "road",
       "class": "primary",
+      "connectors": [
+        { "connector_id": "fooConnector", "at": 0 },
+        { "connector_id": "barConnector", "at": 1 }
+      ],
       "road_flags": [
         {
           "values": ["is_private"]

--- a/reference/counterexamples/transportation/segment/road/bad-road-flags-invalid-string-value.json
+++ b/reference/counterexamples/transportation/segment/road/bad-road-flags-invalid-string-value.json
@@ -14,6 +14,10 @@
       "version": 20,
       "subtype": "road",
       "class": "primary",
+      "connectors": [
+        { "connector_id": "fooConnector", "at": 0 },
+        { "connector_id": "barConnector", "at": 1 }
+      ],
       "road_flags": ["is_tunnel"]
     }
   }

--- a/reference/counterexamples/transportation/segment/road/bad-road-invalid-temporal-scoping.json
+++ b/reference/counterexamples/transportation/segment/road/bad-road-invalid-temporal-scoping.json
@@ -11,6 +11,10 @@
     "version": 20,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "road_flags": [
       {
         "values": ["is_bridge"]

--- a/reference/counterexamples/transportation/segment/road/bad-road-surface-invalid-rule-value.json
+++ b/reference/counterexamples/transportation/segment/road/bad-road-surface-invalid-rule-value.json
@@ -11,6 +11,10 @@
     "version": 23,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "road_surface": [
       {
         "value": "hot mess"

--- a/reference/counterexamples/transportation/segment/road/restrictions/access/bad-access-unsupported-properties.yaml
+++ b/reference/counterexamples/transportation/segment/road/restrictions/access/bad-access-unsupported-properties.yaml
@@ -8,6 +8,11 @@ properties:
   type: segment
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   version: 1
   access_restrictions:
     - foo: bar

--- a/reference/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/unsupported-properties.yaml
+++ b/reference/counterexamples/transportation/segment/road/restrictions/prohibited_transitions/unsupported-properties.yaml
@@ -8,6 +8,11 @@ properties:
   type: segment
   subtype: road
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   version: 1
   prohibited_transitions:
     - sequence:

--- a/reference/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-empty-rule.json
+++ b/reference/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-empty-rule.json
@@ -14,6 +14,10 @@
     "version": 26,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "speed_limits": [{}],
     "ext_description": "road segment where road.restrictions.speed_limits contains an empty rule",
     "ext_expected_errors": [

--- a/reference/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-invalid-type.json
+++ b/reference/counterexamples/transportation/segment/road/restrictions/speed_limits/bad-speed-limits-invalid-type.json
@@ -11,6 +11,10 @@
     "version": 0,
     "subtype": "road",
     "class": "primary",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ],
     "speed_limits": {},
     "ext_expected_errors": [
       "got object, want array"

--- a/reference/examples/common/names/names-lexically-valid-language-tag.yaml
+++ b/reference/examples/common/names/names-lexically-valid-language-tag.yaml
@@ -10,6 +10,11 @@ properties:
   version: 1
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: foo
     common:

--- a/reference/examples/common/timestamp/timestamp-leap-second.yaml
+++ b/reference/examples/common/timestamp/timestamp-leap-second.yaml
@@ -9,4 +9,9 @@ properties:
   type: segment
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   version: 1

--- a/reference/examples/transportation/docusaurus/access-restriction-01-blanket.yaml
+++ b/reference/examples/transportation/docusaurus/access-restriction-01-blanket.yaml
@@ -12,5 +12,10 @@ properties:
   version: 1
   subtype: road
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied

--- a/reference/examples/transportation/docusaurus/access-restriction-02-private-with-deliveries.yaml
+++ b/reference/examples/transportation/docusaurus/access-restriction-02-private-with-deliveries.yaml
@@ -12,6 +12,11 @@ properties:
   version: 1
   subtype: road
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
     - access_type: allowed

--- a/reference/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
+++ b/reference/examples/transportation/docusaurus/access-restriction-03-motor-vehicles-destination-only.yaml
@@ -12,6 +12,11 @@ properties:
   version: 1
   subtype: road
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
       when: { mode: [motor_vehicle] }

--- a/reference/examples/transportation/docusaurus/access-restriction-04-axle-limit.yaml
+++ b/reference/examples/transportation/docusaurus/access-restriction-04-axle-limit.yaml
@@ -12,6 +12,11 @@ properties:
   version: 1
   subtype: road
   class: motorway
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
       when:

--- a/reference/examples/transportation/docusaurus/geometric-scoping.yaml
+++ b/reference/examples/transportation/docusaurus/geometric-scoping.yaml
@@ -10,6 +10,11 @@ properties:
   version: 1
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   speed_limits:
     - between: [0, 0.15]
       max_speed:

--- a/reference/examples/transportation/docusaurus/speed-limits-01-simple.yaml
+++ b/reference/examples/transportation/docusaurus/speed-limits-01-simple.yaml
@@ -12,6 +12,11 @@ properties:
   version: 1
   subtype: road
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   speed_limits:
     - max_speed:
         value: 30

--- a/reference/examples/transportation/docusaurus/speed-limits-02-directional.yaml
+++ b/reference/examples/transportation/docusaurus/speed-limits-02-directional.yaml
@@ -12,6 +12,11 @@ properties:
   version: 2
   subtype: road
   class: secondary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   speed_limits:
     - max_speed: {value: 70, unit: "mph"}
     - when:

--- a/reference/examples/transportation/docusaurus/speed-limits-03-variable-max.yaml
+++ b/reference/examples/transportation/docusaurus/speed-limits-03-variable-max.yaml
@@ -14,6 +14,11 @@ properties:
   version: 1
   subtype: road
   class: motorway
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   speed_limits:
     - max_speed:
         value: 100

--- a/reference/examples/transportation/docusaurus/subjective-heading-scoping.yaml
+++ b/reference/examples/transportation/docusaurus/subjective-heading-scoping.yaml
@@ -16,6 +16,11 @@ properties:
   version: 2
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
       when: { heading: backward }

--- a/reference/examples/transportation/docusaurus/subjective-status-scoping.yaml
+++ b/reference/examples/transportation/docusaurus/subjective-status-scoping.yaml
@@ -13,6 +13,11 @@ properties:
   version: 1
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
     - access_type: allowed

--- a/reference/examples/transportation/docusaurus/subjective-usage-purpose-scoping.yaml
+++ b/reference/examples/transportation/docusaurus/subjective-usage-purpose-scoping.yaml
@@ -12,6 +12,11 @@ properties:
   version: 1
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
     - access_type: allowed

--- a/reference/examples/transportation/docusaurus/subjective-vehicle-attributes-scoping.yaml
+++ b/reference/examples/transportation/docusaurus/subjective-vehicle-attributes-scoping.yaml
@@ -13,6 +13,11 @@ properties:
   version: 1
   subtype: road
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
       when:

--- a/reference/examples/transportation/docusaurus/temporal-scoping.yaml
+++ b/reference/examples/transportation/docusaurus/temporal-scoping.yaml
@@ -13,6 +13,11 @@ properties:
   version: 2
   subtype: road
   class: unknown
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
       when:

--- a/reference/examples/transportation/segment/missing-update-time.json
+++ b/reference/examples/transportation/segment/missing-update-time.json
@@ -11,6 +11,10 @@
     "theme": "transportation",
     "type": "segment",
     "version": 27,
-    "subtype": "water"
+    "subtype": "water",
+    "connectors": [
+      { "connector_id": "fooConnector", "at": 0 },
+      { "connector_id": "barConnector", "at": 1 }
+    ]
   }
 }

--- a/reference/examples/transportation/segment/rail/rail-freight.yaml
+++ b/reference/examples/transportation/segment/rail/rail-freight.yaml
@@ -12,6 +12,11 @@ properties:
   version: 3
   subtype: rail
   class: standard_gauge
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: Generic Rail Name
   rail_flags:

--- a/reference/examples/transportation/segment/rail/rail-tunnel.yaml
+++ b/reference/examples/transportation/segment/rail/rail-tunnel.yaml
@@ -12,6 +12,11 @@ properties:
   version: 3
   subtype: rail
   class: subway
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   names:
     primary: Generic Rail Name
   rail_flags:

--- a/reference/examples/transportation/segment/road/restrictions/road-restrictions-access.yaml
+++ b/reference/examples/transportation/segment/road/restrictions/road-restrictions-access.yaml
@@ -9,6 +9,11 @@ properties:
   type: segment
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   version: 2
   access_restrictions:
     - access_type: denied

--- a/reference/examples/transportation/segment/road/restrictions/road-restrictions-prohibited-transitions.yaml
+++ b/reference/examples/transportation/segment/road/restrictions/road-restrictions-prohibited-transitions.yaml
@@ -9,6 +9,11 @@ properties:
   type: segment
   subtype: road
   class: secondary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   version: 2
   prohibited_transitions:
     - sequence:

--- a/reference/examples/transportation/segment/road/restrictions/road-restrictions-speed-limits.yaml
+++ b/reference/examples/transportation/segment/road/restrictions/road-restrictions-speed-limits.yaml
@@ -9,6 +9,11 @@ properties:
   type: segment
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   version: 3
   speed_limits:
     - max_speed: {value: 20, unit: 'km/h'}

--- a/reference/examples/transportation/segment/road/road-abandoned.yaml
+++ b/reference/examples/transportation/segment/road/road-abandoned.yaml
@@ -11,6 +11,11 @@ properties:
   version: 3
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   road_surface:
     - value: gravel
   road_flags:

--- a/reference/examples/transportation/segment/road/road-acesss-restriction.yaml
+++ b/reference/examples/transportation/segment/road/road-acesss-restriction.yaml
@@ -17,6 +17,11 @@ properties:
   version: 5
   subtype: road
   class: primary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   access_restrictions:
     - access_type: denied
     - access_type: designated

--- a/reference/examples/transportation/segment/road/road-alley.yaml
+++ b/reference/examples/transportation/segment/road/road-alley.yaml
@@ -10,6 +10,11 @@ properties:
   version: 5
   subtype: road
   class: service
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   subclass_rules:
     - value: alley
       between: [0, 0.5]

--- a/reference/examples/transportation/segment/road/road-covered.yaml
+++ b/reference/examples/transportation/segment/road/road-covered.yaml
@@ -11,6 +11,11 @@ properties:
   version: 3
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   road_surface:
     - value: paved
   road_flags:

--- a/reference/examples/transportation/segment/road/road-indoors.yaml
+++ b/reference/examples/transportation/segment/road/road-indoors.yaml
@@ -11,6 +11,11 @@ properties:
   version: 1
   subtype: road
   class: tertiary
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   road_surface:
     - value: unknown
   road_flags:

--- a/reference/examples/transportation/segment/road/road-level.yaml
+++ b/reference/examples/transportation/segment/road/road-level.yaml
@@ -10,6 +10,11 @@ properties:
   subtype: road
   version: 2
   class: residential
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
   level_rules:
     - value: -1
       between: [0, 0.5]

--- a/reference/examples/transportation/segment/road/road-path.yaml
+++ b/reference/examples/transportation/segment/road/road-path.yaml
@@ -10,3 +10,8 @@ properties:
   version: 5
   subtype: road
   class: path
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -17,7 +17,7 @@ properties:
       - "$ref": https://geojson.org/schema/LineString.json
   properties:
     unevaluatedProperties: false
-    required: [subtype]
+    required: [subtype, connectors]
     allOf:
       - title: "Common Segment Properties"
         properties:
@@ -76,7 +76,6 @@ properties:
             at: { "$ref": "../defs.yaml#/$defs/propertyDefinitions/linearlyReferencedPosition" }
         uniqueItems: true
         minItems: 2
-        default: []
 "$defs":
   propertyDefinitions:
     destinationLabelType:


### PR DESCRIPTION
# Major change release plan

## A. Expected release date for this MAJOR change

Bundled into 2.0.0. Since it matches the published data, it doesn't strictly need to be treated as a breaking change.

## B. Related MINOR change steps

- None. The published data already satisfies the tightened constraint, so there is no intermediate step where producers must be given time to comply.

## C. Public documentation and messaging plan

The schema reference regenerates from the model, and every Docusaurus segment example in this PR now carries a `connectors` array, so the visible change is that `connectors` moves into the required-property list for all three segment subtypes. This is effectively a fix for the docs to match what's published in the data.

# Description

`connectors` was declared optional with an empty-list default that its own `min_length=2` constraint rejects:

```python
connectors: Annotated[
    list[ConnectorReference] | None,
    Field(min_length=2, description="..."),
    UniqueItemsConstraint(),
] = []          # violates min_length=2
```

Pydantic does not validate defaults unless `validate_default=True`, so the invalid value was accepted on the way in and refused on the way back out. A segment constructed without connectors dumped to `connectors: []`, and re-validating that dump failed — read → dump → read was not idempotent for any segment lacking connectors.

Rather than correct the default, this makes the field required. A segment is by definition physically connected to at least two connectors, the published data has always reflected that, and an optional field whose only legal values are arrays of two or more was never expressing the real constraint.

Changes:

- `connectors` is now `list[ConnectorReference]` with no default, declared beside `subtype` in the model's required section.
- The YAML schema gains `connectors` in its segment `required` list and drops the matching `default: []` that sat beside `minItems: 2`.
- Every valid segment example gains a two-connector array. Every segment counterexample that was not itself testing connectors gains one too, so each keeps failing only for the defect it names (checklist item 3). Both example trees are updated: `reference/` (read by the test suite) and the root `examples/`/`counterexamples/` trees (the docs build symlinks `examples/`). `theme-type-mismatch.json` is deliberately untouched — it declares `theme: buildings` with `type: segment` and never reaches a segment arm.

# Reference

1. Fixes #669
2. The same contradiction in the pre-Pydantic schema: https://github.com/OvertureMaps/schema/blob/main/schema/transportation/segment.yaml#L61-L79 (noted by @vcschapp on #669)

# Testing

**No published data is affected.** Every segment in the most recent release satisfies the tightened constraint — verified against release `2026-08-19.0` (350,469,378 segments across 128 partitions), which returned zero nulls, zero empty arrays, and zero single-element arrays for all three subtypes:

```sql
SELECT
  subtype,
  count(*)                               AS n_rows,
  count_if(connectors IS NULL)           AS null_connectors,
  count_if(cardinality(connectors) = 0)  AS empty_connectors,
  count_if(cardinality(connectors) = 1)  AS one_connector,
  count_if(cardinality(connectors) >= 2) AS two_or_more
FROM v2026_08_19_0
WHERE theme = 'transportation' AND "type" = 'segment'
GROUP BY GROUPING SETS ((subtype), ())
ORDER BY subtype;
```

**This PR adds no new test, and the example updates are not proofs of the fix** — they are the corpus catching up to a tightened schema. What pins the change is the regenerated JSON Schema baseline, which fails if `connectors` stops being required, and the round trip that motivated #669, which now succeeds because the field has no default at all rather than a corrected one.

Separately verified while investigating: across every field default in the whole model tree, the three segment arms and their shared `TransportationSegment` base were the only ones their own annotations reject. Nothing else in the schema had the defect.

**Required-ness propagated to the generated PySpark layer**, not just the JSON Schema: the regenerated `transportation/segment.py` now emits `_connectors_check` with `check_required(F.col("connectors"))`. Control: optional `access_restrictions` still gets no such check.

**JSON Schema baseline delta is exactly `connectors` joining `required`** in all three arms. The `connectors` subschema itself is byte-identical to before, because the generator already emitted a non-nullable array and expressed optionality solely through `required`.

Full suite: 6215 passed.

# Checklist

1. [x] Add relevant examples.
2. [x] Add relevant counterexamples.
3. [x] Update any counterexamples that became obsolete.
4. [x] Update in-schema documentation using plain English written in complete sentences, if an update is required. — The field description was already accurate; no wording change needed.
5. [ ] Update Docusaurus documentation, if an update is required. — The embedded examples are updated; prose pages not reviewed.

# Documentation website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/692)
