### PR TITLE
[BUG](system) Export Feature from the package root

### DIFF
--- a/packages/overture-schema-system/changelog.d/737.bugfix.md
+++ b/packages/overture-schema-system/changelog.d/737.bugfix.md
@@ -1,0 +1,1 @@
+Export `Feature` from the `overture.schema.system` package root, so `from overture.schema.system import Feature` resolves the way `from overture.schema.common import OvertureFeature` already does.

--- a/packages/overture-schema-system/src/overture/schema/system/__init__.py
+++ b/packages/overture-schema-system/src/overture/schema/system/__init__.py
@@ -163,10 +163,12 @@ from . import (
     string,
 )
 from .create_model import create_model
+from .feature import Feature
 
 __all__ = [
     "create_model",
     "doc",
+    "Feature",
     "feature",
     "field_constraint",
     "geometric",

--- a/packages/overture-schema-system/tests/test_feature.py
+++ b/packages/overture-schema-system/tests/test_feature.py
@@ -2129,3 +2129,10 @@ class TestRefactoring:
             assert expect_properties_object_schema == _properties_object_schema
         else:
             assert properties_object_schema == _properties_object_schema
+
+
+def test_feature_is_exported_from_package_root() -> None:
+    import overture.schema.system as system
+
+    assert system.Feature is Feature
+    assert "Feature" in system.__all__


### PR DESCRIPTION
# Description

`overture.schema.common` exports `OvertureFeature` at its package root. `overture.schema.system` exported only its submodules and `create_model`, so the parallel name did not resolve:

```python
from overture.schema.common import OvertureFeature  # works
from overture.schema.system import Feature  # ImportError
from overture.schema.system.feature import Feature  # the only working form
```

AUTHORING.md points third-party authors at the name that did not exist: "You don't have to build on `OvertureFeature` — subclass `system.Feature` directly for a GeoJSON-serializing model with none of the Overture conventions." Anyone taking that literally hits an ImportError on their first line.

This adds `from .feature import Feature` and `"Feature"` to `__all__`, matching how `common` exports `FeatureVersion`, `OvertureFeature`, `ThemeT` and `TypeT` from its own `feature` submodule. The deep import keeps working; nothing else changes.

Scope is `Feature` alone. `Geometry` and `BBox` under `geometric`, and `Id` under `ref`, sit in the same position — how wide the system root's surface should be is a separate question, and #737 says so.

# Reference

1. Closes #737.

# Testing

`test_feature_is_exported_from_package_root` asserts both the attribute and its presence in `__all__`. Reverting the `__init__.py` change alone fails it with `AttributeError: module 'overture.schema.system' has no attribute 'Feature'`; it is the only added test, and it is a real gate rather than a behaviour-preservation guard.

`make lint-only`, `make mypy-only`, `make doctest-only` and the full suite pass.

# Checklist

*Checklist of tasks commonly-associated with schema pull requests. Please review the relevant checklists and ensure you do all the tasks that are required for the change you made.*

1. [ ] Add relevant examples.
2. [ ] Add relevant counterexamples.
3. [ ] Update any counterexamples that became obsolete. For example, if a counterexample uses property `A` but is not intended to test property `A`'s validity, and you made a schema change that invalidates property `A` in that counterexample, fix the counterexample to align it with your schema change.  
4. [ ] Update in-schema documentation using plain English written in complete sentences, if an update is required.
5. [ ] Update Docusaurus documentation, if an update is required.
6. [ ] Review change with Overture technical writer to ensure any advanced documentation needs will be taken care of, unless the change is trivial and would not affect the documentation.

# Documentation website

*Update the hyperlink below to put the pull request number in.*

[Docs preview for this PR.](https://dfhx9f55j8eg5.cloudfront.net/pr/<PUT THE PR # HERE>)
