### PR TITLE
[FEATURE] Add travel_time property to water segments

### DIFF
--- a/counterexamples/transportation/segment/water/bad-travel-time-type.yaml
+++ b/counterexamples/transportation/segment/water/bad-travel-time-type.yaml
@@ -1,0 +1,14 @@
+---
+# Counterexample: travel_time is an integer number of seconds, not an
+# ISO 8601 / OSM-style duration string.
+id: bad-travel-time-type
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: water
+  travel_time: "00:15"

--- a/counterexamples/transportation/segment/water/bad-travel-time-wrong-subtype.yaml
+++ b/counterexamples/transportation/segment/water/bad-travel-time-wrong-subtype.yaml
@@ -1,0 +1,14 @@
+---
+# Counterexample: travel_time is only allowed on water segments.
+id: bad-travel-time-wrong-subtype
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: road
+  class: primary
+  travel_time: 900

--- a/counterexamples/transportation/segment/water/bad-travel-time-zero.yaml
+++ b/counterexamples/transportation/segment/water/bad-travel-time-zero.yaml
@@ -1,0 +1,13 @@
+---
+# Counterexample: travel_time must be a positive number of seconds.
+id: bad-travel-time-zero
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: water
+  travel_time: 0

--- a/docs/schema/reference/transportation/segment.mdx
+++ b/docs/schema/reference/transportation/segment.mdx
@@ -103,7 +103,11 @@ The schema for `rail` segments is under development.
       </tbody>
     </table>
 
-The schema for `water` segments is under development.
+The schema for `water` segments is under development. Water segments support
+an optional `travel_time` property that captures the scheduled time, in
+seconds, to traverse the full segment from end to end, including time spent
+docking, loading, and unloading (sourced from the OSM `duration` tag on ferry
+routes).
   </TabItem>
 </Tabs>
 

--- a/examples/transportation/segment/water/water-ferry.yaml
+++ b/examples/transportation/segment/water/water-ferry.yaml
@@ -1,0 +1,20 @@
+---
+id: overture:transportation:segment:123
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: water
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
+  names:
+    primary: Generic Ferry Route
+  # 15-minute scheduled crossing, e.g. from OSM duration=00:15
+  travel_time: 900

--- a/packages/overture-schema-theme-transportation/changelog.d/711.feature.md
+++ b/packages/overture-schema-theme-transportation/changelog.d/711.feature.md
@@ -1,0 +1,1 @@
+Added a `travel_time` property to water segments capturing the scheduled end-to-end crossing time in seconds, sourced from the OSM `duration` tag on ferry routes.

--- a/packages/overture-schema-theme-transportation/src/overture/schema/transportation/segment/water.py
+++ b/packages/overture-schema-theme-transportation/src/overture/schema/transportation/segment/water.py
@@ -1,10 +1,28 @@
 """Water segment and its supporting types."""
 
-from typing import Literal
+import textwrap
+from typing import Annotated, Literal, NewType
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, Field
+
+from overture.schema.system.numeric import int32
 
 from ._common import SegmentSubtype, TransportationSegment
+
+TravelTime = NewType(
+    "TravelTime",
+    Annotated[
+        int32,
+        Field(
+            ge=1,
+            description=textwrap.dedent("""
+                Scheduled travel time, in seconds, to traverse the full segment from end
+                to end, including time spent docking, loading, and unloading. Sourced
+                from the OSM duration tag on ferry routes.
+            """).strip(),
+        ),
+    ],
+)
 
 
 class WaterSegment(TransportationSegment):
@@ -15,3 +33,7 @@ class WaterSegment(TransportationSegment):
     # Discriminator
 
     subtype: Literal[SegmentSubtype.WATER]
+
+    # Optional
+
+    travel_time: TravelTime | None = None

--- a/packages/overture-schema-theme-transportation/tests/segment_baseline_schema.json
+++ b/packages/overture-schema-theme-transportation/tests/segment_baseline_schema.json
@@ -1660,6 +1660,13 @@
               "title": "Theme",
               "type": "string"
             },
