### PR TITLE
[BUG](ci) Install uv before publish-legacy/publish-mcd steps

### DIFF
--- a/.github/workflows/main-publish.yaml
+++ b/.github/workflows/main-publish.yaml
@@ -202,6 +202,11 @@ jobs:
       matrix:
         package: ${{ fromJSON(needs.detect.outputs.packages) }}
     steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: latest
+
       - name: Download built artifacts for ${{ matrix.package }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -229,6 +234,11 @@ jobs:
       matrix:
         package: ${{ fromJSON(needs.detect.outputs.packages) }}
     steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: latest
+
       - name: Download built artifacts for ${{ matrix.package }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
Both publish jobs call `uv-publish-to-codeartifact`, which requires `uv` already on `PATH` (its own comment says so). Neither job installs it, since they run on a fresh runner separate from `build`, so every push to `main` since the dual-publish merge (#725) fails with `uv: command not found`, exit 127:

https://github.com/OvertureMaps/schema/actions/runs/34608725611/job/103293782910

The original draft for the uv-publish action *did* self-install `uv`, but later it was changed to allow consumers greater flexibility / avoid double-install attempts. This more closely follows the ecosystem of GHA where many are single-responsibility and chained together, instead of performing multiple functions.

Added the same `astral-sh/setup-uv` step `build` already uses to both `publish-legacy` and `publish-mcd`.

Fixes #743

## Testing

Not covered by CI: the composite action's `uv` requirement only surfaces on a real push to `main`, this workflow doesn't run on PRs. Verifying via a push to `main` after merge.
<!--:robot:-->