### PR TITLE
chore: detect vnext release merge by ancestry, not branch name

### DIFF
--- a/.github/workflows/rebase-vnext.yaml
+++ b/.github/workflows/rebase-vnext.yaml
@@ -3,8 +3,11 @@ name: Rebase vnext onto main
 # Triggered on every push to main. Force-rebases vnext onto the new main HEAD
 # using the overture-pull-requester GitHub App (which has branch-protection bypass).
 #
-# Skipped for vnext→main release merges — vnext is already equal to main at that
-# point so a rebase would be a no-op, and the GitHub API check catches this.
+# Skipped for a vnext release merge — detected by ancestry (origin/vnext is
+# already an ancestor of the new main HEAD), not by branch name, so a staging
+# branch built on top of vnext's tip (e.g. `2_0_0`) is skipped the same as a
+# PR literally named `vnext`. vnext is already equal to main at that point so
+# a rebase would be a no-op.
 #
 # If the rebase fails a GitHub issue is opened and assigned to the PR author
 # so the conflict can be resolved manually.
@@ -41,37 +44,40 @@ jobs:
           permission-pull-requests: read    # read PR on merge commit to detect vnext→main release
           permission-workflows: write       # vnext commits may touch .github/workflows/**
 
-      # Detect whether this push was a vnext→main release merge.
-      # The GitHub API returns the PR(s) associated with the merge commit.
-      - name: Detect vnext→main release merge
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          # Use the app token so the subsequent force-push is authenticated.
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
+
+      # Detect whether this push was a vnext release merge, by ancestry rather
+      # than branch name: if origin/vnext is already an ancestor of the new
+      # main HEAD, all of vnext's commits are in main and rebasing is a no-op.
+      # The GitHub API additionally returns the PR associated with the merge
+      # commit, so a failure issue can still be filed against its author.
+      - name: Detect vnext release merge
         id: skip
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           MAIN_SHA: ${{ github.sha }}
         run: |
+          git fetch origin vnext
+
           PR_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${MAIN_SHA}/pulls" \
             --jq '.[0] // empty' 2>/dev/null || true)
 
-          HEAD_REF=$(echo "$PR_JSON"  | jq -r '.head.ref   // empty' 2>/dev/null || true)
           PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number     // empty' 2>/dev/null || true)
           PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login // empty' 2>/dev/null || true)
 
-          if [ "$HEAD_REF" = "vnext" ]; then
-            echo "Skipping: this is a vnext→main release merge."
+          if git merge-base --is-ancestor origin/vnext "$MAIN_SHA"; then
+            echo "Skipping: origin/vnext is already an ancestor of main, this is a release merge."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false"      >> "$GITHUB_OUTPUT"
             echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
             echo "pr_author=${PR_AUTHOR}" >> "$GITHUB_OUTPUT"
           fi
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: steps.skip.outputs.skip != 'true'
-        with:
-          fetch-depth: 0
-          # Use the app token so the subsequent force-push is authenticated.
-          token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: true
 
       - name: Rebase vnext onto new main HEAD
         if: steps.skip.outputs.skip != 'true'

--- a/.github/workflows/rebase-vnext.yaml
+++ b/.github/workflows/rebase-vnext.yaml
@@ -71,7 +71,7 @@ jobs:
           PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login // empty' 2>/dev/null || true)
 
           if git merge-base --is-ancestor origin/vnext "$MAIN_SHA"; then
-            echo "Skipping: origin/vnext is already an ancestor of main, this is a release merge."
+            echo "::notice::Skipping rebase: origin/vnext is already an ancestor of main, this is a release merge."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false"      >> "$GITHUB_OUTPUT"

--- a/.github/workflows/vnext-compat.yaml
+++ b/.github/workflows/vnext-compat.yaml
@@ -194,7 +194,7 @@ jobs:
     if: github.event.pull_request.base.ref != 'main' || needs.detect-release.outputs.is_release == 'true'
     runs-on: ubuntu-slim
     steps:
-      - run: echo "Base isn't main, or this is the vnext release merge — nothing to check here."
+      - run: echo "::notice::Base isn't main, or this is the vnext release merge — nothing to check here."
 
   vnext-status:
     name: vnext compatibility status

--- a/.github/workflows/vnext-compat.yaml
+++ b/.github/workflows/vnext-compat.yaml
@@ -28,14 +28,17 @@ concurrency:
 jobs:
   detect-release:
     name: Detect vnext release merge
-    if: github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
       is_release: ${{ steps.check.outputs.is_release }}
     steps:
+      # Runs unconditionally so noop/compat-check (which `need` this job) never
+      # get skipped by dependency propagation for non-main bases; skip the
+      # actual check with a fast is_release=false instead.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.event.pull_request.base.ref == 'main'
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -44,7 +47,13 @@ jobs:
         id: check
         env:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
+          if [ "$PR_BASE_REF" != "main" ]; then
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           git fetch origin vnext
           if git merge-base --is-ancestor origin/vnext "$PR_HEAD_SHA"; then
             echo "is_release=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/vnext-compat.yaml
+++ b/.github/workflows/vnext-compat.yaml
@@ -7,9 +7,12 @@ name: vnext compatibility check
 # exact commands to resolve it.
 #
 # Only PRs targeting main do that real work — compat-check is a no-op for
