### PR TITLE
[CHORE](packaging) Publish package READMEs as PyPI project descriptions

### DIFF
--- a/packages/overture-schema-codegen/changelog.d/734.misc.md
+++ b/packages/overture-schema-codegen/changelog.d/734.misc.md
@@ -1,0 +1,1 @@
+Published the package README as the PyPI project description, and added maintainers and project URLs to the package metadata.

--- a/packages/overture-schema-codegen/pyproject.toml
+++ b/packages/overture-schema-codegen/pyproject.toml
@@ -13,10 +13,19 @@ dependencies = [
     "typing-extensions>=4.0",
 ]
 description = "Code generator that produces documentation and code from Pydantic models"
+readme = "README.md"
 version = "2.0.0"
 license = "MIT"
 name = "overture-schema-codegen"
+maintainers = [
+    {name = "Overture Maps Schema Working Group"},
+]
 requires-python = ">=3.10"
+
+[project.urls]
+Homepage = "https://overturemaps.org"
+Source = "https://github.com/OvertureMaps/schema"
+Issues = "https://github.com/OvertureMaps/schema/issues"
 
 [project.scripts]
 overture-codegen = "overture.schema.codegen.cli:main"

--- a/packages/overture-schema-common/changelog.d/734.misc.md
+++ b/packages/overture-schema-common/changelog.d/734.misc.md
@@ -1,0 +1,1 @@
+Published the package README as the PyPI project description.

--- a/packages/overture-schema-common/pyproject.toml
+++ b/packages/overture-schema-common/pyproject.toml
@@ -9,6 +9,7 @@ maintainers = [
 ]
 version = "2.0.0"
 description = "Common components that are shared across Overture theme schemas"
+readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [

--- a/packages/overture-schema-pyspark/changelog.d/734.misc.md
+++ b/packages/overture-schema-pyspark/changelog.d/734.misc.md
@@ -1,0 +1,1 @@
+Published the package README as the PyPI project description, and added maintainers and project URLs to the package metadata.

--- a/packages/overture-schema-pyspark/pyproject.toml
+++ b/packages/overture-schema-pyspark/pyproject.toml
@@ -13,9 +13,18 @@ dependencies = [
 ]
 description = "PySpark validation expressions for Overture Maps data"
 license = "MIT"
+maintainers = [
+    {name = "Overture Maps Schema Working Group"},
+]
 name = "overture-schema-pyspark"
+readme = "README.md"
 requires-python = ">=3.10"
 version = "2.0.0"
+
+[project.urls]
+Homepage = "https://overturemaps.org"
+Source = "https://github.com/OvertureMaps/schema"
+Issues = "https://github.com/OvertureMaps/schema/issues"
 
 [project.optional-dependencies]
 spark = ["pyspark>=3.4"]


### PR DESCRIPTION
# Description

`overture-schema-pyspark`, `overture-schema-codegen`, and `overture-schema-common` publish to PyPI with an empty project description. Each ships a README, but its `pyproject.toml` omits `readme = "README.md"`, so the README never reaches the distribution metadata and the PyPI page renders only the one-line summary.

`overture-schema-pyspark` and `overture-schema-codegen` also omit `maintainers` and `[project.urls]`, leaving their PyPI pages without Homepage, Source, or Issues links.

This adds the missing fields. The other ten packages under `packages/` already declare all three.

PyPI metadata is immutable per release, so each page fills in on that package's next version bump.

Closes #734

# Reference

1. #734
2. [`overture-schema-pyspark` on PyPI](https://pypi.org/project/overture-schema-pyspark/#description), showing the empty description

# Testing

`uv build` for each of the three packages, reading `METADATA` out of the resulting wheel:

| Package | `Description-Content-Type` | Description | `Maintainer` | `Project-URL` |
| --- | --- | --- | --- | --- |
| `overture-schema-pyspark` | `text/markdown` | 8,954 bytes | Overture Maps Schema Working Group | Homepage, Source, Issues |
| `overture-schema-codegen` | `text/markdown` | 5,833 bytes | Overture Maps Schema Working Group | Homepage, Source, Issues |
| `overture-schema-common` | `text/markdown` | 4,196 bytes | Overture Maps Schema Working Group | Homepage, Source, Issues |

`twine check` passes on all three wheels and all three sdists.

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

No schema change, so items 1-6 do not apply.

1. [ ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation website

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/735)