+            "travel_time": {
+              "description": "Scheduled travel time, in seconds, to traverse the full segment from end\nto end, including time spent docking, loading, and unloading. Sourced\nfrom the OSM duration tag on ferry routes.",
+              "maximum": 2147483647,
+              "minimum": 1,
+              "title": "Travel Time",
+              "type": "integer"
+            },
             "type": {
               "const": "segment",
               "title": "Type",

--- a/reference/counterexamples/transportation/segment/water/bad-travel-time-type.yaml
+++ b/reference/counterexamples/transportation/segment/water/bad-travel-time-type.yaml
@@ -1,0 +1,14 @@
+---
+# Counterexample: travel_time is an integer number of seconds, not an
+# ISO 8601 / OSM-style duration string.
+id: bad-travel-time-type
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: water
+  travel_time: "00:15"

--- a/reference/counterexamples/transportation/segment/water/bad-travel-time-wrong-subtype.yaml
+++ b/reference/counterexamples/transportation/segment/water/bad-travel-time-wrong-subtype.yaml
@@ -1,0 +1,14 @@
+---
+# Counterexample: travel_time is only allowed on water segments.
+id: bad-travel-time-wrong-subtype
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: road
+  class: primary
+  travel_time: 900

--- a/reference/counterexamples/transportation/segment/water/bad-travel-time-zero.yaml
+++ b/reference/counterexamples/transportation/segment/water/bad-travel-time-zero.yaml
@@ -1,0 +1,13 @@
+---
+# Counterexample: travel_time must be a positive number of seconds.
+id: bad-travel-time-zero
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: water
+  travel_time: 0

--- a/reference/examples/transportation/segment/water/water-ferry.yaml
+++ b/reference/examples/transportation/segment/water/water-ferry.yaml
@@ -1,0 +1,20 @@
+---
+id: overture:transportation:segment:123
+type: Feature
+geometry:
+  type: LineString
+  coordinates: [[0, 0], [1, 1]]
+properties:
+  theme: transportation
+  type: segment
+  version: 1
+  subtype: water
+  connectors:
+    - connector_id: fooConnector
+      at: 0
+    - connector_id: barConnector
+      at: 1
+  names:
+    primary: Generic Ferry Route
+  # 15-minute scheduled crossing, e.g. from OSM duration=00:15
+  travel_time: 900

--- a/schema/transportation/segment.yaml
+++ b/schema/transportation/segment.yaml
@@ -47,9 +47,10 @@ properties:
           subtype: { const: rail }
           class: { "$ref": "#/$defs/propertyDefinitions/railClass" }
           rail_flags: { "$ref": "#/$defs/propertyContainers/railFlagsContainer" }
-      - title: "Water-Specific Properties" # Placeholder for future water properties
+      - title: "Water-Specific Properties"
         properties:
           subtype: { const: water }
+          travel_time: { "$ref": "#/$defs/propertyDefinitions/travelTime" }
     properties:
       subtype:
         description: Broad category of transportation segment.
@@ -305,6 +306,17 @@ properties:
         - driveway         # Service road intended for deliveries
         - alley            # Service road intended for rear entrances, fire exits
         - cycle_crossing   # Cycleway that intersects with other roads
+    travelTime:
+      description: >-
+        Scheduled travel time, in seconds, to traverse the full segment
+        from end to end, including time spent docking, loading, and
+        unloading.
+      type: integer
+      minimum: 1
+      "$comment": >-
+        Sourced from the OSM duration tag on ferry routes. Unlike a speed
+        limit, this value captures the scheduled end-to-end crossing time,
+        so routers can compute realistic ETAs for ferry crossings.
     speed:
       description: >-
         A speed value, i.e. a certain number of distance units


### PR DESCRIPTION
# Description

Adds an optional `travel_time` property to `subtype=water` transportation segments. The property is a positive integer number of seconds capturing the scheduled end-to-end crossing time for the full segment — including time spent docking, loading, and unloading — matching the semantics of the OSM `duration` tag on ferry routes it is sourced from.

Without it, routers consuming Overture fall back to a default ferry speed (~5 km/h), so car ferries are either avoided or produce wildly inflated ETAs.

Design choices follow the suggestions in the issue (open for working group review on this draft):

- **Type/units**: integer seconds (`minimum: 1`) — simplest for consumers.
- **Scoping**: flat value, no rules container — a single scheduled duration suffices for ferry crossings; linear referencing seems unnecessary.
- **Applicability**: water-only for now, defined inline on the water branch rather than as a reusable container in `defs.yaml`.

## Changes

- `packages/overture-schema-theme-transportation/.../segment/water.py`: new `TravelTime` type (`int32`, `ge=1`) and optional `travel_time` field on `WaterSegment`.
- `schema/transportation/segment.yaml`: new `travelTime` property definition and reference from the water `oneOf` branch (replacing the placeholder).
- Regenerated `segment_baseline_schema.json` via `make update-baselines`.
- New example `water-ferry.yaml` and counterexamples (`bad-travel-time-zero`, `bad-travel-time-type`, `bad-travel-time-wrong-subtype`) in both `examples/`+`counterexamples/` and `reference/examples/`+`reference/counterexamples/`.
- Changelog fragment `changelog.d/711.feature.md` (transportation theme package).
- Docs note in `docs/schema/reference/transportation/segment.mdx` water subtype tab.

# Reference

1. Closes #711
2. Parent issue: OvertureMaps/tf-data-platform#5067

# Testing

- YAML JSON Schema: validated all `examples/transportation` (pass, including new `water-ferry.yaml`) and `counterexamples/transportation` (all fail as expected, including the three new water counterexamples) against `schema/schema.yaml` with a draft 2020-12 validator.
- Pydantic: `pytest packages/overture-schema-theme-transportation packages/overture-schema-validation` — 474 passed (includes the JSON Schema baseline test and the reference examples/counterexamples).
- Full suite: `pytest -W error packages/ tests/` — 3550 passed; PySpark suite (regenerated expressions including the new field) — 3151 passed under JDK 17.
- Gates: `lint-only`, `mypy-only`, `docformat-only`, `doctest-only`, `check-namespace` all pass.

# Checklist

1. [x] Add relevant examples.
2. [x] Add relevant counterexamples.
3. [x] Update any counterexamples that became obsolete. *(None became obsolete — the water branch was previously a placeholder.)*
4. [x] Update in-schema documentation using plain English written in complete sentences.
5. [x] Update Docusaurus documentation.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of.

# Documentation website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/712)