### PR TITLE
[ENHANCEMENT](schema) Remove the non-null defaults from the schema models

### DIFF
--- a/packages/overture-schema-common/changelog.d/696.breaking.md
+++ b/packages/overture-schema-common/changelog.d/696.breaking.md
@@ -1,0 +1,1 @@
+Removed the `level` default of `0`; a feature parsed without a level now yields `None` instead of `0`, and the field description states that absence means visual level.

--- a/packages/overture-schema-common/src/overture/schema/common/level.py
+++ b/packages/overture-schema-common/src/overture/schema/common/level.py
@@ -20,4 +20,12 @@ Level = NewType(
 class Stacked(BaseModel):
     """Properties defining feature Z-order, i.e., stacking order."""
 
-    level: Level | None = 0  # type: ignore[assignment]
+    level: Annotated[
+        Level | None,
+        Field(
+            description=(
+                "Z-order of the feature where 0 is visual level. A feature "
+                "without a level is at visual level."
+            )
+        ),
+    ] = None

--- a/packages/overture-schema-theme-base/changelog.d/696.breaking.md
+++ b/packages/overture-schema-theme-base/changelog.d/696.breaking.md
@@ -1,0 +1,1 @@
+Made `class` and `subtype` required on `Land` and `Water`, matching `Infrastructure` and `LandUse`; constructing either without them now raises instead of falling back to `land`/`water`.

--- a/packages/overture-schema-theme-base/src/overture/schema/base/land.py
+++ b/packages/overture-schema-theme-base/src/overture/schema/base/land.py
@@ -139,10 +139,8 @@ class Land(
 
     # Required
 
-    class_: Annotated[LandClass, Field(default=LandClass.LAND, alias="class")] = (
-        LandClass.LAND
-    )
-    subtype: Annotated[LandSubtype, Field(default=LandSubtype.LAND)] = LandSubtype.LAND
+    class_: Annotated[LandClass, Field(alias="class")]
+    subtype: LandSubtype
 
     # Optional
 

--- a/packages/overture-schema-theme-base/src/overture/schema/base/water.py
+++ b/packages/overture-schema-theme-base/src/overture/schema/base/water.py
@@ -138,19 +138,8 @@ class Water(
 
     # Required
 
-    class_: Annotated[
-        WaterClass,
-        Field(
-            default=WaterClass.WATER,
-            alias="class",
-        ),
-    ] = WaterClass.WATER
-    subtype: Annotated[
-        WaterSubtype,
-        Field(
-            default=WaterSubtype.WATER,
-        ),
-    ] = WaterSubtype.WATER
+    class_: Annotated[WaterClass, Field(alias="class")]
+    subtype: WaterSubtype
 
     # Optional
 

--- a/packages/overture-schema-theme-base/tests/infrastructure_baseline_schema.json
+++ b/packages/overture-schema-theme-base/tests/infrastructure_baseline_schema.json
@@ -643,8 +643,7 @@
           "type": "number"
         },
         "level": {
-          "default": 0,
-          "description": "Z-order of the feature where 0 is visual level",
+          "description": "Z-order of the feature where 0 is visual level. A feature without a level is at visual level.",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "title": "Level",

--- a/packages/overture-schema-theme-base/tests/land_baseline_schema.json
+++ b/packages/overture-schema-theme-base/tests/land_baseline_schema.json
@@ -507,8 +507,7 @@
       },
       "properties": {
         "class": {
-          "$ref": "#/$defs/LandClass",
-          "default": "land"
+          "$ref": "#/$defs/LandClass"
         },
         "elevation": {
           "description": "Elevation above sea level of the feature in meters.",
@@ -518,8 +517,7 @@
           "type": "integer"
         },
         "level": {
-          "default": 0,
-          "description": "Z-order of the feature where 0 is visual level",
+          "description": "Z-order of the feature where 0 is visual level. A feature without a level is at visual level.",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "title": "Level",
@@ -546,8 +544,7 @@
           "uniqueItems": true
         },
         "subtype": {
-          "$ref": "#/$defs/LandSubtype",
-          "default": "land"
+          "$ref": "#/$defs/LandSubtype"
         },
         "surface": {
           "$ref": "#/$defs/SurfaceMaterial"
@@ -579,7 +576,9 @@
       "required": [
         "theme",
         "type",
-        "version"
+        "version",
+        "class",
+        "subtype"
       ],
       "type": "object"
     },

--- a/packages/overture-schema-theme-base/tests/land_use_baseline_schema.json
+++ b/packages/overture-schema-theme-base/tests/land_use_baseline_schema.json
@@ -595,8 +595,7 @@
           "type": "integer"
         },
         "level": {
-          "default": 0,
-          "description": "Z-order of the feature where 0 is visual level",
+          "description": "Z-order of the feature where 0 is visual level. A feature without a level is at visual level.",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "title": "Level",

--- a/packages/overture-schema-theme-base/tests/water_baseline_schema.json
+++ b/packages/overture-schema-theme-base/tests/water_baseline_schema.json
@@ -468,8 +468,7 @@
       },
       "properties": {
         "class": {
-          "$ref": "#/$defs/WaterClass",
-          "default": "water"
+          "$ref": "#/$defs/WaterClass"
         },
         "is_intermittent": {
           "description": "Whether the water body exists intermittently, not permanently",
@@ -482,8 +481,7 @@
           "type": "boolean"
         },
         "level": {
-          "default": 0,
-          "description": "Z-order of the feature where 0 is visual level",
+          "description": "Z-order of the feature where 0 is visual level. A feature without a level is at visual level.",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "title": "Level",
@@ -510,8 +508,7 @@
           "uniqueItems": true
         },
         "subtype": {
-          "$ref": "#/$defs/WaterSubtype",
-          "default": "water"
+          "$ref": "#/$defs/WaterSubtype"
         },
         "theme": {
           "const": "base",
@@ -540,7 +537,9 @@
       "required": [
         "theme",
         "type",
-        "version"
+        "version",
+        "class",
+        "subtype"
       ],
       "type": "object"
     },

--- a/packages/overture-schema-theme-buildings/changelog.d/696.breaking.md
+++ b/packages/overture-schema-theme-buildings/changelog.d/696.breaking.md
@@ -1,0 +1,1 @@
+Buildings and building parts parsed without a `level` now yield `None` instead of `0`, following the removal of the `Stacked.level` default.

--- a/packages/overture-schema-theme-buildings/tests/building_baseline_schema.json
+++ b/packages/overture-schema-theme-buildings/tests/building_baseline_schema.json
@@ -561,8 +561,7 @@
           "type": "boolean"
         },
         "level": {
-          "default": 0,
-          "description": "Z-order of the feature where 0 is visual level",
+          "description": "Z-order of the feature where 0 is visual level. A feature without a level is at visual level.",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "title": "Level",

--- a/packages/overture-schema-theme-buildings/tests/building_part_baseline_schema.json
+++ b/packages/overture-schema-theme-buildings/tests/building_part_baseline_schema.json
@@ -444,8 +444,7 @@
           "type": "boolean"
         },
         "level": {
-          "default": 0,
-          "description": "Z-order of the feature where 0 is visual level",
+          "description": "Z-order of the feature where 0 is visual level. A feature without a level is at visual level.",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "title": "Level",

--- a/packages/overture-schema-theme-transportation/changelog.d/696.breaking.md
+++ b/packages/overture-schema-theme-transportation/changelog.d/696.breaking.md
@@ -1,0 +1,1 @@
+Removed the `is_max_speed_variable` default of `False`; a rule parsed without the flag now yields `None` instead of `False`.

--- a/packages/overture-schema-theme-transportation/src/overture/schema/transportation/segment/_common.py
+++ b/packages/overture-schema-theme-transportation/src/overture/schema/transportation/segment/_common.py
@@ -322,7 +322,7 @@ class SpeedLimitRule(BaseModel):
             description="Indicates a variable speed corridor",
             strict=True,
         ),
-    ] = False
+    ] = None
 
 
 SpeedLimits = NewType(

--- a/packages/overture-schema-theme-transportation/tests/segment_baseline_schema.json
+++ b/packages/overture-schema-theme-transportation/tests/segment_baseline_schema.json
@@ -1323,7 +1323,6 @@
           "type": "array"
         },
         "is_max_speed_variable": {
-          "default": false,
           "description": "Indicates a variable speed corridor",
           "title": "Is Max Speed Variable",
           "type": "boolean"


### PR DESCRIPTION
Closes #696

Implements the policy adopted in #695 for the four remaining declaration sites. No schema field carries a non-null default after this change; a census over `discover_models()` reports zero, across 54 models.

Eleven fields, four sites in four files — the other seven are inherited and re-reported by subclasses.

| Declaration | Was | Now |
| --- | --- | --- |
| `common/level.py` `Stacked.level` | `= 0` | `Level \| None = None` |
| `base/land.py` `Land.class_`, `Land.subtype` | `LandClass.LAND`, `LandSubtype.LAND` | required |
| `base/water.py` `Water.class_`, `Water.subtype` | `WaterClass.WATER`, `WaterSubtype.WATER` | required |
| `transportation/segment/_common.py` `SpeedLimitRule.is_max_speed_variable` | `= False` | `bool \| None`, no default |

`Land` and `Water` now match `Infrastructure` and `LandUse`, which already declared `class_` and `subtype` required with no default. Removing the `level` default also retires a `# type: ignore[assignment]` that existed only to admit it — `Level` is a `NewType` over `Annotated[int32, ...]`, so `0` was never a value of the field's declared type.

## The absence sentence went on the field, not the type

`Stacked.level`'s description states that a feature without a level is at visual level. That sentence is on the field annotation rather than on the `Level` `NewType`, because `Level` is also the type of `LevelRule.value` in `transportation/segment/_common.py`, which is **required** — an absence sentence there renders into a context where absence is impossible.

## `is_max_speed_variable` keeps its description

The default is removed; the description is untouched. What absence means for this field is a domain question, and the existing wording ("Indicates a variable speed corridor") does not define the term precisely enough to extend safely. Both are worth settling with the transportation folks, separately from this change. Flagging it explicitly because #696's second acceptance criterion — that every meaning a removed default carried is stated in the field description — is met for `level` and moot for `class_`/`subtype`, but left open here.

## No consumer sees a difference

Measured against release `2026-08-19.0`, one partition per type. No published row carries any of these defaults:

| Field | Rows measured | Equal to the default | Null |
| --- | --- | --- | --- |
| `Land.level` | 1,174,629 | **0** | 1,174,529 |
| `Water.level` | 1,985,644 | **0** | 1,985,620 |
| `Land.class`/`subtype` | 1,174,629 | n/a | **0 null** |
| `Water.class`/`subtype` | 1,985,644 | n/a | **0 null** |
| `SpeedLimitRule.is_max_speed_variable` | 601,764 rules | **0** (`false`) | 601,497 |

The publisher already writes `class` and `subtype` on every row, so making them required tightens the model to what the release already contains.

## Verification

- The JSON Schema goldens were **hand-written to the predicted shape first**, then the models changed. Seven failed as predicted, and all fifteen went green on the model edit — so the emitted schema matches what was intended rather than whatever the generator happened to produce. That ordering is what caught the `Level` `NewType` problem above.
- `land`, `water` and `segment` partitions from `2026-08-19.0` validate clean under `overture-validate --skip-schema-check`: **0 errors across 5,816,361 rows**. That zero is a real result, not a dead check — injecting nulls into 333 `class` and 200 `subtype` values makes the same command report `class:required` / `subtype:required` and exit 1.
- Regenerated PySpark and Markdown diffs read, not just regenerated. PySpark gains only the four required-field checks (`_class_check` splits into `_class_required_check` + `_class_enum_check`, same for `subtype`); there is no `StructType` diff, since `schema_builder.py` renders every field nullable regardless of requiredness. Markdown drops `(optional)` from the four fields and the example rows change `0` → `null` and `false` → `null` — those examples were displaying the injected default rather than what the release contains.
- Full suite green on both commits via the pre-commit gate.

## Follow-ups

- What `is_max_speed_variable` asserts, and what its absence means.
- Enforcement — a check that fails on any field carrying a default, so this cannot regress. Better placed in the CLI than in a test, so extensions and third-party schemas built on `overture-schema-system` can run it too.