-# anything else (including vnext→main release PRs, head_ref == 'vnext'). The
-# noop job covers that inverse case, and both paths feed vnext-status so
-# there's always a single, consistently-named check to require.
+# anything else, including a vnext release merge. A release merge is detected
+# by ancestry (origin/vnext is an ancestor of the PR head), not by branch name,
+# so a staging branch built on top of vnext's tip (e.g. `2_0_0`) is recognized
+# the same as a PR literally named `vnext`. The noop job covers that inverse
+# case, and both paths feed vnext-status so there's always a single,
+# consistently-named check to require.
 
 on:
   pull_request:
@@ -23,9 +26,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-release:
+    name: Detect vnext release merge
+    if: github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    outputs:
+      is_release: ${{ steps.check.outputs.is_release }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check whether origin/vnext is an ancestor of this PR's head
+        id: check
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git fetch origin vnext
+          if git merge-base --is-ancestor origin/vnext "$PR_HEAD_SHA"; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
   compat-check:
     name: Check vnext compatibility
-    if: github.event.pull_request.base.ref == 'main' && github.head_ref != 'vnext'
+    needs: detect-release
+    if: github.event.pull_request.base.ref == 'main' && needs.detect-release.outputs.is_release != 'true'
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -160,10 +190,11 @@ jobs:
 
   noop:
     name: Skip vnext compatibility check
-    if: github.event.pull_request.base.ref != 'main' || github.head_ref == 'vnext'
+    needs: detect-release
+    if: github.event.pull_request.base.ref != 'main' || needs.detect-release.outputs.is_release == 'true'
     runs-on: ubuntu-slim
     steps:
-      - run: echo "Base isn't main, or this is the vnext release PR — nothing to check here."
+      - run: echo "Base isn't main, or this is the vnext release merge — nothing to check here."
 
   vnext-status:
     name: vnext compatibility status

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,15 @@ merge to `main`, CI cuts a published GitHub Release tagged
 `<package>-v<version>` with those notes. See
 [docs/versioning.md](docs/versioning.md).
 
+The PR that carries the release merge doesn't have to be `vnext` itself: you
+can stage it on a branch built on top of `vnext`'s tip (for example `2_0_0`)
+instead, useful when `vnext` needs to stay open for more breaking work while
+the release stabilizes. Either way it still has to land on `main` as a regular
+merge commit, not a squash. [vnext-compat.yaml](.github/workflows/vnext-compat.yaml)
+and [rebase-vnext.yaml](.github/workflows/rebase-vnext.yaml) detect the
+release merge by ancestry (`git merge-base --is-ancestor origin/vnext <head>`)
+rather than by branch name, so either path is recognized the same way.
+
 ## Opening a PR
 
 Two CI checks may comment on your PR:


### PR DESCRIPTION
## Context

OvertureMaps/schema#709 discussed two ways to make its `2_0_0` staging branch a supported release path instead of a one-off. This picks option 2: keep the staging branch and formalize the detection.

Fixes OvertureMaps/schema#713

## What changed

`vnext-compat.yaml` and `rebase-vnext.yaml` both special-cased `head_ref == 'vnext'` to skip their normal checks for the vnext release merge. That misses OvertureMaps/schema#709, whose head is `2_0_0`, a branch built on top of `vnext`'s tip rather than `vnext` itself.

Both workflows now detect the release merge by ancestry instead: `git merge-base --is-ancestor origin/vnext <head>`. If `vnext` is already an ancestor of the PR head (`vnext-compat`) or the new `main` HEAD (`rebase-vnext`), the branch already carries everything on `vnext`, so it's treated as the release merge regardless of its name.

```mermaid
%%{init: {"theme": "dark", "flowchart": {"padding": 14}, "themeVariables": {"fontSize": "14px", "mainBkg": "#21262d", "nodeBorder": "#4493f8"}}}%%
flowchart TD
    classDef default rx:8,ry:8,stroke-width:0.75px
    subgraph compat["vnext-compat.yaml (on PR)"]
        A["PR targets main"] --> B{"origin/vnext ancestor<br/>of PR head?"}
        B -- yes --> C["noop:<br/>release merge, skip"]
        B -- no --> D["compat-check:<br/>simulate squash + rebase vnext"]
    end
    subgraph rebase["rebase-vnext.yaml (on push to main)"]
        E["Push to main"] --> F{"origin/vnext ancestor<br/>of new main HEAD?"}
        F -- yes --> G["skip:<br/>release merge, no rebase"]
        F -- no --> H["rebase vnext onto main,<br/>force-push"]
    end
```

`vnext-compat.yaml` needed a new `detect-release` job up front since a job's `if:` can't run shell commands; `compat-check` and `noop` now key off its `is_release` output. `rebase-vnext.yaml` just moved its checkout earlier so the existing detection step can run the ancestry check locally instead of only inspecting the merged PR's `head.ref` from the GitHub API.

`CONTRIBUTING.md` now documents the staging-branch pattern as a supported alternative to merging `vnext` directly.

## Testing

No CI-only path here to exercise outside the real workflows: I validated both YAML files parse (`yaml.safe_load`) and traced the `if:`/`needs:` wiring by hand, but haven't watched the ancestry check run against a real PR. Worth watching `vnext-status` on this PR itself once it opens against `main`, and watching `rebase-vnext` on the next `2_0_0`-style release merge.
<!--:robot:-->
