### PR TITLE
[BUG](ci) Pin uv-lock-refresh commit author to overture-pull-requester

### DIFF
--- a/.github/workflows/uv-lock-refresh.yml
+++ b/.github/workflows/uv-lock-refresh.yml
@@ -55,6 +55,11 @@ jobs:
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with: # zizmor: ignore[superfluous-actions]
           token: ${{ steps.app-token.outputs.token }}
+          # author/committer must match the Signed-off-by address for DCO to pass.
+          # create-pull-request otherwise defaults author to whoever triggered the
+          # run (github.actor), which fails DCO on a manual workflow_dispatch.
+          author: overture-pull-requester[bot] <overture-pull-requester[bot]@users.noreply.github.com>
+          committer: overture-pull-requester[bot] <overture-pull-requester[bot]@users.noreply.github.com>
           commit-message: |
             [CHORE](deps) refresh uv.lock
 


### PR DESCRIPTION
## What
Pins `author:` and `committer:` on the `create-pull-request` step in `uv-lock-refresh.yml` to `overture-pull-requester[bot] <overture-pull-requester[bot]@users.noreply.github.com>`.

## Why
#732 fixed the required linked-issue check by opening PRs as the `overture-pull-requester` app, but `create-pull-request`'s `author` input defaults to `github.actor` (the triggering user) when not set explicitly — not the app token's identity. That mismatched the `Signed-off-by` trailer and failed DCO on the follow-up PR ([#739](https://github.com/OvertureMaps/schema/pull/739), triggered via manual `workflow_dispatch`). Pinning both inputs keeps the commit author consistent with the signoff regardless of who/what triggers the run.

Fixes #740

## Testing
- `zizmor .github/workflows/uv-lock-refresh.yml` — no findings.
- YAML validated with `yaml.safe_load`.
- Not run end-to-end; will confirm DCO passes on the next scheduled/`workflow_dispatch` run.