### PR TITLE
[BUG](ci) Fix release title format

### DIFF
--- a/.github/actions/create-package-release/action.yml
+++ b/.github/actions/create-package-release/action.yml
@@ -99,6 +99,11 @@ runs:
         latest_flag="--latest=false"
         [ "$LATEST" = "true" ] && latest_flag="--latest"
 
+        # A release that continues the legacy bare series takes that tag as its
+        # title (v1.18.0 -> v2.0.0); everything else is "<package> v<version>".
+        title="${PACKAGE} v${VERSION}"
+        [ -n "$VANITY_TAG" ] && title="$VANITY_TAG"
+
         # Validate requested assets exist before the dry-run branch, so a dry
         # run catches a missing or misnamed asset.
         read -ra assets <<< "$ASSETS"
@@ -114,7 +119,7 @@ runs:
           {
             echo "## 🔍 Dry run: \`${PACKAGE}\` ${VERSION}"
             echo ""
-            echo "Would create tag \`${TAG}\` at \`${TARGET}\` (${latest_flag})."
+            echo "Would create tag \`${TAG}\` at \`${TARGET}\` titled \`${title}\` (${latest_flag})."
             if [ -n "$VANITY_TAG" ]; then
               echo "Would also create vanity tag \`${VANITY_TAG}\` (no release)."
             fi
@@ -135,7 +140,7 @@ runs:
         gh release create "$TAG" \
           --repo "$GITHUB_REPOSITORY" \
           --target "$TARGET" \
-          --title "\`${PACKAGE}\` ${VERSION}" \
+          --title "$title" \
           --notes-file "${RUNNER_TEMP}/notes.md" \
           $latest_flag \
           "${assets[@]}"

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -80,11 +80,12 @@ cascade (see [Guardrails](#guardrails)).
 ### Tag scheme
 
 Each package has its own release series: tag `<package>-v<major>.<minor>.<patch>`,
-title `` `<package>` <version> ``. The umbrella `overture-schema` release is
+title `<package> v<version>`. The umbrella `overture-schema` release is
 flagged **Latest**, and additionally continues the historical bare series
-(`v0.4.0` … `v1.17.0`) as a vanity tag: each umbrella release also creates a
+(`v0.4.0` … `v1.18.0`) as a vanity tag: each umbrella release also creates a
 bare `v<version>` git tag at the same commit, with no second GitHub Release
-attached. The umbrella package is the primary entrypoint for most consumers,
+attached, and takes that tag as its title (`v2.0.0`) so the release list reads
+as one continuous series. The umbrella package is the primary entrypoint for most consumers,
 so its bare tags keep the long-standing convention alive; all other packages
 use only the package-prefixed scheme.
 


### PR DESCRIPTION
# Description

`create-package-release` titled every 2.0.0 release `` `<package>` 2.0.0 ``, backticks included, since release titles aren't rendered as markdown. Titles are now `<package> v<version>`, and a release with a vanity tag takes that tag as its title so the umbrella series stays `v1.18.0` -> `v2.0.0`.

The 13 live 2.0.0 releases were already retitled by hand with `gh release edit`; this makes the action match. The title is pure gh meta, not the actual tag name.

Fixes OvertureMaps/schema#715

# Reference

1. [Releases page](https://github.com/OvertureMaps/schema/releases), showing the retitled 2.0.0 set.

# Testing

Shell-only change to a composite action; no unit coverage exists for it. The dry-run step summary now prints the computed title so the next release run shows it before anything is created.

# Checklist

1. [ ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete.
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [x] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

<!--:robot:-->