### PR TITLE
[BUG](ci) Always run vnext-compat check with a noop + rollup path

### DIFF
--- a/.github/workflows/vnext-compat.yaml
+++ b/.github/workflows/vnext-compat.yaml
@@ -1,14 +1,18 @@
 name: vnext compatibility check
 
-# Runs on every PR targeting main. Simulates squashing the PR onto main, then
-# attempts a dry-run rebase of vnext onto the result. If vnext would conflict,
-# the check fails and posts a comment with exact commands to resolve it.
+# Runs on every PR regardless of base branch, so this can safely be made a
+# required status check without hanging PRs whose base isn't main. Simulates
+# squashing the PR onto main, then attempts a dry-run rebase of vnext onto the
+# result. If vnext would conflict, the check fails and posts a comment with
+# exact commands to resolve it.
 #
-# Skipped for vnext→main release PRs (head_ref == 'vnext') — self-referential.
+# Only PRs targeting main do that real work — compat-check is a no-op for
+# anything else (including vnext→main release PRs, head_ref == 'vnext'). The
+# noop job covers that inverse case, and both paths feed vnext-status so
+# there's always a single, consistently-named check to require.
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, reopened, synchronize, edited]
 
 permissions:
@@ -21,7 +25,7 @@ concurrency:
 jobs:
   compat-check:
     name: Check vnext compatibility
-    if: github.head_ref != 'vnext'
+    if: github.event.pull_request.base.ref == 'main' && github.head_ref != 'vnext'
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -153,3 +157,20 @@ jobs:
         run: |
           echo "::error::This PR conflicts with 'vnext' when rebased onto main. See the PR comment for resolution instructions."
           exit 1
+
+  noop:
+    name: Skip vnext compatibility check
+    if: github.event.pull_request.base.ref != 'main' || github.head_ref == 'vnext'
+    runs-on: ubuntu-slim
+    steps:
+      - run: echo "Base isn't main, or this is the vnext release PR — nothing to check here."
+
+  vnext-status:
+    name: vnext compatibility status
+    needs: [compat-check, noop]
+    if: always()
+    runs-on: ubuntu-slim
+    steps:
+      - uses: lowlydba/are-we-good@375b418aa07a163e0614537a3fa5c51e53a757e9 # v1.0.0
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/vnext-compat.yaml
+++ b/.github/workflows/vnext-compat.yaml
@@ -170,7 +170,8 @@ jobs:
     needs: [compat-check, noop]
     if: always()
     runs-on: ubuntu-slim
+    permissions: {}
     steps:
-      - uses: lowlydba/are-we-good@375b418aa07a163e0614537a3fa5c51e53a757e9 # v1.0.0
+      - uses: lowlydba/are-we-good@f506ed6324f55ec5e4ff5d92204a72c7f1c2b4f8 # v1.0.5
         with:
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
`vnext-compat.yaml` triggers on `pull_request: branches: [main]` only. A PR based on any other branch (e.g. #434, based on `vnext`) never gets a run. Marking this check required (which it is) would hang those PRs pending forever.

Drops the `branches: [main]` restriction so the workflow always fires. `compat-check` is now gated to only do real work for PRs targeting `main` (excluding the vnext release PR itself, `head_ref == 'vnext'`); a new `noop` job covers everything else. Both feed a `vnext-status` rollup job via [lowlydba/are-we-good](https://github.com/lowlydba/are-we-good), so there's one consistently-named check to eventually add to branch protection.

Fixes OvertureMaps/schema#704


## Testing

Validated the YAML parses and reasoned through the three cases by hand (no CI run yet since this only matters once a PR is opened against this branch):
- PR targeting `vnext` (like #434): `compat-check` skipped, `noop` runs, `vnext-status` passes.
- Normal PR targeting `main`: `compat-check` runs for real, `noop` skipped, `vnext-status` reflects `compat-check`'s result.
- `vnext`→`main` release PR: `compat-check` skipped (self-referential), `noop` runs, `vnext-status` passes.